### PR TITLE
Add better error message for GitHub client errors.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2031,6 +2031,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bytes",
  "chrono",
  "comrak",
  "cron",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ rand = "0.8.5"
 ignore = "0.4.18"
 postgres-types = { version = "0.2.4", features = ["derive"] }
 cron = { version = "0.12.0" }
+bytes = "1.1.0"
 
 [dependencies.serde]
 version = "1"

--- a/src/handlers/github_releases.rs
+++ b/src/handlers/github_releases.rs
@@ -132,7 +132,7 @@ async fn load_changelog(
         .await?
         .ok_or_else(|| anyhow::Error::msg("missing file"))?;
 
-    Ok(String::from_utf8(resp)?)
+    Ok(String::from_utf8(resp.to_vec())?)
 }
 
 async fn load_paginated<T, R, F>(ctx: &Context, url: &str, key: F) -> anyhow::Result<HashMap<R, T>>


### PR DESCRIPTION
This changes it so that the logs will display the body of the response when there is an API error. The body usually explains what was wrong, so this should make debugging issues easier.