### PR TITLE
Fix wrong endpoint when searching in pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ To configure the GitHub webhook, point it to the `/github-hook` path of your
 webserver (by default `http://localhost:8000`), configure the secret you chose
 in `.env`, set the content type to `application/json` and select all events.
 
+## Notes about Github issues/pulls request APIs
+
+The Github API are a bit confusing when the intent is to search either through issues _or_ pull requests. The `/{repo}/pulls` endpoint does not support filter by label, while the `/{repo}/issues` does.
+
+The search endpoint and issues/pulls in some cases can resolve the exact same kind of queries. The `/search` and `/issues` endpoints both return issues and pull requests, the endpoint `/pulls` only returns pull requests. The reason is that under the hood Github only has a "issue" entity and pull requests are just "issues with a special flag" (see [their documentation](https://docs.github.com/en/rest/reference/issues#list-repository-issues)).
+
+In some cases the Triagebot CLI ends up hitting the Github API limit of your auth token so splitting some queries into different endpoints might help. Also, the `/search` endpoint is much slower.
+
 ## License
 
 Triagebot is distributed under the terms of both the MIT license and the

--- a/src/agenda.rs
+++ b/src/agenda.rs
@@ -490,12 +490,12 @@ pub fn prioritization<'a>() -> Box<dyn Action> {
 
     let mut queries = Vec::new();
 
-    //https://github.com/rust-lang/rfcs/pulls?q=is%3Aopen+is%3Apr+label%3AI-nominated+label%3AT-compiler
+    // https://github.com/rust-lang/rfcs/pulls?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler
     queries.push(QueryMap {
         name: "nominated_rfcs_t_compiler",
         query: github::Query {
             kind: github::QueryKind::List,
-            filters: vec![("state", "open"), ("is", "pr")],
+            filters: vec![("state", "open")],
             include_labels: vec!["T-compiler", "I-nominated"],
             exclude_labels: vec![],
         },

--- a/src/github.rs
+++ b/src/github.rs
@@ -767,9 +767,9 @@ impl Repository {
             .any(|&(key, value)| key == "is" && value == "pr");
         // negating filters can only be handled by the search api
         let url = if is_pr {
-            self.build_pulls_url(filters, include_labels)
+            self.build_issues_pulls_url(filters, include_labels)
         } else if use_issues {
-            self.build_issues_url(filters, include_labels)
+            self.build_issues_pulls_url(filters, include_labels)
         } else {
             self.build_search_issues_url(filters, include_labels, exclude_labels)
         };
@@ -797,7 +797,7 @@ impl Repository {
         Ok(self.get_issues(client, query).await?.len())
     }
 
-    fn build_issues_url(&self, filters: &Vec<(&str, &str)>, include_labels: &Vec<&str>) -> String {
+    fn build_issues_pulls_url(&self, filters: &Vec<(&str, &str)>, include_labels: &Vec<&str>) -> String {
         let filters = filters
             .iter()
             .map(|(key, val)| format!("{}={}", key, val))
@@ -813,28 +813,6 @@ impl Repository {
             .join("&");
         format!(
             "{}/repos/{}/issues?{}",
-            Repository::GITHUB_API_URL,
-            self.full_name,
-            filters
-        )
-    }
-
-    fn build_pulls_url(&self, filters: &Vec<(&str, &str)>, include_labels: &Vec<&str>) -> String {
-        let filters = filters
-            .iter()
-            .map(|(key, val)| format!("{}={}", key, val))
-            .chain(std::iter::once(format!(
-                "labels={}",
-                include_labels.join(",")
-            )))
-            .chain(std::iter::once("filter=all".to_owned()))
-            .chain(std::iter::once(format!("sort=created")))
-            .chain(std::iter::once(format!("direction=asc")))
-            .chain(std::iter::once(format!("per_page=100")))
-            .collect::<Vec<_>>()
-            .join("&");
-        format!(
-            "{}/repos/{}/pulls?{}",
             Repository::GITHUB_API_URL,
             self.full_name,
             filters


### PR DESCRIPTION
The Github API are a bit confusing when the intent is to search
either through issues *or* pull requests. Their documentation mentions
the endpoint `/search/issues`, I'm not sure if `/search/pulls`
introduced in #740 was an API since then removed.
https://docs.github.com/en/rest/reference/search#search-issues-and-pull-requests

By the way, under the hood Github only has "issues" as entities and
pull requests are just "issues with a special flag".

Commit 106bbb22 unearthed this bug.

This patch should fix when searching through pull requests in the
rust-lang/rfcs repository, labels `T-compiler` and `I-nominated` were
ignored, corresponding to the `[RFC]` section of the WG-Prioritization agenda