### PR TITLE
WG-prioritization: Cosmetic fix, remove redundant empty space

### DIFF
--- a/templates/_issues.tt
+++ b/templates/_issues.tt
@@ -1,7 +1,11 @@
 {% import "_issue.tt" as issue %}
 
 {% macro render(issues, indent="", branch="", with_age=false, empty="No issues this time.") %}
+{#- If "branch" is not empty add a trailing space but no newlines before or after -#}
+{%- if branch -%}
+{%- set branch = branch ~ " " -%}
+{%- endif -%}
 {%- for issue in issues %}
-{{indent}}- {{ branch }} {{issue::render(issue=issue, with_age=with_age)}}{% else %}
+{{indent}}- {{ branch }}{{issue::render(issue=issue, with_age=with_age)}}{% else %}
 {{indent}}- {{empty}}{% endfor -%}
 {% endmacro %}


### PR DESCRIPTION
This is just a tiny cosmetic fix to the WG prioritization agenda, will remove a redundant space on lists.

Example before:
```
### Oldest PRs waiting for review

[T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-asc+label%3AS-waiting-on-review+draft%3Afalse+label%3AT-compiler)
-  "Mir-Opt for copying enums with large discrepancies" [rust#85158](https://github.com/rust-lang/rust/pull/85158) (last review activity: 2 months ago)
-  "Only compile #[used] as llvm.compiler.used for ELF targets" [rust#93718](https://github.com/rust-lang/rust/pull/93718) (last review activity: about 57 days ago)
-  "TypeId: use a (v0) mangled type to remain sound in the face of hash collisions." [rust#95845](https://github.com/rust-lang/rust/pull/95845) (last review activity: about 46 days ago)
```

Example after
```
### Oldest PRs waiting for review

[T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-asc+label%3AS-waiting-on-review+draft%3Afalse+label%3AT-compiler)
- "Mir-Opt for copying enums with large discrepancies" [rust#85158](https://github.com/rust-lang/rust/pull/85158) (last review activity: 2 months ago)
- "Only compile #[used] as llvm.compiler.used for ELF targets" [rust#93718](https://github.com/rust-lang/rust/pull/93718) (last review activity: about 57 days ago)
- "TypeId: use a (v0) mangled type to remain sound in the face of hash collisions." [rust#95845](https://github.com/rust-lang/rust/pull/95845) (last review activity: about 46 days ago)
 ```

r? @spastorino 