### PR TITLE
Update T-libs labels in agenda

### DIFF
--- a/src/agenda.rs
+++ b/src/agenda.rs
@@ -183,7 +183,7 @@ pub fn prioritization<'a>() -> Box<dyn Action> {
         query: github::Query {
             kind: github::QueryKind::List,
             filters: vec![],
-            include_labels: vec!["beta-nominated", "T-libs-impl"],
+            include_labels: vec!["beta-nominated", "T-libs"],
             exclude_labels: vec!["beta-accepted"],
         },
     });
@@ -214,7 +214,7 @@ pub fn prioritization<'a>() -> Box<dyn Action> {
         query: github::Query {
             kind: github::QueryKind::List,
             filters: vec![],
-            include_labels: vec!["stable-nominated", "T-libs-impl"],
+            include_labels: vec!["stable-nominated", "T-libs"],
             exclude_labels: vec!["stable-accepted"],
         },
     });
@@ -245,7 +245,7 @@ pub fn prioritization<'a>() -> Box<dyn Action> {
         query: github::Query {
             kind: github::QueryKind::List,
             filters: vec![("state", "open")],
-            include_labels: vec!["S-waiting-on-team", "T-libs-impl"],
+            include_labels: vec!["S-waiting-on-team", "T-libs"],
             exclude_labels: vec![],
         },
     });
@@ -426,7 +426,7 @@ pub fn prioritization<'a>() -> Box<dyn Action> {
         query: github::Query {
             kind: github::QueryKind::List,
             filters: vec![("state", "open")],
-            include_labels: vec!["T-libs-impl", "P-critical"],
+            include_labels: vec!["T-libs", "P-critical"],
             exclude_labels: vec![],
         },
     });
@@ -476,7 +476,7 @@ pub fn prioritization<'a>() -> Box<dyn Action> {
         query: github::Query {
             kind: github::QueryKind::List,
             filters: vec![("state", "open")],
-            include_labels: vec!["I-nominated", "T-libs-impl"],
+            include_labels: vec!["I-nominated", "T-libs"],
             exclude_labels: vec![],
         },
     });

--- a/templates/prioritization_agenda.tt
+++ b/templates/prioritization_agenda.tt
@@ -37,9 +37,9 @@ tags: weekly, rustc
 {{-issues::render(issues=beta_nominated_t_compiler, branch=":beta:", empty="No beta nominations for `T-compiler` this time.")}}
 {{-issues::render(issues=stable_nominated_t_compiler, branch=":stable:", empty="No stable nominations for `T-compiler` this time.")}}
 
-[T-libs-impl stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-libs-impl) / [T-libs-impl beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-libs-impl)
-{{-issues::render(issues=beta_nominated_libs_impl, branch=":beta:", empty="No beta nominations for `T-libs-impl` this time.")}}
-{{-issues::render(issues=stable_nominated_libs_impl, branch=":stable:", empty="No stable nominations for `T-libs-impl` this time.")}}
+[T-libs stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-libs) / [T-libs beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-libs)
+{{-issues::render(issues=beta_nominated_libs_impl, branch=":beta:", empty="No beta nominations for `T-libs` this time.")}}
+{{-issues::render(issues=stable_nominated_libs_impl, branch=":stable:", empty="No stable nominations for `T-libs` this time.")}}
 
 [T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
 {{-issues::render(issues=beta_nominated_t_rustdoc, branch=":beta:", empty="No beta nominations for `T-rustdoc` this time.")}}
@@ -52,8 +52,8 @@ tags: weekly, rustc
 [T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
 {{-issues::render(issues=prs_waiting_on_team_t_compiler, empty="No PRs waiting on `T-compiler` this time.")}}
 
-[T-libs-impl](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-libs-impl)
-{{-issues::render(issues=prs_waiting_on_team_libs_impl, empty="No PRs waiting on `T-libs-impl` this time.")}}
+[T-libs](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-libs)
+{{-issues::render(issues=prs_waiting_on_team_libs_impl, empty="No PRs waiting on `T-libs` this time.")}}
 
 ## Issues of Note
 
@@ -72,7 +72,7 @@ tags: weekly, rustc
 [T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
 {{-issues::render(issues=p_critical_t_compiler, empty="No `P-critical` issues for `T-compiler` this time.")}}
 
-[T-libs-impl](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-libs-impl)
+[T-libs](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-libs)
 {{-issues::render(issues=p_critical_libs_impl, empty="No `P-critical` issues for `libs-impl` this time.")}}
 
 [T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
@@ -95,8 +95,8 @@ tags: weekly, rustc
 [T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
 {{-issues::render(issues=nominated_t_compiler, empty="No nominated issues for `T-compiler` this time.")}}
 
-[T-libs-impl](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-libs-impl)
-{{-issues::render(issues=nominated_libs_impl, empty="No nominated issues for `T-libs-impl` this time.")}}
+[T-libs](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-libs)
+{{-issues::render(issues=nominated_libs_impl, empty="No nominated issues for `T-libs` this time.")}}
 
 [RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
 {{-issues::render(issues=nominated_rfcs_t_compiler, empty="No nominated RFCs for `T-compiler` this time.")}}


### PR DESCRIPTION
Companion PR for https://github.com/rust-lang/rust-forge/pull/546

The team now uses `T-libs` and `T-libs-api`, so this patch renames all occurrences of `T-libs-impl` to `T-libs` and will catch both new labels

r? @spastorino 