### PR TITLE
Enhancements around Zulip APIs

### DIFF
--- a/src/handlers/major_change.rs
+++ b/src/handlers/major_change.rs
@@ -182,11 +182,11 @@ async fn handle_input(
         &issue.title[..std::cmp::min(issue.title.len(), 60 - zulip_topic.len())],
     );
 
-    let zulip_stream = config.zulip_stream.to_string();
     let zulip_req = crate::zulip::MessageApiRequest {
-        type_: "stream",
-        to: &zulip_stream,
-        topic: Some(&zulip_topic),
+        recipient: crate::zulip::Recipient::Stream {
+            id: config.zulip_stream,
+            topic: &zulip_topic,
+        },
         content: &zulip_msg,
     };
 


### PR DESCRIPTION
This PR proposes some enhancements for sending and receiving messages, and adds a new `link` commands which sends back a link to the current channel (topic or private message).

- The Zulip `MessageAPIRequest` is now more statically typed and uses an enum to determine the type of recipient, i.e. `"private"` or `"stream"`.
- The `Message` data structure now parses more information, such as the `stream_id` and `topic` of the message. I didn't test this but only tried to construct a valid data structure from the [Zulip API documentation examples](https://www.zulipchat.com/api/get-events#example-response). I think a second look is necessary.

The `link` command is meant as a helper for e.g. mobile clients which have no easy way to determine the link to a topic. Its implementation could also be reused in the context of other commands.

cc @Mark-Simulacrum