### PR TITLE
Print repository name along the issue number

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -31,6 +31,7 @@ pub struct IssueDecorator {
     pub number: u64,
     pub title: String,
     pub html_url: String,
+    pub repo_name: String,
     pub labels: String,
     pub assignees: String,
 }
@@ -75,6 +76,13 @@ impl<'a> Action for Step<'a> {
                                         title: issue.title.clone(),
                                         number: issue.number,
                                         html_url: issue.html_url.clone(),
+                                        repo_name: repository
+                                            .full_name
+                                            .clone()
+                                            .split("/")
+                                            .last()
+                                            .expect("Failed to split repository name")
+                                            .to_string(),
                                         labels: issue
                                             .labels
                                             .iter()

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -78,7 +78,6 @@ impl<'a> Action for Step<'a> {
                                         html_url: issue.html_url.clone(),
                                         repo_name: repository
                                             .full_name
-                                            .clone()
                                             .split("/")
                                             .last()
                                             .expect("Failed to split repository name")

--- a/templates/_issue.tt
+++ b/templates/_issue.tt
@@ -1,1 +1,1 @@
-{% macro render(issue) %}"{{issue.title}}" [#{{issue.number}}]({{issue.html_url}}){% endmacro %}
+{% macro render(issue) %}"{{issue.title}}" [{{issue.repo_name}}#{{issue.number}}]({{issue.html_url}}){% endmacro %}


### PR DESCRIPTION
Closes https://github.com/rust-lang/compiler-team-prioritization/issues/4

This is the least invasive patch I could think of to show the issue as described [here](https://github.com/rust-lang/compiler-team-prioritization/issues/4#issuecomment-650560817), prepending the repository name before the issue number.

```
[rust#13](https://github.com/rust-lang/rust/issues/13)
[compiler-team#143](https://github.com/rust-lang/compiler-team/issues/143)
```

@spastorino opinions?

Thanks for the review!