### PR TITLE
Add support for adding labels based on files changed

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -117,6 +117,8 @@ pub(crate) struct AutolabelLabelConfig {
     pub(crate) trigger_labels: Vec<String>,
     #[serde(default)]
     pub(crate) exclude_labels: Vec<String>,
+    #[serde(default)]
+    pub(crate) trigger_files: Vec<String>,
 }
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -115,7 +115,7 @@ macro_rules! issue_handlers {
             errors: &mut Vec<HandlerError>,
         ) {
             $(
-            match $name::parse_input(ctx, event, config.$name.as_ref()) {
+            match $name::parse_input(ctx, event, config.$name.as_ref()).await {
                 Err(err) => errors.push(HandlerError::Message(err)),
                 Ok(Some(input)) => {
                     if let Some(config) = &config.$name {

--- a/src/handlers/major_change.rs
+++ b/src/handlers/major_change.rs
@@ -14,7 +14,7 @@ pub enum Invocation {
     Rename { prev_issue: ZulipGitHubReference },
 }
 
-pub(super) fn parse_input(
+pub(super) async fn parse_input(
     _ctx: &Context,
     event: &IssuesEvent,
     _config: Option<&MajorChangeConfig>,

--- a/src/handlers/notify_zulip.rs
+++ b/src/handlers/notify_zulip.rs
@@ -20,7 +20,7 @@ pub(super) enum NotificationType {
     Reopened,
 }
 
-pub(super) fn parse_input(
+pub(super) async fn parse_input(
     _ctx: &Context,
     event: &IssuesEvent,
     config: Option<&NotifyZulipConfig>,


### PR DESCRIPTION
Add support for adding labels based on files changed:

```toml
[autolabel."A-rustdoc"]
# preexisting:
trigger_labels = []
exclude_labels = []
# new:
trigger_files = [
    "src/librustdoc",
    "src/tools/rustdoc",
    "src/rustdoc-json-types",
]
```