### PR TITLE
no-merges: match titles instead of labels

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -105,9 +105,9 @@ impl AssignConfig {
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]
 pub(crate) struct NoMergesConfig {
-    /// No action will be taken on PRs with these labels.
+    /// No action will be taken on PRs with these substrings in the title.
     #[serde(default)]
-    pub(crate) exclude_labels: Vec<String>,
+    pub(crate) exclude_titles: Vec<String>,
     /// Set these labels on the PR when merge commits are detected.
     #[serde(default)]
     pub(crate) labels: Vec<String>,


### PR DESCRIPTION
also don't re-add labels if they're manually removed

labels are not always set atomically when opening a PR example: rust-lang/miri#3059

Forge change: https://github.com/rust-lang/rust-forge/pull/701