### PR TITLE
Remove hard-coded `I-prioritize` remove-on-close code

### DIFF
--- a/src/handlers/autolabel.rs
+++ b/src/handlers/autolabel.rs
@@ -96,17 +96,6 @@ pub(super) async fn parse_input(
             }
         }
     }
-    if event.action == IssuesAction::Closed {
-        let labels = event.issue.labels();
-        if labels.iter().any(|x| x.name == "I-prioritize") {
-            return Ok(Some(AutolabelInput {
-                add: vec![],
-                remove: vec![Label {
-                    name: "I-prioritize".to_owned(),
-                }],
-            }));
-        }
-    }
     Ok(None)
 }
 


### PR DESCRIPTION
I think it was masked by bugs until the recent cleanup in
ca4b23dafff31545ee737c441565b279039c8a64. Sometimes issues are closed by
accident, so removing `I-prioritize` should be done manually. Also, now
that triagebot notifies users when issues with the `I-prioritize` label
(or whatever label is specified) are closed, the auto-removal feature
has less value.

See https://rust-lang.zulipchat.com/#narrow/stream/227806-t-compiler.2Fwg-prioritization/topic/rustbot.20auto-unprioritize.

r? @Mark-Simulacrum 