### PR TITLE
break out the outer loop

### DIFF
--- a/src/handlers/prioritize.rs
+++ b/src/handlers/prioritize.rs
@@ -47,7 +47,7 @@ impl Handler for PrioritizeHandler {
                         if config.prioritize_on.iter().any(|l| l == applied_label) {
                             let mut prioritize = false;
 
-                            for label in event.issue().unwrap().labels() {
+                            'outer: for label in event.issue().unwrap().labels() {
                                 for exclude_label in &config.exclude_labels {
                                     match glob::Pattern::new(exclude_label) {
                                         Ok(exclude_glob) => {
@@ -59,7 +59,7 @@ impl Handler for PrioritizeHandler {
                                     }
 
                                     if !prioritize {
-                                        break;
+                                        break 'outer;
                                     }
                                 }
                             }


### PR DESCRIPTION
This fixes the issue that has happened here https://github.com/rust-lang/rust/issues/72933, it should have not added `I-prioritize` there.

r? @Mark-Simulacrum 