### PR TITLE
Check for error response when fetching the rate limit

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -116,6 +116,7 @@ impl GithubClient {
                         .unwrap(),
                 )
                 .await?;
+            rate_resp.error_for_status_ref()?;
             let rate_limit_response = rate_resp.json::<RateLimitResponse>().await?;
 
             // Check url for search path because github has different rate limits for the search api


### PR DESCRIPTION
The code was not checking for any errors from the rate_limit response, and blissfully continuing if there was an error which can result in some confusing behavior.
