### PR TITLE
add more config options for `no_merges`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -94,8 +94,18 @@ pub(crate) struct AssignConfig {
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]
 pub(crate) struct NoMergesConfig {
+    /// No action will be taken on PRs with these labels.
     #[serde(default)]
-    _empty: (),
+    pub(crate) exclude_labels: Vec<String>,
+    /// Set these labels on the PR when merge commits are detected.
+    #[serde(default)]
+    pub(crate) labels: Vec<String>,
+    /// Override the default message to post when merge commits are detected.
+    ///
+    /// This message will always be followed up with
+    /// "The following commits are merge commits:" and then
+    /// a list of the merge commits.
+    pub(crate) message: Option<String>,
 }
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]


### PR DESCRIPTION
- option for excluding PRs with certain labels from consideration
- option for adding labels when merge commits are detected
- option for setting a custom comment message for when merge commits are detected

rust-forge PR: https://github.com/rust-lang/rust-forge/pull/691

### Motivation

Occasionally, a merge commit like rust-lang/rust@cb5c011670ce8d073d0aae8c45e73c20593bfa11 makes it past manual review and gets merged into master.

At one point, we tried adding a check to CI to prevent this from happening (rust-lang/rust#105058), but that ended up [causing issues](https://github.com/rust-lang/rust/pull/106319#issuecomment-1368144076) and was [reverted](https://github.com/rust-lang/rust/pull/106320). This kind of check is simply too fragile for CI, and there must be a way for a human to override the bot's decision.

The capability to detect and warn about merge commits has been present in triagebot for quite some time, but was never enabled at rust-lang/rust, possibly due to concerns about false positives on rollup and subtree/submodule sync PRs. This PR intends to alleviate those concerns.

This will allow us to use the following options at rust-lang/rust:

```toml
[no_merges]
exclude_labels = ["rollup", "sync"] # hypothetical label for PRs that sync subtrees or submodules
labels = ["has-merge-commits", "S-waiting-on-author"]
```

Which will exclude rollup PRs and subtree/submodule sync PRs from merge commit detection, and post the default warning message and add the `has-merge-commits` and `S-waiting-on-author` labels when merge commits are detected on all other PRs.

The eventual vision is to have bors refuse to merge if the `has-merge-commits` label is present. A reviewer can still force the merge by removing that label if they so wish.

### Previous discussion

- [Zulip topic](https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/Merge.20commit.20check.20in.20CI)
- https://github.com/rust-lang/rust/pull/105058