### PR TITLE
Avoid comments consisting of just pings

### DIFF
--- a/src/handlers/shortcut.rs
+++ b/src/handlers/shortcut.rs
@@ -6,7 +6,7 @@ use crate::{
     config::ShortcutConfig,
     github::{Event, Label},
     handlers::Context,
-    interactions::{ErrorComment, PingComment},
+    interactions::ErrorComment,
 };
 use parser::command::shortcut::ShortcutCommand;
 
@@ -37,14 +37,6 @@ pub(super) async fn handle_command(
                 return Ok(());
             }
             issue.set_labels(&ctx.github, issue_labels).await?;
-
-            let to_ping: Vec<_> = issue
-                .assignees
-                .iter()
-                .map(|user| user.login.as_str())
-                .collect();
-            let cmnt = PingComment::new(&issue, &to_ping);
-            cmnt.post(&ctx.github).await?;
         }
         ShortcutCommand::Author => {
             if assign_and_remove_label(&mut issue_labels, waiting_on_author, waiting_on_review)
@@ -53,10 +45,6 @@ pub(super) async fn handle_command(
                 return Ok(());
             }
             issue.set_labels(&ctx.github, issue_labels).await?;
-
-            let to_ping = vec![issue.user.login.as_str()];
-            let cmnt = PingComment::new(&issue, &to_ping);
-            cmnt.post(&ctx.github).await?;
         }
     }
 


### PR DESCRIPTION
The S-waiting-on-{author,review} status change is already accompanied by a
comment from someone (who invokes the shortcut command), that is likely
sufficient in terms of generating a notification. A direct ping in a one-off
comment is not warranted and mostly just adds noise to the thread.