### PR TITLE
Add a new `users_on_vacation` config which prevents PR assignment

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -90,6 +90,17 @@ pub(crate) struct AssignConfig {
     /// usernames, team names, or ad-hoc groups.
     #[serde(default)]
     pub(crate) owners: HashMap<String, Vec<String>>,
+    #[serde(default)]
+    pub(crate) users_on_vacation: HashSet<String>,
+}
+
+impl AssignConfig {
+    pub(crate) fn is_on_vacation(&self, user: &str) -> bool {
+        let name_lower = user.to_lowercase();
+        self.users_on_vacation
+            .iter()
+            .any(|vacationer| name_lower == vacationer.to_lowercase())
+    }
 }
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]
@@ -337,6 +348,7 @@ mod tests {
             ]
 
             [assign]
+            users_on_vacation = ["jyn514"]
 
             [note]
 
@@ -393,6 +405,7 @@ mod tests {
                     contributing_url: None,
                     adhoc_groups: HashMap::new(),
                     owners: HashMap::new(),
+                    users_on_vacation: HashSet::from(["jyn514".into()]),
                 }),
                 note: Some(NoteConfig { _empty: () }),
                 ping: Some(PingConfig { teams: ping_teams }),

--- a/src/handlers/assign/tests/tests_candidates.rs
+++ b/src/handlers/assign/tests/tests_candidates.rs
@@ -265,3 +265,33 @@ fn invalid_org_doesnt_match() {
         )),
     );
 }
+
+#[test]
+fn vacation() {
+    let teams = toml::toml!(bootstrap = ["jyn514", "Mark-Simulacrum"]);
+    let config = toml::toml!(users_on_vacation = ["jyn514"]);
+    let issue = generic_issue("octocat", "rust-lang/rust");
+
+    // Test that `r? user` falls through to assigning from the team.
+    // See `determine_assignee` - ideally we would test that function directly instead of indirectly through `find_reviewer_from_names`.
+    let err_names = vec!["jyn514".into()];
+    test_from_names(
+        Some(teams.clone()),
+        config.clone(),
+        issue.clone(),
+        &["jyn514"],
+        Err(FindReviewerError::AllReviewersFiltered {
+            initial: err_names.clone(),
+            filtered: err_names,
+        }),
+    );
+
+    // Test that `r? bootstrap` doesn't assign from users on vacation.
+    test_from_names(
+        Some(teams.clone()),
+        config.clone(),
+        issue,
+        &["bootstrap"],
+        Ok(&["Mark-Simulacrum"]),
+    );
+}


### PR DESCRIPTION
People keep assigning me to PRs (usually new contributors who haven't seen my Zulip message). I very much do not want this. Prevent it in triagebot.

- If `r? jyn514` is posted as a comment after the PR is opened, post a useful error but otherwise do nothing
- If `r? jyn514` is posted in the PR body, fall back to assigning from the diff (as if `r?` wasn't present)
- If `r? bootstrap` is posted anywhere, filter me out from the team. I am not actually on the review rotation currently, but this would be useful if I were (and maybe other people will find it useful?).