### PR TITLE
Enforce rustfmt in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,15 @@ env:
   AWS_ACCESS_KEY_ID: AKIA46X5W6CZEAQSMRH7
 
 jobs:
+  rustfmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Install Rust
+      run: rustup update stable && rustup default stable && rustup component add rustfmt
+    - run: cargo fmt --all --check
+
   ci:
     name: CI
     runs-on: ubuntu-latest

--- a/parser/src/command.rs
+++ b/parser/src/command.rs
@@ -209,8 +209,7 @@ impl<'a> Command<'a> {
 
 #[test]
 fn errors_outside_command_are_fine() {
-    let input =
-        "haha\" unterminated quotes @bot labels +bug. Terminating after the command";
+    let input = "haha\" unterminated quotes @bot labels +bug. Terminating after the command";
     let mut input = Input::new(input, vec!["bot"]);
     assert!(input.next().unwrap().is_ok());
 }

--- a/src/handlers/autolabel.rs
+++ b/src/handlers/autolabel.rs
@@ -130,7 +130,11 @@ pub(super) async fn handle_input(
         Err(e) => {
             use crate::github::UnknownLabels;
             if let Some(err @ UnknownLabels { .. }) = e.downcast_ref() {
-                event.issue.post_comment(&ctx.github, &err.to_string()).await.context("failed to post missing label comment")?;
+                event
+                    .issue
+                    .post_comment(&ctx.github, &err.to_string())
+                    .await
+                    .context("failed to post missing label comment")?;
                 return Ok(());
             }
             return Err(e);

--- a/src/handlers/note.rs
+++ b/src/handlers/note.rs
@@ -141,9 +141,7 @@ pub(super) async fn handle_command(
                     author,
                 };
                 log::debug!("New Note Entry: {:#?}", new_entry);
-                current
-                    .entries_by_url
-                    .insert(comment_url, new_entry);
+                current.entries_by_url.insert(comment_url, new_entry);
                 log::debug!("Entries by URL: {:#?}", current.entries_by_url);
             }
         }

--- a/src/handlers/review_submitted.rs
+++ b/src/handlers/review_submitted.rs
@@ -7,9 +7,7 @@ pub(crate) async fn handle(
     config: &ReviewSubmittedConfig,
 ) -> anyhow::Result<()> {
     if let Event::IssueComment(
-        event
-        @
-        IssueCommentEvent {
+        event @ IssueCommentEvent {
             action: IssueCommentAction::Created,
             issue: Issue {
                 pull_request: Some(_),


### PR DESCRIPTION
In general I believe that it is nicer to keep the codebase formatted with rustfmt. It can be a chore to run `cargo fmt` and then need to undo the random changes.