### PR TITLE
Fix not finding template files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ FROM ubuntu:bionic AS binary
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     ca-certificates
 
+RUN mkdir -p /opt/triagebot
+
 COPY --from=build /target/release/triagebot /usr/local/bin/
+COPY templates /opt/triagebot/templates
+WORKDIR /opt/triagebot
 ENV PORT=80
 CMD triagebot


### PR DESCRIPTION
The triage dashboard was released but it returns 5xx status code: <https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/Triage.20PR.20dashboard/near/229336937>.

I guess it's because templates are not copied when building docker image, and triagebot can't find templates and panics. ~So I fixed to load templates when building, not running.~ So I fixed to edit the Docker file to copy the templates.

Also, I forgot to check that it work properly on docker at the time of https://github.com/rust-lang/triagebot/pull/1223. I checked it this time.