### PR TITLE
Escape `<`, `>` and `&` to avoid type parameters being parsed as HTML

### DIFF
--- a/src/notification_listing.rs
+++ b/src/notification_listing.rs
@@ -30,7 +30,9 @@ pub async fn render(db: &DbClient, user: &str) -> String {
                 .unwrap_or(&notification.origin_url)
                 .replace('&', "&amp;")
                 .replace('<', "&lt;")
-                .replace('>', "&gt;"),
+                .replace('>', "&gt;")
+                .replace('"', "&quot;")
+                .replace('\'', "&#39;"),
         ));
         if let Some(metadata) = &notification.metadata {
             out.push_str(&format!(
@@ -38,7 +40,9 @@ pub async fn render(db: &DbClient, user: &str) -> String {
                 metadata
                     .replace('&', "&amp;")
                     .replace('<', "&lt;")
-                    .replace('>', "&gt;"),
+                    .replace('>', "&gt;")
+                    .replace('"', "&quot;")
+                    .replace('\'', "&#39;"),
             ));
         }
         out.push_str("</li>");

--- a/src/notification_listing.rs
+++ b/src/notification_listing.rs
@@ -27,10 +27,19 @@ pub async fn render(db: &DbClient, user: &str) -> String {
             notification
                 .short_description
                 .as_ref()
-                .unwrap_or(&notification.origin_url),
+                .unwrap_or(&notification.origin_url)
+                .replace('&', "&amp;")
+                .replace('<', "&lt;")
+                .replace('>', "&gt;"),
         ));
         if let Some(metadata) = &notification.metadata {
-            out.push_str(&format!("<ul><li>{}</li></ul>", metadata));
+            out.push_str(&format!(
+                "<ul><li>{}</li></ul>",
+                metadata
+                    .replace('&', "&amp;")
+                    .replace('<', "&lt;")
+                    .replace('>', "&gt;"),
+            ));
         }
         out.push_str("</li>");
     }


### PR DESCRIPTION
Fixes #422

Not sure if metadata can contain such characters, escape them just in case