### PR TITLE
Fix docs update using the wrong repo for the commit message

### DIFF
--- a/src/handlers/docs_update.rs
+++ b/src/handlers/docs_update.rs
@@ -67,7 +67,7 @@ pub async fn docs_update() -> Result<Option<Issue>> {
     let dest_repo = gh.repository(DEST_REPO).await?;
     let work_repo = gh.repository(WORK_REPO).await?;
 
-    let updates = get_submodule_updates(&gh, &work_repo).await?;
+    let updates = get_submodule_updates(&gh, &dest_repo).await?;
     if updates.is_empty() {
         tracing::trace!("no updates this week?");
         return Ok(None);


### PR DESCRIPTION
This fixes the docs update to correctly generate the commit message. It is currently generating a commit message with outdated information (essentially all changes since before the last update). #1710 had a mistake where it is using the outdated work repo to determine what has changed. It should instead use the latest `rust-lang/rust` repo to determine which submodules are out of date.
