### PR TITLE
Fix auto-assignment not filtering out author.

### DIFF
--- a/src/handlers/assign.rs
+++ b/src/handlers/assign.rs
@@ -682,7 +682,9 @@ fn candidate_reviewers_from_names<'a>(
         }
 
         // Assume it is a user.
-        candidates.insert(group_or_user);
+        if filter(&group_or_user) {
+            candidates.insert(group_or_user);
+        }
     }
     Ok(candidates)
 }


### PR DESCRIPTION
In some cases when a user is listed explicitly in the `[assign]` table, their name was not getting filtered if they are the PR author or current assignee. This PR adds the missing check for this case.

Closes #1662