### PR TITLE
Fix mentions elided for the author.

### DIFF
--- a/src/handlers/mentions.rs
+++ b/src/handlers/mentions.rs
@@ -61,7 +61,9 @@ pub(super) async fn parse_input(
             .filter(|(path, MentionsPathConfig { cc, .. })| {
                 let path = Path::new(path);
                 file_paths.iter().any(|p| p.starts_with(path))
-                    && !cc.iter().any(|r| r == &event.issue.user.login)
+                    && !cc
+                        .iter()
+                        .any(|r| r.trim_start_matches('@') == &event.issue.user.login)
             })
             .map(|(key, _mention)| key.to_string())
             .collect();


### PR DESCRIPTION
The mentions code was intended to not ping if the author is in the mention list. The author check was not working because the `@` symbol was in the way. This fixes it to strip the `@` so the author check works.
