### PR TITLE
Allow acknowledging all notifications

### DIFF
--- a/src/db/notifications.rs
+++ b/src/db/notifications.rs
@@ -59,9 +59,6 @@ pub async fn delete_ping(
                 )
                 .await
                 .context("delete notification query")?;
-            if rows.is_empty() {
-                anyhow::bail!("Did not delete any notifications");
-            }
             Ok(rows
                 .into_iter()
                 .map(|row| {
@@ -150,9 +147,6 @@ pub async fn delete_ping(
                 )
                 .await
                 .context("delete all notifications query")?;
-            if rows.is_empty() {
-                anyhow::bail!("Did not delete any notifications");
-            }
             Ok(rows
                 .into_iter()
                 .map(|row| {

--- a/src/notification_listing.rs
+++ b/src/notification_listing.rs
@@ -54,8 +54,9 @@ pub async fn render(db: &DbClient, user: &str) -> String {
         out.push_str("</ol>");
 
         out.push_str(
-            "<p><em>You can acknowledge notifications by sending </em><code>ack &lt;idx&gt;</code><em> \
-            to </em><strong><code>@triagebot</code></strong><em> on Zulip. Read about the other notification commands \
+            "<p><em>You can acknowledge a notification by sending </em><code>ack &lt;idx&gt;</code><em> \
+            to </em><strong><code>@triagebot</code></strong><em> on Zulip, or you can acknowledge \
+            <em>all</em> notifications by sending <em>ack all</em>. Read about the other notification commands \
             <a href=\"https://forge.rust-lang.org/platforms/zulip/triagebot.html#issue-notifications\">here</a>.</em></p>"
         );
     }

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -484,6 +484,8 @@ async fn acknowledge(gh_id: i64, mut words: impl Iterator<Item = &str>) -> anyho
             std::num::NonZeroUsize::new(number)
                 .ok_or_else(|| anyhow::anyhow!("index must be at least 1"))?,
         )
+    } else if url == "all" || url == "*" {
+        Identifier::All
     } else {
         Identifier::Url(url)
     };


### PR DESCRIPTION
Closes #849.

Now you can send `ack all` or `ack *` to triagebot and all your
notifications will *poof* disappear!
