### PR TITLE
Add age to MCPs not yet seconded

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 
 use async_trait::async_trait;
@@ -35,6 +36,7 @@ pub struct IssueDecorator {
     pub repo_name: String,
     pub labels: String,
     pub assignees: String,
+    pub updated_at: String,
 }
 
 lazy_static! {
@@ -47,6 +49,16 @@ lazy_static! {
             }
         }
     };
+}
+
+fn to_human(d: DateTime<Utc>) -> String {
+    let d1 = chrono::Utc::now() - d;
+    let days = d1.num_days();
+    if days > 60 {
+        format!("{} months ago", days / 30)
+    } else {
+        format!("about {} days ago", days)
+    }
 }
 
 #[async_trait]
@@ -94,6 +106,7 @@ impl<'a> Action for Step<'a> {
                                                 .map(|u| u.login.as_ref())
                                                 .collect::<Vec<_>>()
                                                 .join(", "),
+                                            updated_at: to_human(issue.updated_at),
                                         })
                                         .collect();
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -244,6 +244,7 @@ pub struct Issue {
     pub number: u64,
     pub body: String,
     created_at: chrono::DateTime<Utc>,
+    pub updated_at: chrono::DateTime<Utc>,
     #[serde(default)]
     pub merge_commit_sha: Option<String>,
     pub title: String,

--- a/templates/_issue.tt
+++ b/templates/_issue.tt
@@ -1,1 +1,1 @@
-{% macro render(issue) %}"{{issue.title}}" [{{issue.repo_name}}#{{issue.number}}]({{issue.html_url}}){% endmacro %}
+{% macro render(issue, with_age="") %}"{{issue.title}}" [{{issue.repo_name}}#{{issue.number}}]({{issue.html_url}}) {% if with_age %}(last comment: {{issue.updated_at}}){% endif %}{% endmacro %}

--- a/templates/_issues.tt
+++ b/templates/_issues.tt
@@ -1,7 +1,7 @@
 {% import "_issue.tt" as issue %}
 
-{% macro render(issues, indent="", branch="", empty="No issues this time.") %}
+{% macro render(issues, indent="", branch="", with_age=false, empty="No issues this time.") %}
 {%- for issue in issues %}
-{{indent}}- {{ branch }} {{issue::render(issue=issue)}}{% else %}
+{{indent}}- {{ branch }} {{issue::render(issue=issue, with_age=with_age)}}{% else %}
 {{indent}}- {{empty}}{% endfor -%}
 {% endmacro %}

--- a/templates/prioritization_agenda.tt
+++ b/templates/prioritization_agenda.tt
@@ -13,7 +13,7 @@ tags: weekly, rustc
 - New MCPs (take a look, see if you like them!)
 {{-issues::render(issues=mcp_new_not_seconded, indent="  ", empty="No new proposals this time.")}}
 - Old MCPs (not seconded, take a look)
-{{-issues::render(issues=mcp_old_not_seconded, indent="  ", empty="No old proposals this time.")}}
+{{-issues::render(issues=mcp_old_not_seconded, indent="  ", with_age=true, empty="No old proposals this time.")}}
 - Pending FCP requests (check your boxes!)
 {{-issues::render(issues=in_pre_fcp, indent="  ", empty="No pending FCP requests this time.")}}
 - Things in FCP (make sure you're good with it)


### PR DESCRIPTION
We ran a little experiment at the T-compiler meeting by showing the age of MCP not yet seconded ([was an idea of Felix](https://zulip-archive.rust-lang.org/238009tcompilermeetings/39906weekly2021062454818.html#243793945)) and it seems [that it is working](https://zulip-archive.rust-lang.org/238009tcompilermeetings/08286weekly2021070154818.html#244571967).

The idea is to show at a glance how old an MCP is.

Old (current) agenda rendering:
![grafik](https://user-images.githubusercontent.com/6098822/124163090-8458cf00-da9f-11eb-87b0-409c89d1dbab.png)

New agenda rendering:
![grafik](https://user-images.githubusercontent.com/6098822/124163010-7014d200-da9f-11eb-87de-99300c859d1e.png)

r? @spastorino 

Open to suggestion on how to improve this PR (naming things and anything else)