### PR TITLE
Add Prioritization-WG members to the rust team members

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -61,7 +61,10 @@ impl User {
         let is_triager = map
             .get("wg-triage")
             .map_or(false, |w| w.members.iter().any(|g| g.github == self.login));
-        Ok(map["all"].members.iter().any(|g| g.github == self.login) || is_triager)
+        let is_pri_member = map
+            .get("wg-prioritization")
+            .map_or(false, |w| w.members.iter().any(|g| g.github == self.login));
+        Ok(map["all"].members.iter().any(|g| g.github == self.login) || is_triager || is_pri_member)
     }
 
     // Returns the ID of the given user, if the user is in the `all` team.


### PR DESCRIPTION
This was submitted mostly to allow Prioritization-WG members to use the `@rustbot ping` command.
cc @spastorino @Mark-Simulacrum 