### PR TITLE
Add compiler backlog bonanza generation 

### DIFF
--- a/src/agenda.rs
+++ b/src/agenda.rs
@@ -599,3 +599,30 @@ pub fn lang_planning<'a>() -> Box<dyn Action> {
         ],
     })
 }
+
+// Things to add (maybe):
+// - Compiler RFCs
+// - P-high issues
+pub fn compiler_backlog_bonanza<'a>() -> Box<dyn Action> {
+    Box::new(Step {
+        name: "compiler_backlog_bonanza",
+        actions: vec![
+            Query {
+                repos: vec![
+                    ("rust-lang", "rust"),
+                ],
+                queries: vec![
+                    QueryMap {
+                        name: "tracking_issues",
+                        kind: QueryKind::List,
+                        query: Box::new(github::Query {
+                            filters: vec![("state", "open")],
+                            include_labels: vec!["C-tracking-issue"],
+                            exclude_labels: vec!["T-libs-api", "T-libs", "T-lang", "T-rustdoc"],
+                        }),
+                    },
+                ],
+            },
+        ],
+    })
+}

--- a/src/bin/compiler.rs
+++ b/src/bin/compiler.rs
@@ -1,0 +1,21 @@
+use triagebot::agenda;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    dotenv::dotenv().ok();
+    tracing_subscriber::fmt::init();
+
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() == 2 {
+        match &args[1][..] {
+            "backlog_bonanza" => {
+                let agenda = agenda::compiler_backlog_bonanza();
+                print!("{}", agenda.call().await);
+                return;
+            }
+            _ => {}
+        }
+    }
+
+    eprintln!("Usage: compiler (backlog_bonanza)")
+}

--- a/templates/compiler_backlog_bonanza.tt
+++ b/templates/compiler_backlog_bonanza.tt
@@ -1,0 +1,12 @@
+{% import "_issues_heading.tt" as issues_heading %}
+{% import "_issues.tt" as issues %}
+---
+title: T-compiler backlog bonanza
+tags: backlog-bonanza
+---
+
+# T-compiler backlog bonanza
+
+## Tracking issues
+
+{{-issues_heading::render(issues=tracking_issues)}}


### PR DESCRIPTION
Also, enable pagination for issues. This only applies to the "search" for now; didn't have the time to figure out the right field for the issue/pulls API response. I can potentially come back to this later, but figured this was fine for now.

