### PR TITLE
Rename the entire zulip topic when an MCP issue is renamed. Fixes #1228.

### DIFF
--- a/src/handlers/major_change.rs
+++ b/src/handlers/major_change.rs
@@ -139,7 +139,7 @@ pub(super) async fn handle_input(
             let zulip_update_req = crate::zulip::UpdateMessageApiRequest {
                 message_id: zulip_send_res.message_id,
                 topic: Some(&new_topic),
-                propagate_mode: None,
+                propagate_mode: Some("change_all"),
                 content: None,
             };
             zulip_update_req


### PR DESCRIPTION
See comment [here](https://github.com/rust-lang/triagebot/issues/1228#issuecomment-1066166708). Note that I don't have a local dev instance and haven't been able to verify this change myself.