### PR TITLE
Fix wrong deserialization of PR webook payload

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -303,7 +303,7 @@ pub struct Comment {
 }
 
 #[derive(Debug, serde::Deserialize, Eq, PartialEq)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum PullRequestReviewState {
     Approved,
     ChangesRequested,


### PR DESCRIPTION
While looking at something else I've found a small error when a reviewer submit some comments in a PR.

How to reproduce:
- `User A` opens a PR, review is done by `User B`
- go to "files changed" of the PR
- add a comment, click "start a review"
- click on "changes requested"

The following error log appears in the log ot the triagebot
```
2022-06-27T15:02:41.510650Z  INFO request{uuid=be78bdb6-0289-43da-b57f-f9a07ffcd630}: triagebot: request = Request { method: POST, uri: /github-hook, version: HTTP/1.1, headers: {"host": "my-triagebot.domain.org", "user-agent": "GitHub-Hookshot/00ff07b", "content-length": "23253", "accept": "*/*", "content-type": "application/json", "x-forwarded-for": "123.456.789.123", "x-forwarded-proto": "https", "x-github-delivery": "30d61ac0-f62a-11ec-9cb0-0ec98c7d6080", "x-github-event": "pull_request_review", "x-github-hook-id": "364411628", "x-github-hook-installation-target-id": "471843806", "x-github-hook-installation-target-type": "repository", "x-hub-signature": "sha1=a1c98189dacd28568207fa8e9e6c3f4f8a2aeaa6", "x-hub-signature-256": "sha256=907667a2fd4ba5e63e3244c437b98a7cf8d5ff4f78ea260c968bcbea10898cff", "accept-encoding": "gzip"}, body: Body(Streaming) }
2022-06-27T15:02:41.511435Z DEBUG request{uuid=be78bdb6-0289-43da-b57f-f9a07ffcd630}: triagebot: event=pull_request_review
2022-06-27T15:02:41.511614Z DEBUG request{uuid=be78bdb6-0289-43da-b57f-f9a07ffcd630}: triagebot: signature=sha1=a1c98189dacd28568207fa8e9e6c3f4f8a2aeaa6
2022-06-27T15:02:41.613941Z ERROR request{uuid=be78bdb6-0289-43da-b57f-f9a07ffcd630}: triagebot: request failed: WebhookError(PullRequestReview failed to deserialize

Caused by:
    0: at Path { segments: [Map { key: "review" }, Map { key: "state" }] }
    1: unknown variant `changes_requested`, expected one of `approved`, `changesrequested`, `commented`, `dismissed`, `pending` at line 1 column 1162)
2022-06-27T15:02:41.614534Z  INFO request{uuid=be78bdb6-0289-43da-b57f-f9a07ffcd630}: triagebot: response = Ok(Response { status: 500, version: HTTP/1.1, headers: {"x-request-id": "be78bdb6-0289-43da-b57f-f9a07ffcd630"}, body: Body(Full(b"request failed: WebhookError(PullRequestReview failed to deserialize\n\nCaused by:\n    0: at Path { segments: [Map { key: \"review\" }, Map { key: \"state\" }] }\n    1: unknown variant `changes_requested`, expected one of `approved`, `changesrequested`, `commented`, `dismissed`, `pending` at line 1 column 1162)")) })
```

I'm not sure about the consequences of this error, possibly none? this small patch should fix a 500 HTTP error that the github hook receives from the triagebot. So maybe not so important to fix.

r? @Mark-Simulacrum 