### PR TITLE
Allow configuring bot name

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,3 +5,9 @@ GITHUB_WEBHOOK_SECRET=MUST_BE_CONFIGURED
 # for logging, refer to this document: https://rust-lang-nursery.github.io/rust-cookbook/development_tools/debugging/config_log.html
 # `RUSTC_LOG` is not required to run the application, but it makes local development easier
 # RUST_LOG=MUST_BE_CONFIGURED
+
+# If you are running a bot on non-rustbot account,
+# this allows to configure that username which the bot will respond to.
+# For example write blahblahblah here, if you want for this bot to 
+# respond to @blahblahblah claim.
+# TRIAGEBOT_USERNAME=CAN_BE_CONFIGURED

--- a/src/handlers/assign.rs
+++ b/src/handlers/assign.rs
@@ -47,8 +47,8 @@ minimum review times lag, PR authors and assigned reviewers should ensure that t
 label (`S-waiting-on-review` and `S-waiting-on-author`) stays updated, invoking these commands \
 when appropriate:
 
-- `@rustbot author`: the review is finished, PR author should check the comments and take action accordingly
-- `@rustbot review`: the author is ready for a review, this PR will be queued again in the reviewer's queue";
+- `@{bot} author`: the review is finished, PR author should check the comments and take action accordingly
+- `@{bot} review`: the author is ready for a review, this PR will be queued again in the reviewer's queue";
 
 const WELCOME_WITH_REVIEWER: &str = "@{assignee} (or someone else)";
 
@@ -56,7 +56,7 @@ const WELCOME_WITHOUT_REVIEWER: &str = "@Mark-Simulacrum (NB. this repo may be m
 
 const RETURNING_USER_WELCOME_MESSAGE: &str = "r? @{assignee}
 
-(rustbot has picked a reviewer for you, use r? to override)";
+({bot} has picked a reviewer for you, use r? to override)";
 
 const RETURNING_USER_WELCOME_MESSAGE_NO_REVIEWER: &str =
     "@{author}: no appropriate reviewer found, use r? to override";
@@ -141,12 +141,18 @@ pub(super) async fn handle_input(
             let mut welcome = NEW_USER_WELCOME_MESSAGE.replace("{who}", &who_text);
             if let Some(contrib) = &config.contributing_url {
                 welcome.push_str("\n\n");
-                welcome.push_str(&CONTRIBUTION_MESSAGE.replace("{contributing_url}", contrib));
+                welcome.push_str(
+                    &CONTRIBUTION_MESSAGE
+                        .replace("{contributing_url}", contrib)
+                        .replace("{bot}", &ctx.username),
+                );
             }
             Some(welcome)
         } else if !from_comment {
             let welcome = match &assignee {
-                Some(assignee) => RETURNING_USER_WELCOME_MESSAGE.replace("{assignee}", assignee),
+                Some(assignee) => RETURNING_USER_WELCOME_MESSAGE
+                    .replace("{assignee}", assignee)
+                    .replace("{bot}", &ctx.username),
                 None => RETURNING_USER_WELCOME_MESSAGE_NO_REVIEWER
                     .replace("{author}", &event.issue.user.login),
             };

--- a/src/handlers/glacier.rs
+++ b/src/handlers/glacier.rs
@@ -33,7 +33,7 @@ pub(super) async fn handle_command(
 
     let octocrab = &ctx.octocrab;
 
-    let fork = octocrab.repos("rustbot", "glacier");
+    let fork = octocrab.repos(&ctx.username, "glacier");
     let base = octocrab.repos("rust-lang", "glacier");
 
     let master = base
@@ -65,7 +65,7 @@ pub(super) async fn handle_command(
         .pulls("rust-lang", "glacier")
         .create(
             format!("ICE - rust-lang/rust#{}", number),
-            format!("rustbot:triagebot-ice-{}", number),
+            format!("{}:triagebot-ice-{}", ctx.username, number),
             "master",
         )
         .body(format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,7 +246,10 @@ async fn run_server(addr: SocketAddr) -> anyhow::Result<()> {
         .build()
         .expect("Failed to build octograb.");
     let ctx = Arc::new(Context {
-        username: String::from("rustbot"),
+        username: std::env::var("TRIAGEBOT_USERNAME").or_else(|err| match err {
+            std::env::VarError::NotPresent => Ok("rustbot".to_owned()),
+            err => Err(err),
+        })?,
         db: pool,
         github: gh,
         octocrab: oc,


### PR DESCRIPTION
The first part of #1728.

I still left "rustbot" constants in some places where it's annoying to change, but this should cover most of the things.