### PR TITLE
Fix update_reference

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -1228,7 +1228,7 @@ impl Repository {
         client: &GithubClient,
         refname: &str,
         sha: &str,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<GitReference> {
         let url = format!("{}/git/refs/{}", self.url(), refname);
         client
             .json(client.patch(&url).json(&serde_json::json!({
@@ -1241,8 +1241,7 @@ impl Repository {
                     "{} failed to update reference {refname} to {sha}",
                     self.full_name
                 )
-            })?;
-        Ok(())
+            })
     }
 
     /// Returns a list of recent commits on the given branch.


### PR DESCRIPTION
The `update_reference` GitHub method was failing because it was trying to force the JSON response to be the unit type instead of the proper `GitReference`.
