### PR TITLE
Make error messages easier to read

### DIFF
--- a/parser/src/command/relabel.rs
+++ b/parser/src/command/relabel.rs
@@ -56,8 +56,8 @@ impl fmt::Display for ParseError {
         match self {
             ParseError::EmptyLabel => write!(f, "empty label"),
             ParseError::ExpectedLabelDelta => write!(f, "a label delta"),
-            ParseError::MisleadingTo => write!(f, "forbidden to, use +to"),
-            ParseError::NoSeparator => write!(f, "must have : or to as label starter"),
+            ParseError::MisleadingTo => write!(f, "forbidden `to`, use `+to`"),
+            ParseError::NoSeparator => write!(f, "must have `:` or `to` as label starter"),
         }
     }
 }

--- a/parser/src/error.rs
+++ b/parser/src/error.rs
@@ -32,7 +32,7 @@ impl<'a> fmt::Display for Error<'a> {
         let end = std::cmp::min(self.input.len(), self.position + space);
         write!(
             f,
-            "...{}|error: {} at >|{}...",
+            "...'{}' | error: {} at >| '{}'...",
             &self.input[self.position.saturating_sub(space)..self.position],
             self.source,
             &self.input[self.position..end],


### PR DESCRIPTION
Erroneous input (from https://github.com/rust-lang/rust/issues/72050):
```
@rustbot modify labels A-diagnostics D-papercut
```

Before:
```
Error: Parsing label command in comment failed: ...ify labels|error: must have : or to as label starter at >| A-diagnos...
```

After:
```
Error: Parsing label command in comment failed: ...'ify labels' | error: must have `:` or `to` as label starter at >| ' A-diagnos'...
```