### PR TITLE
Add disallowed labels to notify_zulip config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -125,6 +125,8 @@ pub(crate) struct NotifyZulipLabelConfig {
     pub(crate) message_on_remove: Option<String>,
     #[serde(default)]
     pub(crate) required_labels: Vec<String>,
+    #[serde(default)]
+    pub(crate) disallowed_labels: Vec<String>,
 }
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]


### PR DESCRIPTION
Fixes #714 

I believe the proposed `include_labels` is already added as `required_labels`, correct me if I'm wrong though.