### PR TITLE
After renaming zulip topic, post a comment under the old topic pointing to the new topic

### DIFF
--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -393,6 +393,10 @@ impl Recipient<'_> {
             Recipient::Private { id, .. } => format!("pm-with/{}-xxx", id),
         }
     }
+
+    pub fn url(&self) -> String {
+        format!("https://rust-lang.zulipchat.com/#narrow/{}", self.narrow())
+    }
 }
 
 #[cfg(test)]
@@ -430,10 +434,7 @@ pub struct MessageApiRequest<'a> {
 
 impl<'a> MessageApiRequest<'a> {
     pub fn url(&self) -> String {
-        format!(
-            "https://rust-lang.zulipchat.com/#narrow/{}",
-            self.recipient.narrow()
-        )
+        self.recipient.url()
     }
 
     pub async fn send(&self, client: &reqwest::Client) -> anyhow::Result<reqwest::Response> {


### PR DESCRIPTION
After renaming zulip topic (#1588), post an additional comment under the old (now empty) topic pointing to the newly renamed topic. Fixes #1228.

Alternative to #1589. Although #1589 could potentially still be applied. it would just be somewhat redundant.

cc @Mark-Simulacrum @apiraino