### PR TITLE
Handle absent sender_short_name in zulip-hook

### DIFF
--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -23,7 +23,7 @@ pub struct Request {
 struct Message {
     sender_id: u64,
     recipient_id: u64,
-    sender_short_name: String,
+    sender_short_name: Option<String>,
     sender_full_name: String,
     stream_id: Option<u64>,
     topic: Option<String>,
@@ -268,11 +268,15 @@ async fn execute_for_other_user(
 
     // At this point, the command has been run (FIXME: though it may have
     // errored, it's hard to determine that currently, so we'll just give the
-    // output fromt he command as well as the command itself).
+    // output from the command as well as the command itself).
 
+    let sender = match &message_data.sender_short_name {
+        Some(short_name) => format!("{} ({})", message_data.sender_full_name, short_name),
+        None => message_data.sender_full_name.clone(),
+    };
     let message = format!(
-        "{} ({}) ran `{}` with output `{}` as you.",
-        message_data.sender_full_name, message_data.sender_short_name, command, output_msg
+        "{} ran `{}` with output `{}` as you.",
+        sender, command, output_msg
     );
 
     let res = MessageApiRequest {


### PR DESCRIPTION
Zulip private messages to triagebot recently started failing with *"Failure! Third party responded with 400"*.

<p align="center"><img alt="screenshot" src="https://user-images.githubusercontent.com/1940490/89133179-ca439680-d4ce-11ea-9540-03d9a697473d.png" width="70%"></p>

In my testing it looks like Zulip is no longer always sending a sender_short_name in the outgoing hook request. Possibly related to https://github.com/zulip/zulip/commit/b375581f58447ee49e721b80a2dd462fdf318e87.

The payload getting posted to /zulip-hook looks like:

```json
{
  "data": "ping",
  "message": {
    "id": 205745202,
    "sender_id": 327146,
    "content": "ping",
    "recipient_id": 522016,
    "timestamp": 1596404244,
    "client": "website",
    "subject": "",
    "topic_links": [],
    "rendered_content": "<p>ping</p>",
    "is_me_message": false,
    "reactions": [],
    "submessages": [],
    "sender_full_name": "David Tolnay",
    "sender_email": "dtolnay@gmail.com",
    "sender_realm_str": "dtolnay",
    "display_recipient": [
      {
        "email": "dtolnay@gmail.com",
        "full_name": "David Tolnay",
        "id": 327146,
        "is_mirror_dummy": false
      },
      {
        "id": 327153,
        "email": "dtolnay-bot@zulipchat.com",
        "full_name": "dtolnay-bot",
        "is_mirror_dummy": false
      }
    ],
    "type": "private",
    "avatar_url": "https://secure.gravatar.com/avatar/cb99289473f6393b89474785f2d294d1?d=identicon&version=1",
    "content_type": "text/x-markdown"
  },
  "bot_email": "dtolnay-bot@zulipchat.com",
  "token": "C5aBFtWr7HIMrWzj3dF7t8LBs85SzbGZ",
  "trigger": "private_message"
}
```

and Triagebot currently fails to deserialize that.

```console
HTTP/1.1 400 Bad Request
x-request-id: f18e7a64-c31a-474f-9ed5-0a5bc80a6b93
content-length: 87
date: Sun, 02 Aug 2020 21:40:58 GMT

Did not send valid JSON request: missing field `sender_short_name` at line 1 column 786
```