### PR TITLE
Update to edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "triagebot"
 version = "0.1.0"
 authors = ["Mark Rousskov <mark.simulacrum@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [workspace]
 

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -2,7 +2,7 @@
 name = "parser"
 version = "0.1.0"
 authors = ["Mark Rousskov <mark.simulacrum@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 pulldown-cmark = "0.7.0"


### PR DESCRIPTION
I stumbled on something that is only supported in the 2021 edition, so I figure it would be nice to update.

The feature resolver differences are:

```
  byteorder v1.4.3 (as host dependency) removed features: default
  either v1.6.1 removed features: use_std
  tokio v1.17.0 removed features: winapi
  tracing-core v0.1.25 removed features: valuable
```

none of which look important one way or the other.
