### PR TITLE
Clarify assignee error message.

### DIFF
--- a/src/handlers/assign.rs
+++ b/src/handlers/assign.rs
@@ -249,8 +249,8 @@ async fn set_assignee(issue: &Issue, github: &GithubClient, username: &str) {
                 &format!(
                     "Failed to set assignee to `{username}`: {err}\n\
                      \n\
-                     > **Note**: Only org members, users with write \
-                       permissions, or people who have commented on the PR may \
+                     > **Note**: Only org members with at least the repository \"read\" role, \
+                       users with write permissions, or people who have commented on the PR may \
                        be assigned."
                 ),
             )


### PR DESCRIPTION
This adds a little more information to the assignee error message to hopefully make it clearer. At the time I wrote this, I didn't realize there is a difference between a "repository read role" (which must be explicitly granted) and "being able to read the repository" (which everyone has on a public repo). The documentation for this is at https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users
