### PR TITLE
State: all is default on Github API

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -865,6 +865,7 @@ impl Repository {
     ) -> String {
         let filters = filters
             .iter()
+            .filter(|&&(key, val)| !(key == "state" && val == "all"))
             .map(|(key, val)| format!("{}:{}", key, val))
             .chain(
                 include_labels


### PR DESCRIPTION
The default on Github search endpoint is to return open/closed issues. But if we pass state: all Github search doesn't understand it, which is weird because that's basically how issues endpoint works and it's documented. So the only way to match our API with Github API is to remove state: all from the filter query on search API to make Github do the right thing.