### PR TITLE
Allow MCP "consumers" to add extra text to MCP comment

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -132,6 +132,7 @@ pub(crate) struct MajorChangeConfig {
     pub(crate) second_label: String,
     pub(crate) meeting_label: String,
     pub(crate) zulip_stream: u64,
+    pub(crate) open_extra_text: Option<String>,
 }
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]

--- a/src/handlers/major_change.rs
+++ b/src/handlers/major_change.rs
@@ -189,7 +189,9 @@ async fn handle(
         procedural comments, such as volunteering to review, indicating that you \
         second the proposal (or third, etc), or raising a concern that you would \
         like to be addressed. \
+        \n\n{} \
         \n\n[stream]: {}",
+            config.open_extra_text.as_deref().unwrap_or_default(),
             topic_url
         );
         issue


### PR DESCRIPTION
This would allow e.g. T-compiler to ping compiler contributors on GitHub whenever an MCP is created, as discussed in rust-lang/compiler-team#369.

@Mark-Simulacrum @varkor does this seem like a viable approach?