### PR TITLE
Add options to silence mentions message when a particular assignment is used

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -90,6 +90,10 @@ pub(crate) struct AssignConfig {
     /// usernames, team names, or ad-hoc groups.
     #[serde(default)]
     pub(crate) owners: HashMap<String, Vec<String>>,
+    /// Labels to be added to the issue when a particular assignment is made.
+    /// Key is asignee, value is a vector of labels to be added.
+    #[serde(default)]
+    pub(crate) label: HashMap<String, Vec<String>>,
 }
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -119,6 +119,8 @@ pub(crate) struct MentionsPathConfig {
     pub(crate) message: Option<String>,
     #[serde(default)]
     pub(crate) cc: Vec<String>,
+    #[serde(default)]
+    pub(crate) exclude_labels: Vec<String>,
 }
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]


### PR DESCRIPTION
I'm not sure if this is the right way to do it, but I think this should work.

I want to remove these long comments about `libs-api` team, when `r? libs-api` is used:

![2022-10-29_00-05](https://user-images.githubusercontent.com/38225716/198722899-da683aa1-831c-4850-8b0f-caf64238ea1e.png)

The idea is to add
```toml
[assign.label]
libs-api = ["T-libs-api"]
```

To the Rust `triagebot.toml`, which will add `T-libs-api` label when `r? libs-api` is used. Then `T-libs` won't be added because there is already a `T-*` label.

Then, to silence the message add

```toml
# [mentions."library"]
exclude_labels = ["T-libs-api"]
```

Again, the "solution" and "implementation" seem somewhat hacky. I'm open to suggestions how to better do this.