### PR TITLE
Review requested: don't error if not configured

### DIFF
--- a/src/handlers/review_requested.rs
+++ b/src/handlers/review_requested.rs
@@ -7,9 +7,13 @@ pub(crate) struct ReviewRequestedInput {}
 pub(crate) async fn parse_input(
     _ctx: &Context,
     event: &IssuesEvent,
-    _config: Option<&ReviewRequestedConfig>,
+    config: Option<&ReviewRequestedConfig>,
 ) -> Result<Option<ReviewRequestedInput>, String> {
     // PR author requests a review from one of the assignees
+
+    if config.is_none() {
+        return Ok(None);
+    }
 
     let IssuesAction::ReviewRequested { requested_reviewer } = &event.action else {
         return Ok(None);


### PR DESCRIPTION
If someone clicks the little "request review" button in a repo that doesn't have `review_requested` configured, it was generating an error message. I don't think it should, since that is a normal GitHub feature that works fine without triagebot. This changes it so that clicking that button won't generate an error.
