### PR TITLE
Notify Zulip when issue is closed or reopened

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -123,6 +123,8 @@ pub(crate) struct NotifyZulipLabelConfig {
     pub(crate) topic: String,
     pub(crate) message_on_add: Option<String>,
     pub(crate) message_on_remove: Option<String>,
+    pub(crate) message_on_close: Option<String>,
+    pub(crate) message_on_reopen: Option<String>,
     #[serde(default)]
     pub(crate) required_labels: Vec<String>,
 }


### PR DESCRIPTION
This adds optional `message_on_close` and `message_on_reopen` fields to
`triagebot.toml` to notify the Zulip topic when the issue is closed or
reopened.

Inspired by [this comment] by Ryan Levick.

[this comment]: https://rust-lang.zulipchat.com/#narrow/stream/245100-t-compiler.2Fwg-prioritization.2Falerts/topic/.2380375.20ICE.3A.20compiler.2Frustc_middle.2Fsrc.2Fty.2Fsubst.2Ers.3A568.3A17.3A.20c.E2.80.A6/near/221205328
