### PR TITLE
Run commands on just-opened issue bodies

### DIFF
--- a/src/handlers/tracking_issue.rs
+++ b/src/handlers/tracking_issue.rs
@@ -1,3 +1,4 @@
+#![cfg(empty)]
 use crate::{
     github::GithubClient,
     registry::{Event, Handler},
@@ -84,16 +85,8 @@ impl TrackingIssueHandler {
 
 impl Handler for TrackingIssueHandler {
     fn handle_event(&self, event: &Event) -> Result<(), Error> {
-        #[allow(irrefutable_let_patterns)]
-        let event = if let Event::IssueComment(e) = event {
-            e
-        } else {
-            // not interested in other events
-            return Ok(());
-        };
-
-        self.handle_create(&event)?;
-        self.handle_link(&event)?;
+        //self.handle_create(&event)?;
+        //self.handle_link(&event)?;
         Ok(())
     }
 }


### PR DESCRIPTION
Personally, I feel like UI-wise GitHub should just treat the first "comment" as a comment and issue the comment webhook for it, but apparently, that's not the case.

Fixes #16