### PR TITLE
Do not expect sha field in API response

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -1928,8 +1928,15 @@ impl GithubClient {
 #[derive(Debug, serde::Deserialize)]
 pub struct GithubCommit {
     pub sha: String,
-    pub commit: GitCommit,
+    pub commit: GithubCommitCommitField,
     pub parents: Vec<Parent>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct GithubCommitCommitField {
+    pub author: GitUser,
+    pub message: String,
+    pub tree: GitCommitTree,
 }
 
 #[derive(Debug, serde::Deserialize)]


### PR DESCRIPTION
We should eventually add in-CI testing for this kind of oops (it's fairly common when we change these) or move to auto-generated GitHub API code -- but for now this fixes commit fetching.