### PR TITLE
Don't post mentions for draft PRs.

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -255,6 +255,8 @@ pub struct Issue {
     pub pull_request: Option<PullRequestDetails>,
     #[serde(default)]
     pub merged: bool,
+    #[serde(default)]
+    pub draft: bool,
     // API URL
     comments_url: String,
     #[serde(skip)]

--- a/src/handlers/mentions.rs
+++ b/src/handlers/mentions.rs
@@ -37,13 +37,13 @@ pub(super) async fn parse_input(
 
     if !matches!(
         event.action,
-        IssuesAction::Opened | IssuesAction::Synchronize
+        IssuesAction::Opened | IssuesAction::Synchronize | IssuesAction::ReadyForReview
     ) {
         return Ok(None);
     }
 
-    // Don't ping on rollups.
-    if event.issue.title.starts_with("Rollup of") {
+    // Don't ping on rollups or draft PRs.
+    if event.issue.title.starts_with("Rollup of") || event.issue.draft {
         return Ok(None);
     }
 


### PR DESCRIPTION
The mentions can be quite noisy, so this provides a way to prevent them from being posted. Presumably a draft PR is under construction and may change over time, so the mentions may be premature. Once the author clicks "Ready for review", triagebot will re-scan the PR and post any mentions that haven't already been posted.

cc #1637