### PR TITLE
glacier: Append random sequence to branch name to make it unique

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1919,6 +1919,7 @@ dependencies = [
  "openssl",
  "parser",
  "postgres-native-tls",
+ "rand",
  "regex",
  "reqwest",
  "rust_team_data",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ native-tls = "0.2"
 serde_path_to_error = "0.1.2"
 octocrab = "0.5"
 comrak = "0.8.2"
+rand = "0.7"
 
 [dependencies.serde]
 version = "1"


### PR DESCRIPTION
Sometimes the user (me) will make a mistake (e.g. leave out
`/rust-play/` from the URL) when invoking `@rustbot glacier`
that means the automatically-created PR has to be closed.

However, there was no way to try again, because the branch name
would conflict and triagebot would crash. Now, we append an
8-character random alphanumeric string to the branch name so that
the branch names are unique and you can try again.

This adds a dependency on `rand`, which is probably the most downloaded
crate all-time, but we already depended on it through other crates.

r? @Mark-Simulacrum
