### PR TITLE
Comment on issues when `@rustbot label` is given an invalid label

### DIFF
--- a/src/interactions.rs
+++ b/src/interactions.rs
@@ -1,6 +1,5 @@
 use crate::github::{GithubClient, Issue};
 use std::fmt::Write;
-use tracing as log;
 
 pub struct ErrorComment<'a> {
     issue: &'a Issue,


### PR DESCRIPTION
Previously, the label was just silently ignored, along with all other labels
in the same command. This tells the user what went wrong, and also adds all valid labels.

I'm not sure how to test this :(