### PR TITLE
Fix repository for RFC retrieval query

### DIFF
--- a/src/agenda.rs
+++ b/src/agenda.rs
@@ -479,6 +479,15 @@ pub fn prioritization<'a>() -> Box<dyn Action> {
         },
     });
 
+    actions.push(Query {
+        repo: "rust-lang/rust",
+        queries,
+    });
+
+    // retrieve some RFCs for the T-compiler agenda
+
+    let mut queries = Vec::new();
+
     //https://github.com/rust-lang/rfcs/pulls?q=is%3Aopen+is%3Apr+label%3AI-nominated+label%3AT-compiler
     queries.push(QueryMap {
         name: "nominated_rfcs_t_compiler",
@@ -491,7 +500,7 @@ pub fn prioritization<'a>() -> Box<dyn Action> {
     });
 
     actions.push(Query {
-        repo: "rust-lang/rust",
+        repo: "rust-lang/rfcs",
         queries,
     });
 


### PR DESCRIPTION
This should fix a bug when retrieving the RFC to be added to the T-compiler agenda. The diff is slightly confusing but I have simply moved the `nominated_rfcs_t_compiler` query back inside the `prioritization()` and then run on the correct "rust-lang/rfcs" repository.

Previously this query gave wrong results because it was run on the "rust-lang/rustc" repository.

cc @spastorino 