### PR TITLE
Support multiple different bot names

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -156,9 +156,9 @@ macro_rules! command_handlers {
                 }
             }
 
-            let input = Input::new(&body, &ctx.username);
+            let input = Input::new(&body, vec![&ctx.username, "triagebot"]);
             let commands = if let Some(previous) = event.comment_from() {
-                let prev_commands = Input::new(&previous, &ctx.username).collect::<Vec<_>>();
+                let prev_commands = Input::new(&previous, vec![&ctx.username, "triagebot"]).collect::<Vec<_>>();
                 input.filter(|cmd| !prev_commands.contains(cmd)).collect::<Vec<_>>()
             } else {
                 input.collect()


### PR DESCRIPTION
Currently the triagebot name on GitHub isn't owned by the Rust org, but seems to
be largely unused too. However, we're calling the tool triagebot, and users can
easily get it wrong by calling the tool triagebot on GitHub rather than rustbot
(the "real" name).

For now, just accept both names interchangeably. We do not issue a warning for
the time being.

Fixes #985.