### PR TITLE
Add github token check

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -969,7 +969,7 @@ pub fn default_token_from_env() -> String {
         Err(_) => match get_token_from_git_config() {
             Ok(v) => v,
             Err(_) => {
-                panic!("Could not find token in GITHUB_API_TOKEN or .gitconfig/github.oath-token")
+                panic!("Could not find token in GITHUB_API_TOKEN or .gitconfig/github.oauth-token")
             }
         },
     };


### PR DESCRIPTION
I use a script to retrieve the token from a keychain, I have fumbled with the command and assigned a wrong value to the github API token. The GitHub queries then failed but the error returned by the cli tool was confusing, took me a bit to understand where the problem was.

This check ensures that the Github token retrieved is syntactically correct (a-z0-9).

cc: @spastorino 