### PR TITLE
[WG-prio agenda] Improve filter for T-compiler PRs s-waiting-for-review

### DIFF
--- a/github-graphql/src/lib.rs
+++ b/github-graphql/src/lib.rs
@@ -15,6 +15,7 @@ pub mod queries {
     pub struct LeastRecentlyReviewedPullRequestsArguments {
         pub repository_owner: String,
         pub repository_name: String,
+        pub first: Option<i32>,
         pub after: Option<String>,
     }
 
@@ -31,7 +32,7 @@ pub mod queries {
     #[derive(cynic::QueryFragment, Debug)]
     #[cynic(argument_struct = "LeastRecentlyReviewedPullRequestsArguments")]
     pub struct Repository {
-        #[arguments(states = Some(vec![PullRequestState::Open]), first = 100, after = &args.after, labels = Some(vec!["S-waiting-on-review".to_string()]), order_by = IssueOrder { direction: OrderDirection::Asc, field: IssueOrderField::UpdatedAt })]
+        #[arguments(states = Some(vec![PullRequestState::Open]), first = &args.first, after = &args.after, labels = Some(vec!["T-compiler".to_string(), "S-waiting-on-review".to_string()]), order_by = IssueOrder { direction: OrderDirection::Asc, field: IssueOrderField::UpdatedAt })]
         pub pull_requests: PullRequestConnection,
     }
 

--- a/github-graphql/src/lib.rs
+++ b/github-graphql/src/lib.rs
@@ -27,6 +27,17 @@ pub mod queries {
     pub struct LeastRecentlyReviewedPullRequests {
         #[arguments(owner = &args.repository_owner, name = &args.repository_name)]
         pub repository: Option<Repository>,
+        // rate limiting docs:
+        // https://docs.github.com/en/graphql/overview/resource-limitations
+        pub rate_limit: Option<RateLimit>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    pub struct RateLimit {
+        pub limit: i32,
+        pub cost: i32,
+        pub remaining: i32,
+        pub reset_at: DateTime,
     }
 
     #[derive(cynic::QueryFragment, Debug)]


### PR DESCRIPTION
By adding the "T-compiler" filter straight into the GraphQL query (instead of filtering them post-query) it seems we are getting a better "ranking" for this label - some really old PRs are emerging.

Side effect: by building the GraphQL query with 2 label filters instead of one, I get a 502 error when asking for 100 items per page. Reducing to 10 items per page and running 10 queries seems to workaround the issue.

r? @Mark-Simulacrum 
cc: @jackh726 (introduced GraphQL queries so may have additional comments)

thanks for a review