### PR TITLE
Add alias from `@bot modify labels` to `@bot label`

### DIFF
--- a/parser/src/command.rs
+++ b/parser/src/command.rs
@@ -197,6 +197,13 @@ fn code_2() {
 }
 
 #[test]
+fn code_3() {
+    let input = "@bot label +bug.";
+    let mut input = Input::new(input, "bot");
+    assert!(input.next().is_none());
+}
+
+#[test]
 fn edit_1() {
     let input_old = "@bot modify labels: +bug.";
     let mut input_old = Input::new(input_old, "bot");


### PR DESCRIPTION
I've been participating in the discussions at wg-prioritization, and we use `@rustbot modify labels` a lot.
#892 made a great suggestion for an alias which this PR attempts to support as, for example

`@rustbot label +bug`

which is the equivalent of

`@rustbot modify labels +bug`