### PR TITLE
Fixes glacier command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "octocrab"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arc-swap 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1419,7 +1419,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "octocrab 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "octocrab 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "parser 0.1.0",
@@ -1777,7 +1777,7 @@ dependencies = [
 "checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
 "checksum num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 "checksum object 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
-"checksum octocrab 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72189709b525449bf6f31bec64eb6fdc3106d2b5e58274f1d2a767aa9736ceb5"
+"checksum octocrab 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d93b930d080feb2b5c55a44f3660f73e65b811bea0ee302a7b738560791f5093"
 "checksum once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum openssl 0.10.29 (registry+https://github.com/rust-lang/crates.io-index)" = "cee6d85f4cb4c4f59a6a85d5b68a233d280c82e29e822913b9c8b129fbf20bdd"

--- a/parser/src/command/glacier.rs
+++ b/parser/src/command/glacier.rs
@@ -1,14 +1,13 @@
 //! The glacier command parser.
 //!
-//! This adds the option to track ICEs. The link must be in quotes.
+//! This adds the option to track ICEs. The <code-source> must be in quotes.
 //!
 //! The grammar is as follows:
 //!
 //! ```text
 //! Command: `@bot glacier <code-source>`
 //!
-//! <code-source>:
-//!   - "https://gist.github.com/.*"
+//! <code-source>: any URL that resolves to plain-text Rust code
 //! ```
 
 use crate::error::Error;

--- a/parser/src/command/glacier.rs
+++ b/parser/src/command/glacier.rs
@@ -1,7 +1,6 @@
 //! The glacier command parser.
 //!
-//! This adds the option to track ICEs. Do note that the gist must be from a playground link.
-//! The link must also be in quotes.
+//! This adds the option to track ICEs. The link must be in quotes.
 //!
 //! The grammar is as follows:
 //!

--- a/src/handlers/glacier.rs
+++ b/src/handlers/glacier.rs
@@ -63,8 +63,7 @@ async fn handle_input(ctx: &Context, event: &Event, cmd: GlacierCommand) -> anyh
         return Ok(())
     };
 
-    let url = cmd.source;
-    let response = ctx.github.raw().get(&format!("{}{}", url, "/raw")).send().await?;
+    let response = ctx.github.raw().get(&cmd.source).send().await?;
     let body = response.text().await?;
 
     let number = event.issue().unwrap().number;

--- a/src/handlers/glacier.rs
+++ b/src/handlers/glacier.rs
@@ -64,7 +64,7 @@ async fn handle_input(ctx: &Context, event: &Event, cmd: GlacierCommand) -> anyh
     };
 
     let url = cmd.source;
-    let response = ctx.github.raw().get(&format!("{}{}", url.replace("github", "githubusercontent"), "/playground.rs")).send().await?;
+    let response = ctx.github.raw().get(&format!("{}{}", url, "/raw")).send().await?;
     let body = response.text().await?;
 
     let number = event.issue().unwrap().number;


### PR DESCRIPTION
This updates octocrab to fix the issue mentioned in: https://github.com/rust-lang/glacier/issues/231
Also, it fixes my mistake in parsing the URL. This also allows ANY gist to be used instead of just a playground link.