### PR TITLE
Add cutoff env var for PRs WRF from T-compiler

### DIFF
--- a/src/github/graphql.rs
+++ b/src/github/graphql.rs
@@ -304,7 +304,7 @@ impl super::IssuesQuery for LeastRecentlyReviewedPullRequests {
 
         let prs: Vec<_> = prs
             .into_iter()
-            .take(5)
+            .take(50)
             .map(
                 |(updated_at, number, title, html_url, repo_name, labels, assignees)| {
                     let updated_at = crate::actions::to_human(updated_at);


### PR DESCRIPTION
Very small patch but very useful for me when drafting the T-compiler weekly agenda. The default cutoff value (5) for listing the PRs waiting for a review from the T-compiler is often not enough, I need to dig deeper in this [github query](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-asc+label%3AS-waiting-on-review+draft%3Afalse+label%3AT-compiler+-label%3AT-lang+-label%3AT-infra+-label%3AT-release+-label%3AT-libs+-label%3AT-libs-api).

Having a dynamic cutoff value is for me very helpful. Default value (5) is as before when no override is provided.

r? @Mark-Simulacrum 

thanks!