### PR TITLE
Support `new_issue` in autolabel config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -163,6 +163,8 @@ pub(crate) struct AutolabelLabelConfig {
     pub(crate) trigger_files: Vec<String>,
     #[serde(default)]
     pub(crate) new_pr: bool,
+    #[serde(default)]
+    pub(crate) new_issue: bool,
 }
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]

--- a/src/handlers/autolabel.rs
+++ b/src/handlers/autolabel.rs
@@ -27,43 +27,45 @@ pub(super) async fn parse_input(
     // remove. Not much can be done about that currently; the before/after on
     // synchronize may be straddling a rebase, which will break diff generation.
     if event.action == IssuesAction::Opened || event.action == IssuesAction::Synchronize {
-        if let Some(diff) = event
+        let diff = event
             .issue
             .diff(&ctx.github)
             .await
             .map_err(|e| {
                 log::error!("failed to fetch diff: {:?}", e);
             })
-            .unwrap_or_default()
-        {
-            let files = files_changed(&diff);
-            let mut autolabels = Vec::new();
-            'outer: for (label, cfg) in config.labels.iter() {
+            .unwrap_or_default();
+        let files = diff.as_deref().map(files_changed);
+        let mut autolabels = Vec::new();
+
+        'outer: for (label, cfg) in config.labels.iter() {
+            let exclude_patterns: Vec<glob::Pattern> = cfg
+                .exclude_labels
+                .iter()
+                .filter_map(|label| match glob::Pattern::new(label) {
+                    Ok(exclude_glob) => Some(exclude_glob),
+                    Err(error) => {
+                        log::error!("Invalid glob pattern: {}", error);
+                        None
+                    }
+                })
+                .collect();
+
+            for label in event.issue.labels() {
+                for pat in &exclude_patterns {
+                    if pat.matches(&label.name) {
+                        // If we hit an excluded label, ignore this autolabel and check the next
+                        continue 'outer;
+                    }
+                }
+            }
+
+            if let Some(files) = &files {
                 if cfg
                     .trigger_files
                     .iter()
                     .any(|f| files.iter().any(|diff_file| diff_file.starts_with(f)))
                 {
-                    let exclude_patterns: Vec<glob::Pattern> = cfg
-                        .exclude_labels
-                        .iter()
-                        .filter_map(|label| match glob::Pattern::new(label) {
-                            Ok(exclude_glob) => Some(exclude_glob),
-                            Err(error) => {
-                                log::error!("Invalid glob pattern: {}", error);
-                                None
-                            }
-                        })
-                        .collect();
-                    for label in event.issue.labels() {
-                        for pat in &exclude_patterns {
-                            if pat.matches(&label.name) {
-                                // If we hit an excluded label, ignore this autolabel and check the next
-                                continue 'outer;
-                            }
-                        }
-                    }
-
                     autolabels.push(Label {
                         name: label.to_owned(),
                     });
@@ -74,12 +76,22 @@ pub(super) async fn parse_input(
                     });
                 }
             }
-            if !autolabels.is_empty() {
-                return Ok(Some(AutolabelInput {
-                    add: autolabels,
-                    remove: vec![],
-                }));
+
+            if event.issue.pull_request.is_none()
+                && cfg.new_issue
+                && event.action == IssuesAction::Opened
+            {
+                autolabels.push(Label {
+                    name: label.to_owned(),
+                });
             }
+        }
+
+        if !autolabels.is_empty() {
+            return Ok(Some(AutolabelInput {
+                add: autolabels,
+                remove: vec![],
+            }));
         }
     }
 


### PR DESCRIPTION
Just like `new_pr`, it adds a label to every new issue that is opened.

See https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/make.20untriaged.20issues.20explicit for the motivation.

I've tested it on https://github.com/Nilstrieb/some-cursed-repo, it seems to behave correctly for what I tested.
I tested
```toml
[autolabel."wontfix"]
trigger_labels = [
  "bug"
]

[autolabel."invalid"]
new_issue = true

[autolabel."documentation"]
new_pr = true

[autolabel."help wanted"]
new_pr = true
new_issue = true
exclude_labels = ["duplicate"]
```

- [x] create an issue, "help wanted" and "invalid" are assigned
- [x] create an issue with the "duplicate" label, only "invalid" is assigned
- [x] create a PR, "help wanted" and "documentation" are assigned
- [x] create a PR with the "duplicate" label, only "documentation" is assigned
- [x] add "bug" to an issue, "wontfix" is assigned (this is very useful)
- [x] add "bug" to a PR "wontfix" is assigned

documentation: https://github.com/rust-lang/rust-forge/pull/690