### PR TITLE
Update last comment wording

### DIFF
--- a/templates/_issue.tt
+++ b/templates/_issue.tt
@@ -1,1 +1,1 @@
-{% macro render(issue, with_age="") %}"{{issue.title}}" [{{issue.repo_name}}#{{issue.number}}]({{issue.html_url}}) {% if with_age %}(last comment: {{issue.updated_at}}){% endif %}{% endmacro %}
+{% macro render(issue, with_age="") %}"{{issue.title}}" [{{issue.repo_name}}#{{issue.number}}]({{issue.html_url}}) {% if with_age %}(last review activity: {{issue.updated_at}}){% endif %}{% endmacro %}


### PR DESCRIPTION
Now the timestamp next to an MCP/FCP and the PR's waiting for review has a new meaning.

I've updated the T-compiler template accordingly.

ref: https://github.com/rust-lang/triagebot/pull/1466#discussion_r701077228

r? @spastorino 