### PR TITLE
Automatically re-scan GitHub commits every 30 minutes

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -43,7 +43,7 @@ mod prioritize;
 mod relabel;
 mod review_submitted;
 mod rfc_helper;
-mod rustc_commits;
+pub mod rustc_commits;
 mod shortcut;
 
 pub async fn handle(ctx: &Context, event: &Event) -> Vec<HandlerError> {

--- a/src/handlers/jobs.rs
+++ b/src/handlers/jobs.rs
@@ -4,9 +4,19 @@
 
 // Further info could be find in src/jobs.rs
 
-pub async fn handle_job(name: &String, metadata: &serde_json::Value) -> anyhow::Result<()> {
+use super::Context;
+
+pub async fn handle_job(
+    ctx: &Context,
+    name: &String,
+    metadata: &serde_json::Value,
+) -> anyhow::Result<()> {
     match name.as_str() {
         "docs_update" => super::docs_update::handle_job().await,
+        "rustc_commits" => {
+            super::rustc_commits::synchronize_commits_inner(ctx, None).await;
+            Ok(())
+        }
         _ => default(&name, &metadata),
     }
 }

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -47,6 +47,13 @@ pub fn jobs() -> Vec<JobSchedule> {
     // Add to this vector any new cron task you want (as explained above)
     let mut jobs: Vec<JobSchedule> = Vec::new();
     jobs.push(crate::handlers::docs_update::job());
+    jobs.push(crate::handlers::rustc_commits::job());
 
     jobs
+}
+
+#[test]
+fn jobs_defined() {
+    // Checks we don't panic here, mostly for the schedule parsing.
+    drop(jobs());
 }


### PR DESCRIPTION
This lets us recover from faults in the GitHub API more quickly.

My hope is that this helps with https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/perf.20status.20down.3F but it's not clear what the cause is yet. Presumably re-scanning every 30 minutes will at least limit impact, if the commits are just slow to appear in the API (for example).