### PR TITLE
Don't post mentions on rollups.

### DIFF
--- a/src/handlers/mentions.rs
+++ b/src/handlers/mentions.rs
@@ -42,6 +42,11 @@ pub(super) async fn parse_input(
         return Ok(None);
     }
 
+    // Don't ping on rollups.
+    if event.issue.title.starts_with("Rollup of") {
+        return Ok(None);
+    }
+
     if let Some(diff) = event
         .issue
         .diff(&ctx.github)


### PR DESCRIPTION
People don't need to be pinged on a rollup PR, so this tries to skip them.

An alternate approach would be to scan the issue body for something like `@rustbot modify labels: rollup`, but I think looking at the title should work well enough.

This won't handle beta backports, though.  I'm wondering if maybe it should ignore the beta branch?  I don't know if those pings will happen often enough to be annoying.
