### PR TITLE
Triagebot learned the `read` cmd

### DIFF
--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -181,6 +181,13 @@ fn handle_command<'a>(
                                 })
                                 .unwrap(),
                             },
+                            Some("read") => return match post_waiter(&ctx, message_data, WaitingMessage::start_reading()).await {
+                                Ok(r) => r,
+                                Err(e) => serde_json::to_string(&Response {
+                                    content: &format!("Failed to await at this time: {:?}", e),
+                                })
+                                .unwrap(),
+                            },
                             _ => {}
                         }
                     }
@@ -747,6 +754,13 @@ impl WaitingMessage<'static> {
                   React with :working_on_it: if you have something to say.\n\
                   React with :all_good: if you're ready to end the meeting.",
             emoji: &["working_on_it", "all_good"],
+        }
+    }
+    fn start_reading() -> Self {
+        WaitingMessage {
+            primary: "Click on the :book: when you start reading (and leave it clicked).\n\
+                      Click on the :checkered_flag: when you finish reading.",
+            emoji: &["book", "checkered_flag"],
         }
     }
 }


### PR DESCRIPTION
Meeting attendees are invited to read a document and notify when they
start and when they finish reading the document.

As suggested, I've just duplicated some code, making the simplest patch possible. Wording and emoji are modeled after one of the [T-compiler meeting](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bsteering.20meeting.5D.202022-06-17.20compiler-team.23516.3A.20sanitize/near/286494283), can be of course improved.

Rendering should be close to this:
![screenshot-20220629-184355](https://user-images.githubusercontent.com/6098822/176491279-d947b1ba-c3ea-496e-9cae-a478cafcd924.png)

Note: IUUC the current format of [Message](https://github.com/rust-lang/triagebot/blob/13ece7c760650b891cb797341550a418c888c91d/src/zulip.rs#L23-L36) seems to not allow also a `body` to Zulip ([API docs](https://zulip.com/api/send-message)) so as for all other messages, anything following the command will be ignored.

r? @Mark-Simulacrum cc @jackh726 for suggestions on wording :)

Closes #1613