### PR TITLE
implement the shortcut handler

### DIFF
--- a/parser/src/command.rs
+++ b/parser/src/command.rs
@@ -10,6 +10,7 @@ pub mod ping;
 pub mod prioritize;
 pub mod relabel;
 pub mod second;
+pub mod shortcut;
 
 pub fn find_command_start(input: &str, bot: &str) -> Option<usize> {
     input.to_ascii_lowercase().find(&format!("@{}", bot))
@@ -24,6 +25,7 @@ pub enum Command<'a> {
     Prioritize(Result<prioritize::PrioritizeCommand, Error<'a>>),
     Second(Result<second::SecondCommand, Error<'a>>),
     Glacier(Result<glacier::GlacierCommand, Error<'a>>),
+    Shortcut(Result<shortcut::ShortcutCommand, Error<'a>>),
     Close(Result<close::CloseCommand, Error<'a>>),
 }
 
@@ -120,6 +122,11 @@ impl<'a> Input<'a> {
             &original_tokenizer,
         ));
         success.extend(parse_single_command(
+            shortcut::ShortcutCommand::parse,
+            Command::Shortcut,
+            &original_tokenizer,
+        ));
+        success.extend(parse_single_command(
             close::CloseCommand::parse,
             Command::Close,
             &original_tokenizer,
@@ -182,6 +189,7 @@ impl<'a> Command<'a> {
             Command::Prioritize(r) => r.is_ok(),
             Command::Second(r) => r.is_ok(),
             Command::Glacier(r) => r.is_ok(),
+            Command::Shortcut(r) => r.is_ok(),
             Command::Close(r) => r.is_ok(),
         }
     }

--- a/parser/src/command/shortcut.rs
+++ b/parser/src/command/shortcut.rs
@@ -1,0 +1,95 @@
+//! The shortcut command parser.
+//!
+//! This can parse predefined shortcut input, single word commands.
+//!
+//! The grammar is as follows:
+//!
+//! ```text
+//! Command: `@bot ready`, or `@bot author`.
+//! ```
+
+use crate::error::Error;
+use crate::token::{Token, Tokenizer};
+use std::fmt;
+
+#[derive(PartialEq, Eq, Debug)]
+pub enum ShortcutCommand {
+    Ready,
+    Author,
+}
+
+#[derive(PartialEq, Eq, Debug)]
+pub enum ParseError {
+    ExpectedEnd,
+}
+
+impl std::error::Error for ParseError {}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ParseError::ExpectedEnd => write!(f, "expected end of command"),
+        }
+    }
+}
+
+impl ShortcutCommand {
+    pub fn parse<'a>(input: &mut Tokenizer<'a>) -> Result<Option<Self>, Error<'a>> {
+        let mut toks = input.clone();
+        if let Some(Token::Word("ready")) = toks.peek_token()? {
+            toks.next_token()?;
+            if let Some(Token::Dot) | Some(Token::EndOfLine) = toks.peek_token()? {
+                toks.next_token()?;
+                *input = toks;
+                return Ok(Some(ShortcutCommand::Ready));
+            } else {
+                return Err(toks.error(ParseError::ExpectedEnd));
+            }
+        } else if let Some(Token::Word("author")) = toks.peek_token()? {
+            toks.next_token()?;
+            if let Some(Token::Dot) | Some(Token::EndOfLine) = toks.peek_token()? {
+                toks.next_token()?;
+                *input = toks;
+                return Ok(Some(ShortcutCommand::Author));
+            } else {
+                return Err(toks.error(ParseError::ExpectedEnd));
+            }
+        } else {
+            return Ok(None);
+        }
+    }
+}
+
+#[cfg(test)]
+fn parse(input: &str) -> Result<Option<ShortcutCommand>, Error<'_>> {
+    let mut toks = Tokenizer::new(input);
+    Ok(ShortcutCommand::parse(&mut toks)?)
+}
+
+#[test]
+fn test_1() {
+    assert_eq!(parse("ready."), Ok(Some(ShortcutCommand::Ready)),);
+}
+
+#[test]
+fn test_2() {
+    assert_eq!(parse("ready"), Ok(Some(ShortcutCommand::Ready)),);
+}
+
+#[test]
+fn test_3() {
+    assert_eq!(parse("author"), Ok(Some(ShortcutCommand::Author)),);
+}
+
+#[test]
+fn test_4() {
+    use std::error::Error;
+    assert_eq!(
+        parse("ready word")
+            .unwrap_err()
+            .source()
+            .unwrap()
+            .downcast_ref(),
+        Some(&ParseError::ExpectedEnd),
+    );
+}

--- a/parser/src/command/shortcut.rs
+++ b/parser/src/command/shortcut.rs
@@ -42,11 +42,11 @@ impl ShortcutCommand {
 
         let mut toks = input.clone();
         if let Some(Token::Word(word)) = toks.peek_token()? {
+            if !shortcuts.contains_key(word) {
+                return Ok(None);
+            }
             toks.next_token()?;
             if let Some(Token::Dot) | Some(Token::EndOfLine) = toks.peek_token()? {
-                if !shortcuts.contains_key(word) {
-                    return Ok(None);
-                }
                 toks.next_token()?;
                 *input = toks;
                 let command = shortcuts.get(word).unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -86,7 +86,7 @@ pub(crate) struct RelabelConfig {
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]
 pub(crate) struct ShortcutConfig {
     #[serde(default)]
-    pub(crate) allow: Vec<String>,
+    _empty: (),
 }
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]
@@ -264,9 +264,6 @@ mod tests {
             infra = "T-infra"
 
             [shortcut]
-            allow = [
-                "ready"
-            ]
         "#;
         let config = toml::from_str::<Config>(&config).unwrap();
         let mut ping_teams = HashMap::new();
@@ -302,7 +299,7 @@ mod tests {
                 nominate: Some(NominateConfig {
                     teams: nominate_teams
                 }),
-                shortcut: Some(ShortcutConfig {allow: vec!["ready".into()]}),
+                shortcut: Some(ShortcutConfig { _empty: () }),
                 prioritize: None,
                 major_change: None,
                 glacier: None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,7 @@ pub(crate) struct Config {
     pub(crate) notify_zulip: Option<NotifyZulipConfig>,
     pub(crate) github_releases: Option<GitHubReleasesConfig>,
     pub(crate) review_submitted: Option<ReviewSubmittedConfig>,
+    pub(crate) shortcut: Option<ShortcutConfig>,
 }
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]
@@ -80,6 +81,12 @@ pub(crate) struct AssignConfig {
 pub(crate) struct RelabelConfig {
     #[serde(default)]
     pub(crate) allow_unauthenticated: Vec<String>,
+}
+
+#[derive(PartialEq, Eq, Debug, serde::Deserialize)]
+pub(crate) struct ShortcutConfig {
+    #[serde(default)]
+    pub(crate) allow: Vec<String>,
 }
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]
@@ -255,6 +262,11 @@ mod tests {
             release = "T-release"
             core = "T-core"
             infra = "T-infra"
+
+            [shortcut]
+            allow = [
+                "ready"
+            ]
         "#;
         let config = toml::from_str::<Config>(&config).unwrap();
         let mut ping_teams = HashMap::new();
@@ -290,6 +302,7 @@ mod tests {
                 nominate: Some(NominateConfig {
                     teams: nominate_teams
                 }),
+                shortcut: Some(ShortcutConfig {allow: vec!["ready".into()]}),
                 prioritize: None,
                 major_change: None,
                 glacier: None,

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -38,6 +38,7 @@ mod prioritize;
 mod relabel;
 mod review_submitted;
 mod rustc_commits;
+mod shortcut;
 
 pub async fn handle(ctx: &Context, event: &Event) -> Vec<HandlerError> {
     let config = config::get(&ctx.github, event.repo_name()).await;
@@ -240,6 +241,7 @@ command_handlers! {
     prioritize: Prioritize,
     relabel: Relabel,
     major_change: Second,
+    shortcut: Shortcut,
     close: Close,
 }
 

--- a/src/handlers/shortcut.rs
+++ b/src/handlers/shortcut.rs
@@ -1,0 +1,116 @@
+//! Purpose: Allow the use of single words shortcut to do specific actions on GitHub via comments.
+//!
+//! Parsing is done in the `parser::command::shortcut` module.
+
+use crate::{
+    config::ShortcutConfig,
+    github::{Event, Label},
+    handlers::Context,
+    interactions::ErrorComment,
+};
+use parser::command::shortcut::ShortcutCommand;
+
+pub(super) async fn handle_command(
+    ctx: &Context,
+    _config: &ShortcutConfig,
+    event: &Event,
+    input: ShortcutCommand,
+) -> anyhow::Result<()> {
+    let issue = event.issue().unwrap();
+    // NOTE: if shortcuts available to issues are created, they need to be allowed here
+    if !issue.is_pr() {
+        let msg = format!("The \"{:?}\" shortcut only works on pull requests.", input);
+        let cmnt = ErrorComment::new(&issue, msg);
+        cmnt.post(&ctx.github).await?;
+        return Ok(());
+    }
+
+    let mut issue_labels = issue.labels().to_owned();
+    let waiting_on_review = "S-waiting-on-review";
+    let waiting_on_author = "S-waiting-on-author";
+
+    match input {
+        ShortcutCommand::Ready => {
+            if assign_and_remove_label(&mut issue_labels, waiting_on_review, waiting_on_author)
+                .is_some()
+            {
+                return Ok(());
+            }
+            issue.set_labels(&ctx.github, issue_labels).await?;
+        }
+        ShortcutCommand::Author => {
+            if assign_and_remove_label(&mut issue_labels, waiting_on_author, waiting_on_review)
+                .is_some()
+            {
+                return Ok(());
+            }
+            issue.set_labels(&ctx.github, issue_labels).await?;
+        }
+    }
+
+    Ok(())
+}
+
+fn assign_and_remove_label(
+    issue_labels: &mut Vec<Label>,
+    assign: &str,
+    remove: &str,
+) -> Option<()> {
+    if issue_labels.iter().any(|label| label.name == assign) {
+        return Some(());
+    }
+
+    if let Some(index) = issue_labels.iter().position(|label| label.name == remove) {
+        issue_labels.swap_remove(index);
+    }
+
+    issue_labels.push(Label {
+        name: assign.into(),
+    });
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::{assign_and_remove_label, Label};
+    fn create_labels(names: Vec<&str>) -> Vec<Label> {
+        names
+            .into_iter()
+            .map(|name| Label { name: name.into() })
+            .collect()
+    }
+
+    #[test]
+    fn test_adds_without_labels() {
+        let expected = create_labels(vec!["assign"]);
+        let mut labels = vec![];
+        assert!(assign_and_remove_label(&mut labels, "assign", "remove").is_none());
+        assert_eq!(labels, expected);
+    }
+
+    #[test]
+    fn test_do_nothing_with_label_already_set() {
+        let expected = create_labels(vec!["assign"]);
+        let mut labels = create_labels(vec!["assign"]);
+        assert!(assign_and_remove_label(&mut labels, "assign", "remove").is_some());
+        assert_eq!(labels, expected);
+    }
+
+    #[test]
+    fn test_other_labels_untouched() {
+        let expected = create_labels(vec!["bug", "documentation", "assign"]);
+        let mut labels = create_labels(vec!["bug", "documentation"]);
+        assert!(assign_and_remove_label(&mut labels, "assign", "remove").is_none());
+        assert_eq!(labels, expected);
+    }
+
+    #[test]
+    fn test_correctly_remove_label() {
+        let expected = create_labels(vec!["bug", "documentation", "assign"]);
+        let mut labels = create_labels(vec!["bug", "documentation", "remove"]);
+        assert!(assign_and_remove_label(&mut labels, "assign", "remove").is_none());
+        assert_eq!(labels, expected);
+    }
+}

--- a/src/interactions.rs
+++ b/src/interactions.rs
@@ -29,6 +29,25 @@ impl<'a> ErrorComment<'a> {
     }
 }
 
+pub struct PingComment<'a> {
+    issue: &'a Issue,
+    users: &'a [&'a str],
+}
+
+impl<'a> PingComment<'a> {
+    pub fn new(issue: &'a Issue, users: &'a [&str]) -> PingComment<'a> {
+        PingComment { issue, users }
+    }
+
+    pub async fn post(&self, client: &GithubClient) -> anyhow::Result<()> {
+        let mut body = String::new();
+        for user in self.users {
+            write!(body, "@{} ", user)?;
+        }
+        self.issue.post_comment(client, &body).await
+    }
+}
+
 pub struct EditIssueBody<'a> {
     issue: &'a Issue,
     id: &'static str,


### PR DESCRIPTION
#1339 

This implements the shorcut handler and already works with two shorcuts:
  - `ready` -> `S-waiting-on-review`
  - `author` -> `S-waiting-on-author`
  
It correctly remove the unnecessary label while keeping previous ones. This functionality is accompanied by unit tests.

I do wonder if the `author` command should be allowed to only team members or it's ok as it is allowed now.

A follow up to this that require more analysis, would be to ping assigned reviewers.
  