### PR TITLE
Use shorter date format for updated at

### DIFF
--- a/src/triage.rs
+++ b/src/triage.rs
@@ -56,7 +56,7 @@ pub async fn pulls(
         let assignee = base_pull.assignee.map_or("".to_string(), |v| v.login);
         let updated_at = base_pull
             .updated_at
-            .map_or("".to_string(), |v| v.to_rfc2822());
+            .map_or("".to_string(), |v| v.format("%Y-%m-%d").to_string());
 
         let yellow_line = Utc::now() - Duration::days(YELLOW_DAYS);
         let red_line = Utc::now() - Duration::days(RED_DAYS);


### PR DESCRIPTION
Before:

    Wed, 27 May 2020 17:57:14 +0000

After:

    2020-05-27

(Note that I haven't tested it, but that's what it should look like.)

This PR was split out from #1248.
