### PR TITLE
Revert pull_request field change.

### DIFF
--- a/src/handlers/review_submitted.rs
+++ b/src/handlers/review_submitted.rs
@@ -10,7 +10,8 @@ pub(crate) async fn handle(
         event @ IssueCommentEvent {
             action: IssueCommentAction::Created,
             issue: Issue {
-                pull_request: true, ..
+                pull_request: Some(_),
+                ..
             },
             ..
         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 #[macro_use]
 extern crate lazy_static;
 
+use crate::github::PullRequestDetails;
+
 use anyhow::Context;
 use handlers::HandlerError;
 use interactions::ErrorComment;
@@ -143,7 +145,7 @@ pub async fn webhook(
                 .map_err(anyhow::Error::from)?;
 
             log::info!("handling pull request review comment {:?}", payload);
-            payload.pull_request.pull_request = true;
+            payload.pull_request.pull_request = Some(PullRequestDetails {});
 
             // Treat pull request review comments exactly like pull request
             // review comments.
@@ -168,7 +170,7 @@ pub async fn webhook(
                 .context("PullRequestReview(Comment) failed to deserialize")
                 .map_err(anyhow::Error::from)?;
 
-            payload.issue.pull_request = true;
+            payload.issue.pull_request = Some(PullRequestDetails {});
 
             log::info!("handling pull request review comment {:?}", payload);
 
@@ -197,7 +199,7 @@ pub async fn webhook(
                 .map_err(anyhow::Error::from)?;
 
             if matches!(event, EventName::PullRequest) {
-                payload.issue.pull_request = true;
+                payload.issue.pull_request = Some(PullRequestDetails {});
             }
 
             log::info!("handling issue event {:?}", payload);


### PR DESCRIPTION
The change to the `pull_request` field in #1646 is causing way more trouble than it is worth. If GitHub *sometimes* populates this field, then it is useful to know if it is a pull request or not.

Fixes #1651.
