### PR TITLE
Edit template to avoid some repetitions

### DIFF
--- a/templates/_issues.tt
+++ b/templates/_issues.tt
@@ -2,6 +2,5 @@
 
 {% macro render(issues, indent="", empty="No issues this time.") %}
 {%- for issue in issues %}
-{{indent}}- {{issue::render(issue=issue)}}{% else %}
-{{indent}}- {{empty}}{% endfor -%}
+{{indent}}- {{issue::render(issue=issue)}}{% else %}{{empty}}{% endfor -%}
 {% endmacro %}

--- a/templates/_issues.tt
+++ b/templates/_issues.tt
@@ -1,6 +1,7 @@
 {% import "_issue.tt" as issue %}
 
-{% macro render(issues, indent="", empty="No issues this time.") %}
+{% macro render(issues, indent="", newline_and_indent=true, empty="No issues this time.") %}
 {%- for issue in issues %}
-{{indent}}- {{issue::render(issue=issue)}}{% else %}{{empty}}{% endfor -%}
+{{indent}}- {{issue::render(issue=issue)}}{% else %}{% if newline_and_indent %}
+{{indent}}- {% endif %}{{empty}}{% endfor -%}
 {% endmacro %}

--- a/templates/prioritization_agenda.tt
+++ b/templates/prioritization_agenda.tt
@@ -25,7 +25,7 @@ tags: weekly, rustc
 - Accepted MCPs
 {{-issues::render(issues=mcp_accepted, indent="  ", empty="No new accepted proposals this time.")}}
 - Finalized FCPs (disposition merge)
-{{-issues::render(issues=fcp_finished_compiler_team, indent="", newline-and_indent=false, empty="")}}
+{{-issues::render(issues=fcp_finished_compiler_team, indent="", newline_and_indent=false, empty="")}}
 {{-issues::render(issues=fcp_finished_rust, indent="", newline_and_indent=false, empty="")}}
 {{-issues::render(issues=fcp_finished_forge, indent="  ", empty="No new finished FCP (disposition merge) this time.")}}
 

--- a/templates/prioritization_agenda.tt
+++ b/templates/prioritization_agenda.tt
@@ -25,11 +25,13 @@ tags: weekly, rustc
 {{-issues::render(issues=in_fcp_forge, indent="  ", empty="
   - No FCP requests this time.")}}
 - Accepted MCPs
-{{-issues::render(issues=mcp_accepted, indent="  ", empty="No new accepted proposals this time.")}}
+{{-issues::render(issues=mcp_accepted, indent="  ", empty="
+  - No new accepted proposals this time.")}}
 - Finalized FCPs (disposition merge)
-{{-issues::render(issues=fcp_finished_compiler_team, indent="  ", empty="No new finished FCP (disposition merge) this time.")}}
-{{-issues::render(issues=fcp_finished_rust, indent="  ", empty="No new finished FCP (disposition merge) this time.")}}
-{{-issues::render(issues=fcp_finished_forge, indent="  ", empty="No new finished FCP (disposition merge) this time.")}}
+{{-issues::render(issues=fcp_finished_compiler_team, indent="  ", empty="")}}
+{{-issues::render(issues=fcp_finished_rust, indent="  ", empty="")}}
+{{-issues::render(issues=fcp_finished_forge, indent="  ", empty="
+  - No new finished FCP (disposition merge) this time.")}}
 
 ### WG checkins
 

--- a/templates/prioritization_agenda.tt
+++ b/templates/prioritization_agenda.tt
@@ -15,23 +15,19 @@ tags: weekly, rustc
 - Old MCPs (not seconded, take a look)
 {{-issues::render(issues=mcp_old_not_seconded, indent="  ", empty="No old proposals this time.")}}
 - Pending FCP requests (check your boxes!)
-{{-issues::render(issues=in_pre_fcp_compiler_team, indent="  ", empty="")}}
-{{-issues::render(issues=in_pre_fcp_rust, indent="  ", empty="")}}
-{{-issues::render(issues=in_pre_fcp_forge, indent="  ", empty="
-  - No pending FCP requests this time.")}}
+{{-issues::render(issues=in_pre_fcp_compiler_team, indent="", newline_and_indent=false, empty="")}}
+{{-issues::render(issues=in_pre_fcp_rust, indent="", newline_and_indent=false, empty="")}}
+{{-issues::render(issues=in_pre_fcp_forge, indent="  ", empty="No pending FCP requests this time.")}}
 - Things in FCP (make sure you're good with it)
-{{-issues::render(issues=in_fcp_compiler_team, indent="  ", empty="")}}
-{{-issues::render(issues=in_fcp_rust, indent="  ", empty="")}}
-{{-issues::render(issues=in_fcp_forge, indent="  ", empty="
-  - No FCP requests this time.")}}
+{{-issues::render(issues=in_fcp_compiler_team, indent="", newline_and_indent=false, empty="")}}
+{{-issues::render(issues=in_fcp_rust, indent="", newline_and_indent=false, empty="")}}
+{{-issues::render(issues=in_fcp_forge, indent="  ", empty="No FCP requests this time.")}}
 - Accepted MCPs
-{{-issues::render(issues=mcp_accepted, indent="  ", empty="
-  - No new accepted proposals this time.")}}
+{{-issues::render(issues=mcp_accepted, indent="  ", empty="No new accepted proposals this time.")}}
 - Finalized FCPs (disposition merge)
-{{-issues::render(issues=fcp_finished_compiler_team, indent="  ", empty="")}}
-{{-issues::render(issues=fcp_finished_rust, indent="  ", empty="")}}
-{{-issues::render(issues=fcp_finished_forge, indent="  ", empty="
-  - No new finished FCP (disposition merge) this time.")}}
+{{-issues::render(issues=fcp_finished_compiler_team, indent="", newline-and_indent=false, empty="")}}
+{{-issues::render(issues=fcp_finished_rust, indent="", newline_and_indent=false, empty="")}}
+{{-issues::render(issues=fcp_finished_forge, indent="  ", empty="No new finished FCP (disposition merge) this time.")}}
 
 ### WG checkins
 

--- a/templates/prioritization_agenda.tt
+++ b/templates/prioritization_agenda.tt
@@ -15,13 +15,15 @@ tags: weekly, rustc
 - Old MCPs (not seconded, take a look)
 {{-issues::render(issues=mcp_old_not_seconded, indent="  ", empty="No old proposals this time.")}}
 - Pending FCP requests (check your boxes!)
-{{-issues::render(issues=in_pre_fcp_compiler_team, indent="  ", empty="No pending FCP requests this time.")}}
-{{-issues::render(issues=in_pre_fcp_rust, indent="  ", empty="No pending FCP requests this time.")}}
-{{-issues::render(issues=in_pre_fcp_forge, indent="  ", empty="No pending FCP requests this time.")}}
+{{-issues::render(issues=in_pre_fcp_compiler_team, indent="  ", empty="")}}
+{{-issues::render(issues=in_pre_fcp_rust, indent="  ", empty="")}}
+{{-issues::render(issues=in_pre_fcp_forge, indent="  ", empty="
+  - No pending FCP requests this time.")}}
 - Things in FCP (make sure you're good with it)
-{{-issues::render(issues=in_fcp_compiler_team, indent="  ", empty="No FCP requests this time.")}}
-{{-issues::render(issues=in_fcp_rust, indent="  ", empty="No FCP requests this time.")}}
-{{-issues::render(issues=in_fcp_forge, indent="  ", empty="No FCP requests this time.")}}
+{{-issues::render(issues=in_fcp_compiler_team, indent="  ", empty="")}}
+{{-issues::render(issues=in_fcp_rust, indent="  ", empty="")}}
+{{-issues::render(issues=in_fcp_forge, indent="  ", empty="
+  - No FCP requests this time.")}}
 - Accepted MCPs
 {{-issues::render(issues=mcp_accepted, indent="  ", empty="No new accepted proposals this time.")}}
 - Finalized FCPs (disposition merge)


### PR DESCRIPTION
Should fix https://github.com/rust-lang/compiler-team-prioritization/issues/10

not the most elegant solution, but I tried not to touch the templates too much.

Old text
```
- Pending FCP requests (check your boxes!)
  - No pending FCP requests on compiler-team repo this time.
  - No pending FCP requests on rust repo this time.
  - No pending FCP requests on forge repo this time.
```

new rendering
```
- Pending FCP requests (check your boxes!)
  - No pending FCP requests this time.
```

and equivalent for other FCP and MCP (cannot test everything until github returns nothing)

@spastorino how does it look?