### PR TITLE
WG-prioritization: retrieve all T-compiler WG meetings

### DIFF
--- a/src/http_client/mod.rs
+++ b/src/http_client/mod.rs
@@ -1,0 +1,72 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use reqwest::Url;
+
+#[derive(serde::Deserialize, serde::Serialize, Debug)]
+pub struct CompilerMeetings {
+    items: Vec<CompilerMeeting>,
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Debug)]
+pub struct Start {
+    #[serde(rename(deserialize = "dateTime"))]
+    date_time: String,
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Debug)]
+pub struct CompilerMeeting {
+    summary: String,
+    #[serde(rename(deserialize = "htmlLink"))]
+    html_link: String,
+    #[serde(rename(deserialize = "originalStartTime"))]
+    original_start: Option<Start>,
+    start: Option<Start>,
+}
+
+#[async_trait]
+pub trait HttpClient {
+    async fn get_meetings(
+        start_date: chrono::DateTime<chrono::Local>,
+        end_date: chrono::DateTime<chrono::Local>,
+    ) -> Result<Vec<CompilerMeeting>>
+    where
+        Self: Sized;
+}
+
+#[async_trait]
+impl HttpClient for CompilerMeeting {
+    /// Retrieve all meetings from the Rust Compiler Team Calendar in a date range
+    /// If a Google API auth token is not provided just return
+    // Google calendar API documentation:
+    // https://developers.google.com/calendar/api/v3/reference/events/list
+    // The API token needs only one permission: https://www.googleapis.com/auth/calendar.events.readonly
+    async fn get_meetings(
+        start_date: chrono::DateTime<chrono::Local>,
+        end_date: chrono::DateTime<chrono::Local>,
+    ) -> Result<Vec<CompilerMeeting>> {
+        let api_key = match std::env::var("GOOGLE_API_KEY") {
+            Ok(v) => v,
+            Err(_) => {
+                return Ok(vec![]);
+            }
+        };
+        let google_calendar_id = "6u5rrtce6lrtv07pfi3damgjus%40group.calendar.google.com";
+        let time_min = format!("{}T00:00:00+00:00", start_date.format("%F").to_string());
+        let time_max = format!("{}T23:59:59+00:00", end_date.format("%F").to_string());
+        let url = Url::parse_with_params(
+            &format!(
+                "https://www.googleapis.com/calendar/v3/calendars/{}/events",
+                google_calendar_id
+            ),
+            &[
+                // see google docs for the meaning of these values
+                ("key", api_key),
+                ("timeMin", time_min),
+                ("timeMax", time_max),
+                ("singleEvents", "true".to_string()),
+            ],
+        )?;
+        let calendar = reqwest::get(url).await?.json::<CompilerMeetings>().await?;
+        Ok(calendar.items)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod config;
 pub mod db;
 pub mod github;
 pub mod handlers;
+pub mod http_client;
 pub mod interactions;
 pub mod notification_listing;
 pub mod payload;

--- a/templates/_meetings.tt
+++ b/templates/_meetings.tt
@@ -1,0 +1,5 @@
+{% macro render(meetings, empty="No other meetings scheduled.") %}
+{%- for mtg in meetings %}
+- [{{ mtg.summary }}]({{ mtg.html_link }}) at <time:{{ mtg.start.date_time }}>{% else %}
+- {{empty}}{% endfor -%}
+{% endmacro %}

--- a/templates/prioritization_agenda.tt
+++ b/templates/prioritization_agenda.tt
@@ -1,4 +1,5 @@
 {% import "_issues.tt" as issues %}
+{% import "_meetings.tt" as meetings %}
 
 ---
 tags: weekly, rustc
@@ -9,6 +10,9 @@ tags: weekly, rustc
 [Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
 
 ## Announcements
+
+### Other WG meetings ([calendar link](https://calendar.google.com/calendar/embed?src=6u5rrtce6lrtv07pfi3damgjus%40group.calendar.google.com))
+{{-meetings::render(meetings=meetings_tcompiler, empty="No meetings scheduled for next week")}}
 
 - New MCPs (take a look, see if you like them!)
 {{-issues::render(issues=mcp_new_not_seconded, indent="  ", empty="No new proposals this time.")}}


### PR DESCRIPTION
For WG-prioritization agenda, add all Rust compiler WG meetings happening in the following week.

This new bit of the agenda is added automatically by calling the [google calendar API](https://developers.google.com/calendar/api/v3/reference/events/list), needs the caller to set a new env var (`GOOGLE_API_KEY`) with the API token.

Was mentioned in a past [T-compiler meeting](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202022-05-19/near/282933732), I've attempted an implementation.

r? @spastorino 