### PR TITLE
Rustfmt

### DIFF
--- a/github-graphql/src/lib.rs
+++ b/github-graphql/src/lib.rs
@@ -326,12 +326,16 @@ pub mod project_items {
 
     impl ProjectV2Item {
         pub fn status(&self) -> Option<&str> {
-            let Some(ref status) = self.status else { return None };
+            let Some(ref status) = self.status else {
+                return None;
+            };
             status.as_str()
         }
 
         pub fn date(&self) -> Option<Date> {
-            let Some(ref date) = self.date else { return None };
+            let Some(ref date) = self.date else {
+                return None;
+            };
             date.as_date()
         }
     }


### PR DESCRIPTION
Rustfmt now formats let-else, which is causing CI to fail.