### PR TITLE
Add finalized FCPs to agenda

### DIFF
--- a/src/prioritization.rs
+++ b/src/prioritization.rs
@@ -308,6 +308,16 @@ pub fn agenda<'a>() -> Box<Step<'a>> {
         },
     });
 
+    queries.push(QueryMap {
+        name: "fcp_finished",
+        query: github::Query {
+            kind: github::QueryKind::List,
+            filters: vec![("state", "open")],
+            include_labels: vec!["finished-final-comment-period", "disposition-merge"],
+            exclude_labels: vec![],
+        },
+    });
+
     actions.push(Query {
         repo: "rust-lang/rust",
         queries,

--- a/templates/agenda.tt
+++ b/templates/agenda.tt
@@ -24,6 +24,8 @@ tags: weekly, rustc
 {{-issues::render(issues=in_fcp_forge, indent="    ", empty="No FCP requests on forge repo this time.")}}
 - Accepted MCPs
 {{-issues::render(issues=mcp_accepted, indent="    ", empty="No new accepted proposals this time.")}}
+- Finalized FCPs
+{{-issues::render(issues=fcp_finished, indent="    ", empty="No new finished FCP this time.")}}
 
 ### WG checkins
 


### PR DESCRIPTION
This adds the finalized FCPs to the agenda.

It may be a good idea to use `to-announce` also in rust repo as soon as an FCP is accepted, and then I can just remove the label after adding it to the agenda. Otherwise, right now this dumps the following issues ...

- "BufReader should provide a way to seek without dumping the buffer" [rust#31100](https://github.com/rust-lang/rust/issues/31100)
- "Allocator traits and std::heap" [rust#32838](https://github.com/rust-lang/rust/issues/32838)
- "Tracking issue for std::sync::Once poisoning" [rust#33577](https://github.com/rust-lang/rust/issues/33577)
- "Tracking issue for Vec::resize_with and resize_default" [rust#41758](https://github.com/rust-lang/rust/issues/41758)
- "non-lexical lifetimes (NLL) tracking issue" [rust#43234](https://github.com/rust-lang/rust/issues/43234)
- "Tracking issue: RFC 2103 - attributes for tools" [rust#44690](https://github.com/rust-lang/rust/issues/44690)
- "`extern type` cannot support `size_of_val` and `align_of_val`" [rust#49708](https://github.com/rust-lang/rust/issues/49708)
- "Tracking issue for Option::deref, Result::deref, Result::deref_ok, and Result::deref_err" [rust#50264](https://github.com/rust-lang/rust/issues/50264)
- " Tracking issue for `#![feature(maybe_uninit_ref)]`" [rust#63568](https://github.com/rust-lang/rust/issues/63568)
- "Stabilize the `#[alloc_error_handler]` attribute (for no_std + liballoc)" [rust#66740](https://github.com/rust-lang/rust/issues/66740)
- "Make `handle_alloc_error` default to panic (for no_std + liballoc)" [rust#66741](https://github.com/rust-lang/rust/issues/66741)
- "Stabilize core::panic::Location::caller" [rust#72448](https://github.com/rust-lang/rust/issues/72448)
- "mv std libs to std/" [rust#73265](https://github.com/rust-lang/rust/pull/73265)

But we want just show the new ones. Still this is good for now because I can manually edit the agenda output.

r? @Mark-Simulacrum 