### PR TITLE
Allow anyone to use the triage bot to set the perf-regression label

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,5 +1,5 @@
 [relabel]
-allow-unauthenticated = ["bug", "invalid", "question", "enhancement"]
+allow-unauthenticated = ["bug", "invalid", "question", "enhancement", "perf-regression"]
 
 [assign]
 


### PR DESCRIPTION
Triage bot doesn't have permission to make the label needed for marking pull requests as performance regressions after they a perf run shows regressions. For example, https://github.com/rust-lang/rust/pull/86525#issuecomment-868593482. 

This enables that scenario. 

cc @Mark-Simulacrum 