### PR TITLE
Update to cynic 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,6 @@
 version = 3
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-dependencies = [
- "lazy_static",
- "regex",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,6 +261,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "counter"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d458e66999348f56fd3ffcfbb7f7951542075ca8359687c703de6500c1ddccd"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,27 +311,26 @@ dependencies = [
 
 [[package]]
 name = "cynic"
-version = "0.14.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06f1415b8314cde001d73cacbc152b6ca7f88c139d261f0da325c5483003cb1"
+checksum = "a4a3b1c069f38d62c0795fd74df7a55bde42d3ff44e58a00576d1e5c65222fa8"
 dependencies = [
  "cynic-proc-macros",
- "json-decode",
  "serde",
- "serde_json",
+ "static_assertions",
  "thiserror",
 ]
 
 [[package]]
 name = "cynic-codegen"
-version = "0.14.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b58270fd2d5ced0cb1d2b4ca8b632be15840a6c99285d1062c37be40bd48ac"
+checksum = "aefc758a26044bd02a2a0ecb871b158abcb98c92d93d7bc40750285064de602c"
 dependencies = [
- "Inflector",
+ "counter",
  "darling",
  "graphql-parser",
- "lazy_static",
+ "once_cell",
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
@@ -341,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "cynic-proc-macros"
-version = "0.14.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d016913e640d17de49a4ad8df09a39ea4be1554dd976b9e6ed964eedaafd563"
+checksum = "c948605f5b7ae37c2e70b42c71679172c4a147351ee1b475578ea8f7d70680db"
 dependencies = [
  "cynic-codegen",
  "syn",
@@ -351,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.12.4"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -361,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.12.4"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
 dependencies = [
  "fnv",
  "ident_case",
@@ -375,9 +373,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.12.4"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core",
  "quote",
@@ -683,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "graphql-parser"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1abd4ce5247dfc04a03ccde70f87a048458c9356c7e41d21ad8c407b3dde6f2"
+checksum = "d2ebc8013b4426d5b81a4364c419a95ed0b404af2b82e2457de52d9348f0e474"
 dependencies = [
  "combine",
  "thiserror",
@@ -910,17 +908,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
 dependencies = [
  "wasm-bindgen",
-]
-
-[[package]]
-name = "json-decode"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd72139ade93da4f8a437afe8654a4a3cf1d858dc195fc6691e6e932fa1b6ee"
-dependencies = [
- "serde",
- "serde_json",
- "thiserror",
 ]
 
 [[package]]
@@ -1750,6 +1737,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stringprep"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ serde_path_to_error = "0.1.2"
 octocrab = "0.9.1"
 comrak = "0.8.2"
 route-recognizer = "0.3.0"
-cynic = { version = "0.14" }
+cynic = { version = "2.0.0" }
 itertools = "0.10.2"
 tower = { version = "0.4.13", features = ["util", "limit", "buffer", "load-shed"] }
 github-graphql = { path = "github-graphql" }

--- a/github-graphql/Cargo.toml
+++ b/github-graphql/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
-cynic = { version = "0.14" }
+cynic = { version = "2.2.2" }

--- a/github-graphql/src/lib.rs
+++ b/github-graphql/src/lib.rs
@@ -11,7 +11,7 @@ pub mod queries {
 
     cynic::impl_scalar!(DateTime, schema::DateTime);
 
-    #[derive(cynic::FragmentArguments, Debug)]
+    #[derive(cynic::QueryVariables, Debug, Clone)]
     pub struct LeastRecentlyReviewedPullRequestsArguments {
         pub repository_owner: String,
         pub repository_name: String,
@@ -21,17 +21,23 @@ pub mod queries {
     #[derive(cynic::QueryFragment, Debug)]
     #[cynic(
         graphql_type = "Query",
-        argument_struct = "LeastRecentlyReviewedPullRequestsArguments"
+        variables = "LeastRecentlyReviewedPullRequestsArguments"
     )]
     pub struct LeastRecentlyReviewedPullRequests {
-        #[arguments(owner = &args.repository_owner, name = &args.repository_name)]
+        #[arguments(owner: $repository_owner, name: $repository_name)]
         pub repository: Option<Repository>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(argument_struct = "LeastRecentlyReviewedPullRequestsArguments")]
+    #[cynic(variables = "LeastRecentlyReviewedPullRequestsArguments")]
     pub struct Repository {
-        #[arguments(states = Some(vec![PullRequestState::Open]), first = 100, after = &args.after, labels = Some(vec!["S-waiting-on-review".to_string()]), order_by = IssueOrder { direction: OrderDirection::Asc, field: IssueOrderField::UpdatedAt })]
+        #[arguments(
+            states: "OPEN",
+            first: 100,
+            after: $after,
+            labels: ["S-waiting-on-review"],
+            orderBy: {direction: "ASC", field: "UPDATED_AT"}
+        )]
         pub pull_requests: PullRequestConnection,
     }
 
@@ -53,7 +59,7 @@ pub mod queries {
         pub is_draft: bool,
         #[arguments(first = 100)]
         pub assignees: UserConnection,
-        #[arguments(first = 100, order_by = IssueCommentOrder { direction: OrderDirection::Desc, field: IssueCommentOrderField::UpdatedAt })]
+        #[arguments(first = 100, orderBy: { direction: "DESC", field: "UPDATED_AT" })]
         pub comments: IssueCommentConnection,
         #[arguments(last = 20)]
         pub latest_reviews: Option<PullRequestReviewConnection>,
@@ -109,49 +115,13 @@ pub mod queries {
         pub created_at: DateTime,
     }
 
-    #[derive(cynic::Enum, Clone, Copy, Debug)]
-    pub enum IssueCommentOrderField {
-        UpdatedAt,
-    }
-
-    #[derive(cynic::Enum, Clone, Copy, Debug)]
-    pub enum IssueOrderField {
-        Comments,
-        CreatedAt,
-        UpdatedAt,
-    }
-
-    #[derive(cynic::Enum, Clone, Copy, Debug)]
-    pub enum OrderDirection {
-        Asc,
-        Desc,
-    }
-
-    #[derive(cynic::Enum, Clone, Copy, Debug)]
-    pub enum PullRequestState {
-        Closed,
-        Merged,
-        Open,
-    }
-
-    #[derive(cynic::InputObject, Debug)]
-    pub struct IssueOrder {
-        pub direction: OrderDirection,
-        pub field: IssueOrderField,
-    }
-
-    #[derive(cynic::InputObject, Debug)]
-    pub struct IssueCommentOrder {
-        pub direction: OrderDirection,
-        pub field: IssueCommentOrderField,
-    }
-
     #[derive(cynic::QueryFragment, Debug)]
     pub struct Actor {
         pub login: String,
     }
 
     #[derive(cynic::Scalar, Debug, Clone)]
+    #[cynic(graphql_type = "URI")]
     pub struct Uri(pub String);
 }
 
@@ -160,7 +130,7 @@ pub mod docs_update_queries {
     use super::queries::{DateTime, PageInfo};
     use super::schema;
 
-    #[derive(cynic::FragmentArguments, Debug)]
+    #[derive(cynic::QueryVariables, Clone, Debug)]
     pub struct RecentCommitsArguments {
         pub branch: String,
         pub name: String,
@@ -208,30 +178,30 @@ pub mod docs_update_queries {
     /// }
     /// ```
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Query", argument_struct = "RecentCommitsArguments")]
+    #[cynic(graphql_type = "Query", variables = "RecentCommitsArguments")]
     pub struct RecentCommits {
-        #[arguments(name = &args.name, owner = &args.owner)]
+        #[arguments(name: $name, owner: $owner)]
         pub repository: Option<Repository>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(argument_struct = "RecentCommitsArguments")]
+    #[cynic(variables = "RecentCommitsArguments")]
     pub struct Repository {
-        #[arguments(qualified_name = &args.branch)]
+        #[arguments(qualifiedName: $branch)]
         #[cynic(rename = "ref")]
         pub ref_: Option<Ref>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(argument_struct = "RecentCommitsArguments")]
+    #[cynic(variables = "RecentCommitsArguments")]
     pub struct Ref {
         pub target: Option<GitObject>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(argument_struct = "RecentCommitsArguments")]
+    #[cynic(variables = "RecentCommitsArguments")]
     pub struct Commit {
-        #[arguments(first = 100, after = &args.after)]
+        #[arguments(first: 100, after: $after)]
         pub history: CommitHistoryConnection,
     }
 
@@ -277,33 +247,18 @@ pub mod docs_update_queries {
     }
 
     #[derive(cynic::InlineFragments, Debug)]
-    #[cynic(argument_struct = "RecentCommitsArguments")]
+    #[cynic(variables = "RecentCommitsArguments")]
     pub enum GitObject {
         Commit(Commit),
-        // These three variants are here just to pacify cynic. I don't know
-        // why it fails to compile without them.
-        Tree(Tree),
-        Tag(Tag),
-        Blob(Blob),
-    }
-
-    #[derive(cynic::QueryFragment, Debug)]
-    pub struct Tree {
-        pub id: cynic::Id,
-    }
-    #[derive(cynic::QueryFragment, Debug)]
-    pub struct Tag {
-        pub id: cynic::Id,
-    }
-    #[derive(cynic::QueryFragment, Debug)]
-    pub struct Blob {
-        pub id: cynic::Id,
+        #[cynic(fallback)]
+        Other,
     }
 
     #[derive(cynic::Scalar, Debug, Clone)]
     pub struct GitObjectID(pub String);
 }
 
+#[allow(non_snake_case, non_camel_case_types)]
 mod schema {
     cynic::use_schema!("src/github.graphql");
 }

--- a/github-graphql/src/lib.rs
+++ b/github-graphql/src/lib.rs
@@ -45,7 +45,8 @@ pub mod queries {
     pub struct PullRequestConnection {
         pub total_count: i32,
         pub page_info: PageInfo,
-        pub nodes: Option<Vec<Option<PullRequest>>>,
+        #[cynic(flatten)]
+        pub nodes: Vec<PullRequest>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
@@ -68,7 +69,8 @@ pub mod queries {
     #[derive(cynic::QueryFragment, Debug)]
     pub struct PullRequestReviewConnection {
         pub total_count: i32,
-        pub nodes: Option<Vec<Option<PullRequestReview>>>,
+        #[cynic(flatten)]
+        pub nodes: Vec<PullRequestReview>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
@@ -79,7 +81,8 @@ pub mod queries {
 
     #[derive(cynic::QueryFragment, Debug)]
     pub struct UserConnection {
-        pub nodes: Option<Vec<Option<User>>>,
+        #[cynic(flatten)]
+        pub nodes: Vec<User>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
@@ -95,7 +98,8 @@ pub mod queries {
 
     #[derive(cynic::QueryFragment, Debug)]
     pub struct LabelConnection {
-        pub nodes: Option<Vec<Option<Label>>>,
+        #[cynic(flatten)]
+        pub nodes: Vec<Label>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
@@ -106,7 +110,8 @@ pub mod queries {
     #[derive(cynic::QueryFragment, Debug)]
     pub struct IssueCommentConnection {
         pub total_count: i32,
-        pub nodes: Option<Vec<Option<IssueComment>>>,
+        #[cynic(flatten)]
+        pub nodes: Vec<IssueComment>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
@@ -209,7 +214,8 @@ pub mod docs_update_queries {
     pub struct CommitHistoryConnection {
         pub total_count: i32,
         pub page_info: PageInfo,
-        pub nodes: Option<Vec<Option<Commit2>>>,
+        #[cynic(flatten)]
+        pub nodes: Vec<Commit2>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
@@ -226,7 +232,8 @@ pub mod docs_update_queries {
 
     #[derive(cynic::QueryFragment, Debug)]
     pub struct PullRequestConnection {
-        pub nodes: Option<Vec<Option<PullRequest>>>,
+        #[cynic(flatten)]
+        pub nodes: Vec<PullRequest>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
@@ -237,7 +244,8 @@ pub mod docs_update_queries {
 
     #[derive(cynic::QueryFragment, Debug)]
     pub struct CommitConnection {
-        pub nodes: Option<Vec<Option<Commit3>>>,
+        #[cynic(flatten)]
+        pub nodes: Vec<Commit3>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]


### PR DESCRIPTION
I'm the author of cynic, the graphql client library this project is using.  I just released v2 of cynic, so thought I'd raise a PR that updates triagebot to use it.

I've put some effort into improving compile times for large schemas in this release.  In my (not very scientific) tests the `github-graphql` crate in this repo compiles in about half the time after these changes.  Frankly it's still not as fast as I'd like but the github schema is a real challenge.

I also simplified a few of your queries & the associated handling code, hope that's ok.  Happy to revert that stuff if not though.