### PR TITLE
Update queries and templates for move from I-nominated to I-teamname-nominated

### DIFF
--- a/src/agenda.rs
+++ b/src/agenda.rs
@@ -406,7 +406,7 @@ pub fn prioritization<'a>() -> Box<dyn Action> {
                         kind: QueryKind::List,
                         query: Box::new(github::Query {
                             filters: vec![("state", "open")],
-                            include_labels: vec!["I-nominated", "T-compiler"],
+                            include_labels: vec!["I-compiler-nominated"],
                             exclude_labels: vec![],
                         }),
                     },
@@ -421,13 +421,13 @@ pub fn prioritization<'a>() -> Box<dyn Action> {
                 repos: vec![("rust-lang", "rfcs")],
                 queries: vec![
                     // retrieve some RFCs for the T-compiler agenda
-                    // https://github.com/rust-lang/rfcs/pulls?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler
+                    // https://github.com/rust-lang/rfcs/pulls?q=is%3Aopen+label%3AI-compiler-nominated
                     QueryMap {
                         name: "nominated_rfcs_t_compiler",
                         kind: QueryKind::List,
                         query: Box::new(github::Query {
                             filters: vec![("state", "open")],
-                            include_labels: vec!["T-compiler", "I-nominated"],
+                            include_labels: vec!["I-compiler-nominated"],
                             exclude_labels: vec![],
                         }),
                     },
@@ -511,7 +511,7 @@ pub fn lang<'a>() -> Box<dyn Action> {
                         kind: QueryKind::List,
                         query: Box::new(github::Query {
                             filters: vec![("state", "open")],
-                            include_labels: vec!["T-lang", "I-nominated"],
+                            include_labels: vec!["I-lang-nominated"],
                             exclude_labels: vec![],
                         }),
                     },

--- a/src/handlers/relabel.rs
+++ b/src/handlers/relabel.rs
@@ -185,7 +185,7 @@ mod tests {
         macro_rules! t {
             ($($member:ident { $($label:expr => $res:ident,)* })*) => {
                 let config = RelabelConfig {
-                    allow_unauthenticated: vec!["T-*".into(), "I-*".into(), "!I-nominated".into()],
+                    allow_unauthenticated: vec!["T-*".into(), "I-*".into(), "!I-*nominated".into()],
                 };
                 $($(assert_eq!(
                     check_filter($label, &config, TeamMembership::$member),
@@ -197,18 +197,21 @@ mod tests {
             Member {
                 "T-release" => Allow,
                 "I-slow" => Allow,
+                "I-lang-nominated" => Allow,
                 "I-nominated" => Allow,
                 "A-spurious" => Allow,
             }
             Outsider {
                 "T-release" => Allow,
                 "I-slow" => Allow,
+                "I-lang-nominated" => Deny,
                 "I-nominated" => Deny,
                 "A-spurious" => Deny,
             }
             Unknown {
                 "T-release" => Allow,
                 "I-slow" => Allow,
+                "I-lang-nominated" => DenyUnknown,
                 "I-nominated" => DenyUnknown,
                 "A-spurious" => DenyUnknown,
             }

--- a/templates/prioritization_agenda.tt
+++ b/templates/prioritization_agenda.tt
@@ -87,8 +87,8 @@ tags: weekly, rustc
 
 ## Nominated Issues
 
-[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
-{{-issues::render(issues=nominated_t_compiler, empty="No nominated issues for `T-compiler` this time.")}}
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-compiler-nominated)
+{{-issues::render(issues=nominated_t_compiler, empty="No I-compiler-nominated issues this time.")}}
 
-[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-nominated+label%3AT-compiler)
-{{-issues::render(issues=nominated_rfcs_t_compiler, empty="No nominated RFCs for `T-compiler` this time.")}}
+[RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-compiler-nominated)
+{{-issues::render(issues=nominated_rfcs_t_compiler, empty="No I-compiler-nominated RFCs this time.")}}


### PR DESCRIPTION
This updates queries and templates that referenced I-nominated.

This does not attempt to update the `nominate` command.