### PR TITLE
Remove T-libs content from T-compiler agenda

### DIFF
--- a/src/agenda.rs
+++ b/src/agenda.rs
@@ -179,16 +179,6 @@ pub fn prioritization<'a>() -> Box<dyn Action> {
     });
 
     queries.push(QueryMap {
-        name: "beta_nominated_libs_impl",
-        query: github::Query {
-            kind: github::QueryKind::List,
-            filters: vec![],
-            include_labels: vec!["beta-nominated", "T-libs"],
-            exclude_labels: vec!["beta-accepted"],
-        },
-    });
-
-    queries.push(QueryMap {
         name: "beta_nominated_t_rustdoc",
         query: github::Query {
             kind: github::QueryKind::List,
@@ -210,16 +200,6 @@ pub fn prioritization<'a>() -> Box<dyn Action> {
     });
 
     queries.push(QueryMap {
-        name: "stable_nominated_libs_impl",
-        query: github::Query {
-            kind: github::QueryKind::List,
-            filters: vec![],
-            include_labels: vec!["stable-nominated", "T-libs"],
-            exclude_labels: vec!["stable-accepted"],
-        },
-    });
-
-    queries.push(QueryMap {
         name: "stable_nominated_t_rustdoc",
         query: github::Query {
             kind: github::QueryKind::List,
@@ -236,16 +216,6 @@ pub fn prioritization<'a>() -> Box<dyn Action> {
             kind: github::QueryKind::List,
             filters: vec![("state", "open")],
             include_labels: vec!["S-waiting-on-team", "T-compiler"],
-            exclude_labels: vec![],
-        },
-    });
-
-    queries.push(QueryMap {
-        name: "prs_waiting_on_team_libs_impl",
-        query: github::Query {
-            kind: github::QueryKind::List,
-            filters: vec![("state", "open")],
-            include_labels: vec!["S-waiting-on-team", "T-libs"],
             exclude_labels: vec![],
         },
     });
@@ -422,16 +392,6 @@ pub fn prioritization<'a>() -> Box<dyn Action> {
     });
 
     queries.push(QueryMap {
-        name: "p_critical_libs_impl",
-        query: github::Query {
-            kind: github::QueryKind::List,
-            filters: vec![("state", "open")],
-            include_labels: vec!["T-libs", "P-critical"],
-            exclude_labels: vec![],
-        },
-    });
-
-    queries.push(QueryMap {
         name: "p_critical_t_rustdoc",
         query: github::Query {
             kind: github::QueryKind::List,
@@ -467,16 +427,6 @@ pub fn prioritization<'a>() -> Box<dyn Action> {
             kind: github::QueryKind::List,
             filters: vec![("state", "open")],
             include_labels: vec!["I-nominated", "T-compiler"],
-            exclude_labels: vec![],
-        },
-    });
-
-    queries.push(QueryMap {
-        name: "nominated_libs_impl",
-        query: github::Query {
-            kind: github::QueryKind::List,
-            filters: vec![("state", "open")],
-            include_labels: vec!["I-nominated", "T-libs"],
             exclude_labels: vec![],
         },
     });

--- a/templates/prioritization_agenda.tt
+++ b/templates/prioritization_agenda.tt
@@ -37,10 +37,6 @@ tags: weekly, rustc
 {{-issues::render(issues=beta_nominated_t_compiler, branch=":beta:", empty="No beta nominations for `T-compiler` this time.")}}
 {{-issues::render(issues=stable_nominated_t_compiler, branch=":stable:", empty="No stable nominations for `T-compiler` this time.")}}
 
-[T-libs stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-libs) / [T-libs beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-libs)
-{{-issues::render(issues=beta_nominated_libs_impl, branch=":beta:", empty="No beta nominations for `T-libs` this time.")}}
-{{-issues::render(issues=stable_nominated_libs_impl, branch=":stable:", empty="No stable nominations for `T-libs` this time.")}}
-
 [T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
 {{-issues::render(issues=beta_nominated_t_rustdoc, branch=":beta:", empty="No beta nominations for `T-rustdoc` this time.")}}
 {{-issues::render(issues=stable_nominated_t_rustdoc, branch=":stable:", empty="No stable nominations for `T-rustdoc` this time.")}}
@@ -51,9 +47,6 @@ tags: weekly, rustc
 
 [T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
 {{-issues::render(issues=prs_waiting_on_team_t_compiler, empty="No PRs waiting on `T-compiler` this time.")}}
-
-[T-libs](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-libs)
-{{-issues::render(issues=prs_waiting_on_team_libs_impl, empty="No PRs waiting on `T-libs` this time.")}}
 
 ## Issues of Note
 
@@ -72,18 +65,15 @@ tags: weekly, rustc
 [T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
 {{-issues::render(issues=p_critical_t_compiler, empty="No `P-critical` issues for `T-compiler` this time.")}}
 
-[T-libs](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-libs)
-{{-issues::render(issues=p_critical_libs_impl, empty="No `P-critical` issues for `libs-impl` this time.")}}
-
 [T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
 {{-issues::render(issues=p_critical_t_rustdoc, empty="No `P-critical` issues for `T-rustdoc` this time.")}}
 
 ### P-high regressions
 
-[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
 {{-issues::render(issues=beta_regressions_p_high, empty="No `P-high` beta regressions this time.")}}
 
-[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
 {{-issues::render(issues=nightly_regressions_unassigned_p_high, empty="No unassigned `P-high` nightly regressions this time.")}}
 
 ## Performance logs
@@ -94,9 +84,6 @@ tags: weekly, rustc
 
 [T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
 {{-issues::render(issues=nominated_t_compiler, empty="No nominated issues for `T-compiler` this time.")}}
-
-[T-libs](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-libs)
-{{-issues::render(issues=nominated_libs_impl, empty="No nominated issues for `T-libs` this time.")}}
 
 [RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
 {{-issues::render(issues=nominated_rfcs_t_compiler, empty="No nominated RFCs for `T-compiler` this time.")}}


### PR DESCRIPTION
`T-libs` holds their own meetings and schedule, so `T-compiler` doesn't need to have an additional eye on their issues and pull requests.

I've updated the [T-compiler agenda](https://hackmd.io/WQW0yzDDS16YvtBNurmj6A?both) template accordingly.

r? @spastorino 