### PR TITLE
Filter FFCPs by to-announce label on prioritization

### DIFF
--- a/src/agenda.rs
+++ b/src/agenda.rs
@@ -87,7 +87,11 @@ pub fn prioritization<'a>() -> Box<dyn Action> {
         query: github::Query {
             kind: github::QueryKind::List,
             filters: vec![("state", "open")],
-            include_labels: vec!["finished-final-comment-period", "disposition-merge"],
+            include_labels: vec![
+                "finished-final-comment-period",
+                "disposition-merge",
+                "to-announce",
+            ],
             exclude_labels: vec![],
         },
     });

--- a/templates/prioritization_agenda.tt
+++ b/templates/prioritization_agenda.tt
@@ -24,8 +24,8 @@ tags: weekly, rustc
 {{-issues::render(issues=in_fcp_forge, indent="  ", empty="No FCP requests on forge repo this time.")}}
 - Accepted MCPs
 {{-issues::render(issues=mcp_accepted, indent="  ", empty="No new accepted proposals this time.")}}
-- Finalized FCPs
-{{-issues::render(issues=fcp_finished, indent="  ", empty="No new finished FCP this time.")}}
+- Finalized FCPs (disposition merge)
+{{-issues::render(issues=fcp_finished, indent="  ", empty="No new finished FCP (disposition merge) this time.")}}
 
 ### WG checkins
 


### PR DESCRIPTION
This PR goes with https://github.com/rust-lang/rfcbot-rs/pull/289. Even with that one not yet merged it won't hurt our process to merge this PR.

r? @Mark-Simulacrum 

cc @rust-lang/wg-prioritization 