### PR TITLE
Updates to the T-compiler meeting agenda

### DIFF
--- a/src/agenda.rs
+++ b/src/agenda.rs
@@ -169,15 +169,6 @@ pub fn prioritization<'a>() -> Box<dyn Action> {
                             exclude_labels: vec!["beta-accepted"],
                         }),
                     },
-                    QueryMap {
-                        name: "beta_nominated_t_rustdoc",
-                        kind: QueryKind::List,
-                        query: Arc::new(github::Query {
-                            filters: vec![],
-                            include_labels: vec!["beta-nominated", "T-rustdoc"],
-                            exclude_labels: vec!["beta-accepted"],
-                        }),
-                    },
                     // stable nomination queries
                     QueryMap {
                         name: "stable_nominated_t_compiler",
@@ -185,15 +176,6 @@ pub fn prioritization<'a>() -> Box<dyn Action> {
                         query: Arc::new(github::Query {
                             filters: vec![],
                             include_labels: vec!["stable-nominated", "T-compiler"],
-                            exclude_labels: vec!["stable-accepted"],
-                        }),
-                    },
-                    QueryMap {
-                        name: "stable_nominated_t_rustdoc",
-                        kind: QueryKind::List,
-                        query: Arc::new(github::Query {
-                            filters: vec![],
-                            include_labels: vec!["stable-nominated", "T-rustdoc"],
                             exclude_labels: vec!["stable-accepted"],
                         }),
                     },

--- a/templates/_issue.tt
+++ b/templates/_issue.tt
@@ -1,1 +1,1 @@
-{% macro render(issue, with_age="") %}"{{issue.title}}" [{{issue.repo_name}}#{{issue.number}}]({{issue.html_url}}) {% if with_age %}(last review activity: {{issue.updated_at_hts}}){% endif %}{% endmacro %}
+{% macro render(issue, with_age="") %}"{{issue.title}}" [{{issue.repo_name}}#{{issue.number}}]({{issue.html_url}}){% if with_age %}(last review activity: {{issue.updated_at_hts}}){% endif %}{% endmacro %}

--- a/templates/_issues.tt
+++ b/templates/_issues.tt
@@ -1,6 +1,6 @@
 {% import "_issue.tt" as issue %}
 
-{% macro render(issues, indent="", branch="", with_age=false, empty="No issues this time.") %}
+{% macro render(issues, indent="", branch="", with_age=false, empty="No issues at this time.") %}
 {#- If "branch" is not empty add a trailing space but no newlines before or after -#}
 {%- if branch -%}
 {%- set branch = branch ~ " " -%}

--- a/templates/prioritization_agenda.tt
+++ b/templates/prioritization_agenda.tt
@@ -3,6 +3,7 @@
 
 ---
 tags: weekly, rustc
+type: docs
 ---
 
 # T-compiler Meeting Agenda YYYY-MM-DD
@@ -39,34 +40,34 @@ tags: weekly, rustc
 (TIP) pick from [here](https://rust-lang.github.io/compiler-team/about/triage-meeting/#working-group-check-in)
 
 @*WG-X* checkin by @**person1** ([previous checkin](https://hackmd.io/team/rust-compiler-team?nav=overview)):
-> Checkin text
+  > Checkin text
 
 @*WG-Y* checkin by @**person2** ([previous checkin](https://hackmd.io/team/rust-compiler-team?nav=overview)):
-> Checkin text
+  > Checkin text
 
 ## Backport nominations
 
 [T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
 {{-issues::render(issues=beta_nominated_t_compiler, branch=":beta:", empty="No beta nominations for `T-compiler` this time.")}}
+<!--
+/poll Approve beta backport of #12345?
+approve
+decline
+don't know
+-->
 {{-issues::render(issues=stable_nominated_t_compiler, branch=":stable:", empty="No stable nominations for `T-compiler` this time.")}}
-
-[T-rustdoc stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-rustdoc) / [T-rustdoc beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-rustdoc)
-{{-issues::render(issues=beta_nominated_t_rustdoc, branch=":beta:", empty="No beta nominations for `T-rustdoc` this time.")}}
-{{-issues::render(issues=stable_nominated_t_rustdoc, branch=":stable:", empty="No stable nominations for `T-rustdoc` this time.")}}
-
-:back: / :shrug: / :hand:
+<!--
+/poll Approve stable backport of #12345?
+approve
+approve but does not justify new dot release
+decline
+don't know
+-->
 
 ## PRs S-waiting-on-team
 
 [T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
 {{-issues::render(issues=prs_waiting_on_team_t_compiler, empty="No PRs waiting on `T-compiler` this time.")}}
-
-### Oldest PRs waiting for review
-
-(TIP) Curate this list before the meeting
-
-[T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-asc+label%3AS-waiting-on-review+draft%3Afalse+label%3AT-compiler)
-{{-issues::render(issues=top_unreviewed_prs, with_age=true, empty="No unreviewed PRs on `T-compiler` this time.")}}
 
 ## Issues of Note
 
@@ -83,13 +84,13 @@ tags: weekly, rustc
 ### P-critical
 
 [T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AP-critical+label%3AT-compiler)
-{{-issues::render(issues=p_critical_t_compiler, empty="No `P-critical` issues for `T-compiler` at this time.")}}
+{{-issues::render(issues=p_critical_t_compiler, empty="No `P-critical` issues for `T-compiler` this time.")}}
 
 [T-types](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AP-critical+label%3AT-types)
-{{-issues::render(issues=p_critical_t_types, empty="No `P-critical` issues for `T-types` at this time.")}}
+{{-issues::render(issues=p_critical_t_types, empty="No `P-critical` issues for `T-types` this time.")}}
 
 [T-rustdoc](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AP-critical+label%3AT-rustdoc)
-{{-issues::render(issues=p_critical_t_rustdoc, empty="No `P-critical` issues for `T-rustdoc` at this time.")}}
+{{-issues::render(issues=p_critical_t_rustdoc, empty="No `P-critical` issues for `T-rustdoc` this time.")}}
 
 ### P-high regressions
 
@@ -111,7 +112,16 @@ tags: weekly, rustc
 [RFC](https://github.com/rust-lang/rfcs/issues?q=is%3Aopen+label%3AI-compiler-nominated)
 {{-issues::render(issues=nominated_rfcs_t_compiler, empty="No I-compiler-nominated RFCs this time.")}}
 
+### Oldest PRs waiting for review
+
+(TIP) Curate this list before the meeting
+
+[T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-asc+label%3AS-waiting-on-review+draft%3Afalse+label%3AT-compiler)
+{{-issues::render(issues=top_unreviewed_prs, with_age=true, empty="No unreviewed PRs on `T-compiler` this time.")}}
+
 ## Next week's WG checkins
 
 - @*WG-X* checkin by @**person1**
 - @*WG-X* checkin by @**person2**
+
+Next meetings' agenda draft: `<hackmd link>`


### PR DESCRIPTION
- Removed T-rustdoc backport nominations (as agreed [on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202023-07-20/near/376989910), they will take care of them during their meetings)
- small cosmetic updates to the T-compiler agenda template

r? @spastorino 