### PR TITLE
Use default for `trigger_labels` when absent

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -114,6 +114,7 @@ impl AutolabelConfig {
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]
 pub(crate) struct AutolabelLabelConfig {
+    #[serde(default)]
     pub(crate) trigger_labels: Vec<String>,
     #[serde(default)]
     pub(crate) exclude_labels: Vec<String>,


### PR DESCRIPTION
to allow configuration that contains only `trigger_files` field.

This should fix the parsing issue occurning after rust-lang/rust#91817
landed:

> Error: Malformed triagebot.toml in master branch.
> missing field trigger_labels for key autolabel at line 156 column 1