### PR TITLE
Add `first_contrib` configuration option

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -163,6 +163,8 @@ pub(crate) struct AutolabelLabelConfig {
     pub(crate) trigger_files: Vec<String>,
     #[serde(default)]
     pub(crate) new_pr: bool,
+    #[serde(default)]
+    pub(crate) first_contrib: bool,
 }
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]
@@ -321,6 +323,9 @@ mod tests {
                 "C-*"
             ]
 
+			[autolabel."new-contributor"]
+			first_contrib = true
+
             [assign]
 
             [note]
@@ -389,7 +394,18 @@ mod tests {
                 major_change: None,
                 glacier: None,
                 close: None,
-                autolabel: None,
+                autolabel: Some(AutolabelConfig {
+                    labels: HashMap::from([(
+                        "new-contributor".to_owned(),
+                        AutolabelLabelConfig {
+                            first_contrib: true,
+                            trigger_labels: Vec::new(),
+                            exclude_labels: Vec::new(),
+                            trigger_files: Vec::new(),
+                            new_pr: false
+                        }
+                    )])
+                }),
                 notify_zulip: None,
                 github_releases: None,
                 review_submitted: None,

--- a/src/handlers/autolabel.rs
+++ b/src/handlers/autolabel.rs
@@ -72,6 +72,15 @@ pub(super) async fn parse_input(
                     autolabels.push(Label {
                         name: label.to_owned(),
                     });
+                } else if cfg.first_contrib // If we didn't had this 'else', we could push the same label 2 times
+                    && ctx
+                        .github
+                        .is_new_contributor(&event.repository, &event.issue.user.login)
+                        .await
+                {
+                    autolabels.push(Label {
+                        name: label.to_owned(),
+                    })
                 }
             }
             if !autolabels.is_empty() {


### PR DESCRIPTION
The `first_contrib` is a new option on the `[autolabel]` table. It is used similar to `new_pr`

```toml
[autolabel."new-contributor"]
first_contrib = true
```

If `first_contrib` is enabled, triagebot will add the label designated to any new PR made by new contributors. (In this case, it will add the `new-contributor` label).
This is done so that, experience contributors can focus some mentoring on these new contributors.

By other people focusing on solving simple problems about contributions (like naming, answering questions about how to do certain things), we can leave team members to more complex reviews, using more efficiently the human bandwidth of a project review system.

## Unresolved questions

* Name of the configuration option (is `first_contrib` good enough? maybe `new_contributor` or `first_contribution`, without abbreviating)

(Testing done)
