### PR TITLE
Add detail to PR welcome msg

### DIFF
--- a/src/handlers/assign.rs
+++ b/src/handlers/assign.rs
@@ -41,8 +41,13 @@ mod tests {
 const NEW_USER_WELCOME_MESSAGE: &str = "Thanks for the pull request, and welcome! \
 The Rust team is excited to review your changes, and you should hear from {who} soon.";
 
-const CONTRIBUTION_MESSAGE: &str = "\
-Please see [the contribution instructions]({contributing_url}) for more information.";
+const CONTRIBUTION_MESSAGE: &str = "Please see [the contribution
+instructions]({contributing_url}) for more information. Namely, in order to ensure the
+minimum review times lag, PR authors and assigned reviewers should ensure that the review
+label (`S-waiting-on-review` and `S-waiting-on-author`) stays updated, invoking these commands \
+when appropriate:\n \
+`@rustbot author`: the review is finished, PR author should check the comments and take action accordingly \
+`@rustbot review`: the author is ready for a review, this PR will be queued again in the reviewer's queue";
 
 const WELCOME_WITH_REVIEWER: &str = "@{assignee} (or someone else)";
 


### PR DESCRIPTION
We are trying to improve on the pull request review flow. This patch add additional info on how to use the review flags during the lifecycle of a pull request. See also the patch to update the documentation: [rustc-dev-guide#1628](https://github.com/rust-lang/rustc-dev-guide/pull/1628).

Discussed during T-compiler meeting ([comment](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bsteering.5D.202023-02-17.20review.20latency.20compiler-team.23589/near/328505647)).

thanks!

r? @Mark-Simulacrum 
