### PR TITLE
Track PR number of bors merges

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -137,4 +137,5 @@ CREATE TABLE rustc_commits (
     time TIMESTAMP WITH TIME ZONE
 );
 ",
+    "ALTER TABLE rustc_commits ADD COLUMN pr INTEGER;",
 ];

--- a/src/db/rustc_commits.rs
+++ b/src/db/rustc_commits.rs
@@ -8,12 +8,14 @@ pub struct Commit {
     pub sha: String,
     pub parent_sha: String,
     pub time: DateTime<FixedOffset>,
+    pub pr: Option<u32>,
 }
 
 pub async fn record_commit(db: &DbClient, commit: Commit) -> anyhow::Result<()> {
+    let pr = commit.pr.expect("commit has pr");
     db.execute(
-        "INSERT INTO rustc_commits (sha, parent_sha, time) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING",
-        &[&commit.sha, &commit.parent_sha, &commit.time],
+        "INSERT INTO rustc_commits (sha, parent_sha, time, pr) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING",
+        &[&commit.sha, &commit.parent_sha, &commit.time, &(pr as i32)],
     )
     .await
     .context("inserting commit")?;
@@ -24,7 +26,7 @@ pub async fn get_commits_with_artifacts(db: &DbClient) -> anyhow::Result<Vec<Com
     let commits = db
         .query(
             "
-        select sha, parent_sha, time
+        select sha, parent_sha, time, pr
         from rustc_commits
         where time >= current_date - interval '168 days'
         order by time desc;",
@@ -38,11 +40,13 @@ pub async fn get_commits_with_artifacts(db: &DbClient) -> anyhow::Result<Vec<Com
         let sha: String = commit.get(0);
         let parent_sha: String = commit.get(1);
         let time: DateTime<FixedOffset> = commit.get(2);
+        let pr: Option<i32> = commit.get(3);
 
         data.push(Commit {
             sha,
             parent_sha,
             time,
+            pr: pr.map(|n| n as u32),
         });
     }
 

--- a/src/handlers/rustc_commits.rs
+++ b/src/handlers/rustc_commits.rs
@@ -3,6 +3,7 @@ use crate::{
     github::{self, Event},
     handlers::Context,
 };
+use std::convert::TryInto;
 
 const BORS_GH_ID: i64 = 3372342;
 
@@ -87,6 +88,7 @@ pub async fn handle(ctx: &Context, event: &Event) -> anyhow::Result<()> {
             sha: gc.sha,
             parent_sha: gc.parents.remove(0).sha,
             time: gc.commit.author.date,
+            pr: Some(event.issue.number.try_into().unwrap()),
         },
     )
     .await;


### PR DESCRIPTION
This enables tooling like perf to post back comments on additional results.