### PR TITLE
Fetch triagebot.toml config from the default branch.

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -109,6 +109,8 @@ impl<'a> Action for Step<'a> {
             for repo in repos {
                 let repository = Repository {
                     full_name: format!("{}/{}", repo.0, repo.1),
+                    // This is unused for query.
+                    default_branch: "master".to_string(),
                 };
 
                 for QueryMap { name, kind, query } in queries {

--- a/src/github.rs
+++ b/src/github.rs
@@ -906,6 +906,7 @@ pub struct IssueSearchResult {
 #[derive(Clone, Debug, serde::Deserialize)]
 pub struct Repository {
     pub full_name: String,
+    pub default_branch: String,
 }
 
 #[derive(Copy, Clone)]
@@ -1225,12 +1226,12 @@ pub enum Event {
 }
 
 impl Event {
-    pub fn repo_name(&self) -> String {
+    pub fn repo(&self) -> &Repository {
         match self {
-            Event::Create(event) => event.repository.full_name.clone(),
-            Event::IssueComment(event) => event.repository.full_name.clone(),
-            Event::Issue(event) => event.repository.full_name.clone(),
-            Event::Push(event) => event.repository.full_name.clone(),
+            Event::Create(event) => &event.repository,
+            Event::IssueComment(event) => &event.repository,
+            Event::Issue(event) => &event.repository,
+            Event::Push(event) => &event.repository,
         }
     }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -44,7 +44,10 @@ mod rustc_commits;
 mod shortcut;
 
 pub async fn handle(ctx: &Context, event: &Event) -> Vec<HandlerError> {
-    let config = config::get(&ctx.github, &event.repo_name()).await;
+    let config = config::get(&ctx.github, event.repo()).await;
+    if let Err(e) = &config {
+        log::warn!("failed to load configuration: {e}");
+    }
     let mut errors = Vec::new();
 
     if let (Ok(config), Event::Issue(event)) = (config.as_ref(), event) {

--- a/src/handlers/nominate.rs
+++ b/src/handlers/nominate.rs
@@ -60,7 +60,7 @@ pub(super) async fn handle_command(
                 &event.issue().unwrap(),
                 format!(
                     "This team (`{}`) cannot be nominated for via this command;\
-                     it may need to be added to `triagebot.toml` on the master branch.",
+                     it may need to be added to `triagebot.toml` on the default branch.",
                     cmd.team,
                 ),
             );

--- a/src/handlers/ping.rs
+++ b/src/handlers/ping.rs
@@ -41,7 +41,7 @@ pub(super) async fn handle_command(
                 &event.issue().unwrap(),
                 format!(
                     "This team (`{}`) cannot be pinged via this command; \
-                    it may need to be added to `triagebot.toml` on the master branch.",
+                    it may need to be added to `triagebot.toml` on the default branch.",
                     team_name.team,
                 ),
             );


### PR DESCRIPTION
This changes it so that instead of hard-coding the "master" branch for `triagebot.toml`, it will use the default branch of the repository. This helps with newer repositories which default to "main".
