### PR TITLE
List all beta regressions

### DIFF
--- a/src/agenda.rs
+++ b/src/agenda.rs
@@ -440,10 +440,10 @@ pub fn prioritization<'a>() -> Box<dyn Action> {
     });
 
     queries.push(QueryMap {
-        name: "beta_regressions_unassigned_p_high",
+        name: "beta_regressions_p_high",
         query: github::Query {
             kind: github::QueryKind::List,
-            filters: vec![("state", "open"), ("no", "assignee")],
+            filters: vec![("state", "open")],
             include_labels: vec!["regression-from-stable-to-beta", "P-high"],
             exclude_labels: vec!["T-infra", "T-libs", "T-release", "T-rustdoc", "T-core"],
         },

--- a/templates/prioritization_agenda.tt
+++ b/templates/prioritization_agenda.tt
@@ -88,12 +88,12 @@ tags: weekly, rustc
 [T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
 {{-issues::render(issues=p_critical_t_rustdoc, empty="No `P-critical` issues for `T-rustdoc` this time.")}}
 
-### Unassigned P-high regressions
+### P-high regressions
 
-[Beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+P-high+no%3Aassignee)
-{{-issues::render(issues=beta_regressions_unassigned_p_high, empty="No unassigned `P-high` beta regressions this time.")}}
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high)
+{{-issues::render(issues=beta_regressions_p_high, empty="No `P-high` beta regressions this time.")}}
 
-[Nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+P-high+no%3Aassignee)
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee)
 {{-issues::render(issues=nightly_regressions_unassigned_p_high, empty="No unassigned `P-high` nightly regressions this time.")}}
 
 ## Performance logs


### PR DESCRIPTION
r? @Mark-Simulacrum 

cc @rust-lang/wg-prioritization 

I think we should be listing all `P-high` beta regressions as a way to maximize our chances to not land them on stable.