### PR TITLE
Exclude more T-libs issues from T-compiler meeting agenda

### DIFF
--- a/src/agenda.rs
+++ b/src/agenda.rs
@@ -378,6 +378,7 @@ pub fn prioritization<'a>() -> Box<dyn Action> {
                             exclude_labels: vec![
                                 "T-infra",
                                 "T-libs",
+                                "T-libs-api",
                                 "T-release",
                                 "T-rustdoc",
                                 "T-core",
@@ -393,6 +394,7 @@ pub fn prioritization<'a>() -> Box<dyn Action> {
                             exclude_labels: vec![
                                 "T-infra",
                                 "T-libs",
+                                "T-libs-api",
                                 "T-release",
                                 "T-rustdoc",
                                 "T-core",

--- a/templates/prioritization_agenda.tt
+++ b/templates/prioritization_agenda.tt
@@ -75,10 +75,10 @@ tags: weekly, rustc
 
 ### P-high regressions
 
-[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-libs-api+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
 {{-issues::render(issues=beta_regressions_p_high, empty="No `P-high` beta regressions this time.")}}
 
-[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core)
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-libs-api+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-core+)
 {{-issues::render(issues=nightly_regressions_unassigned_p_high, empty="No unassigned `P-high` nightly regressions this time.")}}
 
 ## Performance logs


### PR DESCRIPTION
I've noticed that some T-libs issue were not filtered out from the issues listing.

I have update the github filtering of these issues and the meeting agenda template we WG-prioritiazation prepare

r? @spastorino 

thanks!