### PR TITLE
WG-prio agenda template updates

### DIFF
--- a/src/http_client/mod.rs
+++ b/src/http_client/mod.rs
@@ -64,6 +64,7 @@ impl HttpClient for CompilerMeeting {
                 ("timeMin", time_min),
                 ("timeMax", time_max),
                 ("singleEvents", "true".to_string()),
+                ("orderBy", "startTime".to_string()),
             ],
         )?;
         let calendar = reqwest::get(url).await?.json::<CompilerMeetings>().await?;

--- a/templates/prioritization_agenda.tt
+++ b/templates/prioritization_agenda.tt
@@ -7,12 +7,16 @@ tags: weekly, rustc
 
 # T-compiler Meeting Agenda YYYY-MM-DD
 
-[Tracking Issue](https://github.com/rust-lang/rust/issues/54818)
-
 ## Announcements
+
+- (TIP) add here non-recurrent scheduled meetings, [check the schedule calendar](https://calendar.google.com/calendar/htmlembed?src=6u5rrtce6lrtv07pfi3damgjus%40group.calendar.google.com)
+- (TIP) mention upcoming Rust stable releases, [check the release calendar](https://calendar.google.com/calendar/htmlembed?src=l1b1gkqvfbgunjs18nemq4c580%40group.calendar.google.com)
+- Reminder: if you see a PR/issue that seems like there might be legal implications due to copyright/IP/etc, please let the Core team know (or at least message @_**pnkfelix** or @_**Wesley Wiser** so we can pass it along).
 
 ### Other WG meetings ([calendar link](https://calendar.google.com/calendar/embed?src=6u5rrtce6lrtv07pfi3damgjus%40group.calendar.google.com))
 {{-meetings::render(meetings=meetings_tcompiler, empty="No meetings scheduled for next week")}}
+
+## MCPs/FCPs
 
 - New MCPs (take a look, see if you like them!)
 {{-issues::render(issues=mcp_new_not_seconded, indent="  ", empty="No new proposals this time.")}}
@@ -29,10 +33,12 @@ tags: weekly, rustc
 
 ### WG checkins
 
-@*WG-X* checkin by @**person1**:
+(TIP) pick from [here](https://rust-lang.github.io/compiler-team/about/triage-meeting/#working-group-check-in)
+
+@*WG-X* checkin by @**person1** ([previous checkin](https://hackmd.io/team/rust-compiler-team?nav=overview)):
 > Checkin text
 
-@*WG-Y* checkin by @**person2**:
+@*WG-Y* checkin by @**person2** ([previous checkin](https://hackmd.io/team/rust-compiler-team?nav=overview)):
 > Checkin text
 
 ## Backport nominations
@@ -49,10 +55,12 @@ tags: weekly, rustc
 
 ## PRs S-waiting-on-team
 
-[T-compiler](https://github.com/rust-lang/rust/pulls?utf8=%E2%9C%93&q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+[T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
 {{-issues::render(issues=prs_waiting_on_team_t_compiler, empty="No PRs waiting on `T-compiler` this time.")}}
 
 ### Oldest PRs waiting for review
+
+(TIP) Curate this list before the meeting
 
 [T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-asc+label%3AS-waiting-on-review+draft%3Afalse+label%3AT-compiler)
 {{-issues::render(issues=top_unreviewed_prs, with_age=true, empty="No unreviewed PRs on `T-compiler` this time.")}}
@@ -71,10 +79,10 @@ tags: weekly, rustc
 
 ### P-critical
 
-[T-compiler](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
+[T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
 {{-issues::render(issues=p_critical_t_compiler, empty="No `P-critical` issues for `T-compiler` this time.")}}
 
-[T-rustdoc](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
+[T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
 {{-issues::render(issues=p_critical_t_rustdoc, empty="No `P-critical` issues for `T-rustdoc` this time.")}}
 
 ### P-high regressions
@@ -96,3 +104,8 @@ tags: weekly, rustc
 
 [RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-compiler-nominated)
 {{-issues::render(issues=nominated_rfcs_t_compiler, empty="No I-compiler-nominated RFCs this time.")}}
+
+## Next week's WG checkins
+
+- @*WG-X* checkin by @**person1**
+- @*WG-X* checkin by @**person2**


### PR DESCRIPTION
Mostly cosmestic changes.

Added sorting to the Google calendar query when retrieving T-compiler meetings