### PR TITLE
Iterate rustc commits when appending to database

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -1162,6 +1162,8 @@ impl GithubClient {
 #[derive(Debug, serde::Deserialize)]
 pub struct GithubCommit {
     pub sha: String,
+    #[serde(default)]
+    pub message: String,
     pub commit: GitCommit,
     pub parents: Vec<Parent>,
 }


### PR DESCRIPTION
We sometimes get webhook deliveries that end up somewhat spurious -- for
example, when the final push fails due to 422 Fast Forward failure. This should
let us recover on subsequent notifications by going back until we hit a known
commit over the linked list formed by the first parents.

This should avoid picking up non-bors rust-lang/rust commits (e.g., those
made by bors in clippy or elsewhere), as the first parent is always correct.
