### PR TITLE
Fix PR comment deserialization

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -264,7 +264,10 @@ pub struct Issue {
     /// Note that this field does not come from GitHub. This is manually added
     /// when the webhook arrives to help differentiate between an event
     /// related to an issue versus a pull request.
-    #[serde(default)]
+    ///
+    /// GitHub *does* actually populate this field on some events, but triagebot ignores that data
+    /// and just stores a bool here when appropriate.
+    #[serde(skip)]
     pub pull_request: bool,
     /// Whether or not the pull request was merged.
     #[serde(default)]


### PR DESCRIPTION
Broke in https://github.com/rust-lang/triagebot/pull/1646.

```
request failed: WebhookError(IssueCommentEvent failed to deserialize

Caused by:
    0: at Path { segments: [Map { key: "issue" }, Map { key: "pull_request" }] }
    1: invalid type: map, expected a boolean at line 1 column 6086)
```