### PR TITLE
Add triage command

### DIFF
--- a/parser/src/command/triage.rs
+++ b/parser/src/command/triage.rs
@@ -1,0 +1,77 @@
+//! The triage command parser.
+//!
+//! Gives the priority to be changed to.
+//!
+//! The grammar is as follows:
+//!
+//! ```text
+//! Command: `@bot triage {high,medium,low,P-high,P-medium,P-low}`
+//! ```
+
+use crate::error::Error;
+use crate::token::{Token, Tokenizer};
+use std::fmt;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Priority {
+    High,
+    Low,
+    Medium,
+}
+
+#[derive(PartialEq, Eq, Debug)]
+pub struct TriageCommand {
+    pub priority: Priority,
+}
+
+#[derive(PartialEq, Eq, Debug)]
+pub enum ParseError {
+    ExpectedPriority,
+    ExpectedEnd,
+}
+
+impl std::error::Error for ParseError {}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ParseError::ExpectedPriority => write!(f, "expected priority (high, medium, low)"),
+            ParseError::ExpectedEnd => write!(f, "expected end of command"),
+        }
+    }
+}
+
+impl TriageCommand {
+    pub fn parse<'a>(input: &mut Tokenizer<'a>) -> Result<Option<Self>, Error<'a>> {
+        let mut toks = input.clone();
+        if let Some(Token::Word("triage")) = toks.peek_token()? {
+            toks.next_token()?;
+            let priority = match toks.peek_token()? {
+                Some(Token::Word("high")) | Some(Token::Word("P-high")) => {
+                    toks.next_token()?;
+                    Priority::High
+                }
+                Some(Token::Word("medium")) | Some(Token::Word("P-medium")) => {
+                    toks.next_token()?;
+                    Priority::Medium
+                }
+                Some(Token::Word("low")) | Some(Token::Word("P-low")) => {
+                    toks.next_token()?;
+                    Priority::Low
+                }
+                _ => {
+                    return Err(toks.error(ParseError::ExpectedPriority));
+                }
+            };
+            if let Some(Token::Dot) | Some(Token::EndOfLine) = toks.peek_token()? {
+                toks.next_token()?;
+                *input = toks;
+                return Ok(Some(TriageCommand { priority: priority }));
+            } else {
+                return Err(toks.error(ParseError::ExpectedEnd));
+            }
+        } else {
+            return Ok(None);
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,7 @@ lazy_static::lazy_static! {
 pub(crate) struct Config {
     pub(crate) relabel: Option<RelabelConfig>,
     pub(crate) assign: Option<AssignConfig>,
+    pub(crate) triage: Option<TriageConfig>,
 }
 
 #[derive(serde::Deserialize)]
@@ -29,6 +30,14 @@ pub(crate) struct AssignConfig {
 pub(crate) struct RelabelConfig {
     #[serde(default)]
     pub(crate) allow_unauthenticated: Vec<String>,
+}
+
+#[derive(serde::Deserialize)]
+pub(crate) struct TriageConfig {
+    pub(crate) remove: Vec<String>,
+    pub(crate) high: String,
+    pub(crate) medium: String,
+    pub(crate) low: String,
 }
 
 pub(crate) fn get(gh: &GithubClient, repo: &str) -> Result<Arc<Config>, Error> {

--- a/src/github.rs
+++ b/src/github.rs
@@ -31,7 +31,7 @@ impl User {
     }
 }
 
-#[derive(Debug, Clone, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Deserialize, PartialEq, Eq)]
 pub struct Label {
     pub name: String,
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -27,6 +27,7 @@ macro_rules! handlers {
 handlers! {
     assign = assign::AssignmentHandler,
     relabel = relabel::RelabelHandler,
+    triage = triage::TriageHandler,
     //tracking_issue = tracking_issue::TrackingIssueHandler,
 }
 

--- a/src/handlers/triage.rs
+++ b/src/handlers/triage.rs
@@ -1,0 +1,82 @@
+//! Triage command
+//!
+//! Removes I-nominated tag and adds priority label.
+
+use crate::{
+    config::TriageConfig,
+    github::{self, Event},
+    handlers::{Context, Handler},
+};
+use failure::Error;
+use parser::command::triage::{Priority, TriageCommand};
+use parser::command::{Command, Input};
+
+pub(super) struct TriageHandler;
+
+impl Handler for TriageHandler {
+    type Input = TriageCommand;
+    type Config = TriageConfig;
+
+    fn parse_input(&self, ctx: &Context, event: &Event) -> Result<Option<Self::Input>, Error> {
+        #[allow(irrefutable_let_patterns)]
+        let event = if let Event::IssueComment(e) = event {
+            e
+        } else {
+            // not interested in other events
+            return Ok(None);
+        };
+
+        let mut input = Input::new(&event.comment.body, &ctx.username);
+        match input.parse_command() {
+            Command::Triage(Ok(command)) => Ok(Some(command)),
+            Command::Triage(Err(err)) => {
+                failure::bail!(
+                    "Parsing triage command in [comment]({}) failed: {}",
+                    event.comment.html_url,
+                    err
+                );
+            }
+            _ => Ok(None),
+        }
+    }
+
+    fn handle_input(
+        &self,
+        ctx: &Context,
+        config: &TriageConfig,
+        event: &Event,
+        cmd: TriageCommand,
+    ) -> Result<(), Error> {
+        #[allow(irrefutable_let_patterns)]
+        let event = if let Event::IssueComment(e) = event {
+            e
+        } else {
+            // not interested in other events
+            return Ok(());
+        };
+
+        let is_team_member =
+            if let Err(_) | Ok(false) = event.comment.user.is_team_member(&ctx.github) {
+                false
+            } else {
+                true
+            };
+        if !is_team_member {
+            failure::bail!("Cannot use triage command as non-team-member");
+        }
+
+        let mut labels = event.issue.labels().to_owned();
+        let add = match cmd.priority {
+            Priority::High => &config.high,
+            Priority::Medium => &config.medium,
+            Priority::Low => &config.low,
+        };
+        labels.push(github::Label { name: add.clone() });
+        labels.retain(|label| !config.remove.contains(&label.name));
+        if &labels[..] != event.issue.labels() {
+            event.issue.set_labels(&ctx.github, labels)?;
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This command is intended for the addition of priority tags
(high/medium/low) while removing some set of tags, usually a nomination.

See [wiki page](https://github.com/rust-lang/triagebot/wiki/Triage) for usage.