### PR TITLE
Fix auto-assign not ignoring bot comments.

### DIFF
--- a/src/handlers/assign.rs
+++ b/src/handlers/assign.rs
@@ -408,7 +408,7 @@ pub(super) async fn handle_command(
     // Don't handle commands in comments from the bot. Some of the comments it
     // posts contain commands to instruct the user, not things that the bot
     // should respond to.
-    if event.comment_from() == Some(ctx.username.as_str()) {
+    if event.user().login == ctx.username.as_str() {
         return Ok(());
     }
 


### PR DESCRIPTION
This fixes a bug where triagebot was listening to `r?` commands from triagebot itself. This is a problem because the bot may post a comment illustrating how to use `r?`, and it shouldn't trigger itself to use that command.

This was just a stupid oversight on my part of using the wrong function for checking this condition.