### PR TITLE
Automatically rename Zulip topics for MCPs when the GitHub issue is renamed

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -613,6 +613,7 @@ pub struct ChangeInner {
 
 #[derive(Debug, serde::Deserialize)]
 pub struct Changes {
+    pub title: ChangeInner,
     pub body: ChangeInner,
 }
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -260,6 +260,8 @@ pub struct Issue {
     repository: OnceCell<IssueRepository>,
 }
 
+/// Contains only the parts of `Issue` that are needed for turning the issue title into a Zulip
+/// topic.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PartialIssue {
     pub number: u64,

--- a/src/github.rs
+++ b/src/github.rs
@@ -284,16 +284,6 @@ impl ZulipGitHubReference {
     }
 }
 
-impl From<&Issue> for ZulipGitHubReference {
-    fn from(other: &Issue) -> ZulipGitHubReference {
-        ZulipGitHubReference {
-            number: other.number,
-            title: other.title.clone(),
-            repository: other.repository.get().unwrap().clone(),
-        }
-    }
-}
-
 #[derive(Debug, serde::Deserialize)]
 pub struct Comment {
     #[serde(deserialize_with = "opt_string")]
@@ -361,6 +351,14 @@ impl IssueRepository {
 }
 
 impl Issue {
+    pub fn to_zulip_github_reference(&self) -> ZulipGitHubReference {
+        ZulipGitHubReference {
+            number: self.number,
+            title: self.title.clone(),
+            repository: self.repository.get().unwrap().clone(),
+        }
+    }
+
     pub fn repository(&self) -> &IssueRepository {
         self.repository.get_or_init(|| {
             // https://api.github.com/repos/rust-lang/rust/issues/69257/comments

--- a/src/github.rs
+++ b/src/github.rs
@@ -263,13 +263,13 @@ pub struct Issue {
 /// Contains only the parts of `Issue` that are needed for turning the issue title into a Zulip
 /// topic.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct PartialIssue {
+pub struct ZulipGitHubReference {
     pub number: u64,
     pub title: String,
     pub repository: IssueRepository,
 }
 
-impl PartialIssue {
+impl ZulipGitHubReference {
     pub fn zulip_topic_reference(&self) -> String {
         let repo = &self.repository;
         if repo.organization == "rust-lang" {
@@ -284,9 +284,9 @@ impl PartialIssue {
     }
 }
 
-impl From<&Issue> for PartialIssue {
-    fn from(other: &Issue) -> PartialIssue {
-        PartialIssue {
+impl From<&Issue> for ZulipGitHubReference {
+    fn from(other: &Issue) -> ZulipGitHubReference {
+        ZulipGitHubReference {
             number: other.number,
             title: other.title.clone(),
             repository: other.repository.get().unwrap().clone(),

--- a/src/handlers/major_change.rs
+++ b/src/handlers/major_change.rs
@@ -11,6 +11,7 @@ use parser::command::second::SecondCommand;
 pub enum Invocation {
     NewProposal,
     AcceptedProposal,
+    Rename,
 }
 
 pub(super) fn parse_input(
@@ -18,6 +19,10 @@ pub(super) fn parse_input(
     event: &IssuesEvent,
     _config: Option<&MajorChangeConfig>,
 ) -> Result<Option<Invocation>, String> {
+    if event.action == IssuesAction::Edited {
+        return Ok(Some(Invocation::Rename));
+    }
+
     // If we were labeled with accepted, then issue that event
     if event.action == IssuesAction::Labeled
         && event
@@ -32,7 +37,7 @@ pub(super) fn parse_input(
     // "Opened" and "Labeled" events.
     //
     // We want to treat reopened issues as new proposals but if the
-    // issues is freshly opened, we only want to trigger once;
+    // issue is freshly opened, we only want to trigger once;
     // currently we do so on the label event.
     if (event.action == IssuesAction::Reopened
         && event
@@ -85,6 +90,51 @@ pub(super) async fn handle_input(
             "This proposal has been accepted: [#{}]({}).",
             event.issue.number, event.issue.html_url,
         ),
+        Invocation::Rename => {
+            let issue = &event.issue;
+            
+            // Concatenate the issue title and the topic reference, truncating such that
+            // the overall length does not exceed 60 characters (a Zulip limitation).
+            let topic_ref = issue.zulip_topic_reference();
+            // Skip chars until the last characters that can be written:
+            // Maximum 60, minus the reference, minus the elipsis and the space
+            let mut chars = issue
+                .title
+                .char_indices()
+                .skip(60 - topic_ref.chars().count() - 2);
+            let zulip_topic = match chars.next() {
+                Some((len, _)) if chars.next().is_some() => {
+                    format!("{}… {}", &issue.title[..len], topic_ref)
+                }
+                _ => format!("{} {}", issue.title, topic_ref),
+            };
+
+            let zulip_send_req = crate::zulip::MessageApiRequest {
+                recipient: crate::zulip::Recipient::Stream {
+                    id: config.zulip_stream,
+                    topic: &zulip_topic,
+                },
+                content: "The associated GitHub issue has been renamed. Renaming this Zulip topic.",
+            };
+            let zulip_send_res = zulip_send_req
+                .send(&ctx.github.raw())
+                .await
+                .context("zulip post failed")?;
+
+            let zulip_send_res: crate::zulip::MessageApiResponse = zulip_send_res.json().await?;
+
+            let zulip_update_req = crate::zulip::UpdateMessageApiRequest {
+                message_id: zulip_send_res.message_id,
+                topic: Some("TODO"),
+                ..Default::default()
+            };
+            zulip_update_req
+                .send(&ctx.github.raw())
+                .await
+                .context("zulip message update failed")?;
+
+            return Ok(());
+        }
     };
     handle(
         ctx,

--- a/src/handlers/major_change.rs
+++ b/src/handlers/major_change.rs
@@ -104,6 +104,7 @@ pub(super) async fn handle_input(
 
             let prev_topic = zulip_topic_from_issue(&prev_issue);
             let partial_issue: PartialIssue = issue.into();
+            let new_topic = zulip_topic_from_issue(&partial_issue);
 
             let zulip_send_req = crate::zulip::MessageApiRequest {
                 recipient: crate::zulip::Recipient::Stream {
@@ -121,7 +122,7 @@ pub(super) async fn handle_input(
 
             let zulip_update_req = crate::zulip::UpdateMessageApiRequest {
                 message_id: zulip_send_res.message_id,
-                topic: Some(&partial_issue.title),
+                topic: Some(&new_topic),
                 ..Default::default()
             };
             zulip_update_req

--- a/src/handlers/major_change.rs
+++ b/src/handlers/major_change.rs
@@ -123,7 +123,8 @@ pub(super) async fn handle_input(
             let zulip_update_req = crate::zulip::UpdateMessageApiRequest {
                 message_id: zulip_send_res.message_id,
                 topic: Some(&new_topic),
-                ..Default::default()
+                propagate_mode: None,
+                content: None,
             };
             zulip_update_req
                 .send(&ctx.github.raw())

--- a/src/handlers/major_change.rs
+++ b/src/handlers/major_change.rs
@@ -103,7 +103,7 @@ pub(super) async fn handle_input(
             let issue = &event.issue;
 
             let prev_topic = zulip_topic_from_issue(&prev_issue);
-            let partial_issue: ZulipGitHubReference = issue.into();
+            let partial_issue = issue.to_zulip_github_reference();
             let new_topic = zulip_topic_from_issue(&partial_issue);
 
             let zulip_send_req = crate::zulip::MessageApiRequest {
@@ -205,7 +205,7 @@ async fn handle(
     labels.push(Label { name: label_to_add });
     let github_req = issue.set_labels(&ctx.github, labels);
 
-    let partial_issue: ZulipGitHubReference = issue.into();
+    let partial_issue = issue.to_zulip_github_reference();
     let zulip_topic = zulip_topic_from_issue(&partial_issue);
 
     let zulip_req = crate::zulip::MessageApiRequest {

--- a/src/interactions.rs
+++ b/src/interactions.rs
@@ -1,29 +1,9 @@
 use crate::github::{GithubClient, Issue};
 use std::fmt::Write;
 
-pub struct Comment<'a> {
+pub struct ErrorComment<'a> {
     issue: &'a Issue,
     message: String,
-}
-
-impl<'a> Comment<'a> {
-    pub fn new<T>(issue: &'a Issue, message: T) -> Comment<'a>
-    where
-        T: Into<String>,
-    {
-        Comment {
-            issue,
-            message: message.into(),
-        }
-    }
-
-    pub async fn post(&self, client: &GithubClient) -> anyhow::Result<()> {
-        self.issue.post_comment(client, &self.message).await
-    }
-}
-
-pub struct ErrorComment<'a> {
-    comment: Comment<'a>,
 }
 
 impl<'a> ErrorComment<'a> {
@@ -32,19 +12,20 @@ impl<'a> ErrorComment<'a> {
         T: Into<String>,
     {
         ErrorComment {
-            comment: Comment::new(issue, message),
+            issue,
+            message: message.into(),
         }
     }
 
     pub async fn post(&self, client: &GithubClient) -> anyhow::Result<()> {
         let mut body = String::new();
-        writeln!(body, "**Error**: {}", self.comment.message)?;
+        writeln!(body, "**Error**: {}", self.message)?;
         writeln!(body)?;
         writeln!(
             body,
             "Please let **`@rust-lang/release`** know if you're having trouble with this bot."
         )?;
-        self.comment.issue.post_comment(client, &body).await
+        self.issue.post_comment(client, &body).await
     }
 }
 

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -475,7 +475,7 @@ pub struct MessageApiResponse {
     pub message_id: u64,
 }
 
-#[derive(Default)]
+#[derive(Debug)]
 pub struct UpdateMessageApiRequest<'a> {
     pub message_id: u64,
     pub topic: Option<&'a str>,


### PR DESCRIPTION
Fixes #701

r? @Mark-Simulacrum