### PR TITLE
Support GitHub's rendered label syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,6 +1178,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "pulldown-cmark",
+ "urlencoding",
 ]
 
 [[package]]
@@ -2218,6 +2219,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b90931029ab9b034b300b797048cf23723400aa757e8a2bfb9d748102f9821"
 
 [[package]]
 name = "uuid"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["Mark Rousskov <mark.simulacrum@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-pulldown-cmark = "0.7.0"
 log = "0.4"
+pulldown-cmark = "0.7.0"
+urlencoding = "2.1"

--- a/parser/src/command/relabel.rs
+++ b/parser/src/command/relabel.rs
@@ -273,3 +273,27 @@ fn parse_shorter_command_with_to_colon() {
         ]))
     );
 }
+
+#[test]
+fn parse_delta_empty() {
+    assert_eq!(
+        parse("label + T-lang")
+            .unwrap_err()
+            .source()
+            .unwrap()
+            .downcast_ref(),
+        Some(&ParseError::EmptyLabel),
+    );
+}
+
+#[test]
+fn parse_unknown_url() {
+    assert_eq!(
+        parse("label +https://rust-lang.org")
+            .unwrap_err()
+            .source()
+            .unwrap()
+            .downcast_ref(),
+        Some(&ParseError::ExpectedLabelDelta),
+    );
+}

--- a/parser/src/token.rs
+++ b/parser/src/token.rs
@@ -219,6 +219,18 @@ impl<'a> Tokenizer<'a> {
             _ => Ok(false),
         }
     }
+
+    pub fn starts_with(&mut self, string: &str) -> bool {
+        self.input[self.cur_pos()..].starts_with(string)
+    }
+
+    pub fn take_until_whitespace(&mut self) -> &'a str {
+        let start = self.cur_pos();
+        while self.cur().map_or(false, |(_, ch)| !ch.is_whitespace()) {
+            self.advance();
+        }
+        &self.str_from(start)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
See https://github.blog/changelog/2022-02-03-reference-labels-in-markdown/.

@rustbot label https://github.com/rust-lang/triagebot/labels/T-libs https://github.com/rust-lang/triagebot/labels/help%20wanted 