### PR TITLE
Add new PR review assignment

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -6,6 +6,17 @@ GITHUB_WEBHOOK_SECRET=MUST_BE_CONFIGURED
 # `RUSTC_LOG` is not required to run the application, but it makes local development easier
 # RUST_LOG=MUST_BE_CONFIGURED
 
+# Flag to enable the new pull request assignment workflow (see pr_prefs_backoffice.md).
+# If this env var is UNSET, the old pull request assignment is used (basically random assignment).
+# If this env var is SET, the new pull request assignment reads the Rust contributors preferences and assigns PRs accordingly.
+USE_NEW_PR_ASSIGNMENT=yes
+
+# A comma separated list of teams that are allowed to use the new PR assignment workflow.
+# Used to limit the number of users during the test phase.
+# Team name matches names in the rust-lang/team repository:
+# https://github.com/rust-lang/team/tree/master/teams
+NEW_PR_ASSIGNMENT_TEAMS=compiler,compiler-contributors
+
 # If you are running a bot on non-rustbot account,
 # this allows to configure that username which the bot will respond to.
 # For example write blahblahblah here, if you want for this bot to 

--- a/src/bin/import-users-from-github.rs
+++ b/src/bin/import-users-from-github.rs
@@ -1,0 +1,102 @@
+use reqwest::Client;
+use tracing::{debug, info};
+// TODO: this should become an HTTP API
+// use triagebot::db::notifications::record_username;
+use triagebot::github;
+use triagebot::github::User;
+
+// TODO: these should become HTTP APIs
+// use triagebot::handlers::review_prefs::{add_prefs, delete_prefs, get_prefs};
+
+// Import and synchronization:
+// 1. Download teams and retrieve those listed in $NEW_PR_ASSIGNMENT_TEAMS
+// 2. Add missing team members to the review preferences table
+// 3. Delete preferences for members not present in the team roster anymore
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    dotenv::dotenv().ok();
+    tracing_subscriber::fmt::init();
+
+    let gh = github::GithubClient::new_with_default_token(Client::new());
+    let teams_data = triagebot::team_data::teams(&gh).await?;
+
+    // 1. get team members
+    let x = std::env::var("NEW_PR_ASSIGNMENT_TEAMS")
+        .expect("NEW_PR_ASSIGNMENT_TEAMS env var must be set");
+    let allowed_teams = x.split(",").collect::<Vec<&str>>();
+    info!("Will download members for teams: {:?}", allowed_teams);
+    for team in &allowed_teams {
+        let members = teams_data.teams.get(*team).unwrap();
+        let team_members = members
+            .members
+            .iter()
+            .map(|tm| User {
+                login: tm.github.clone(),
+                id: Some(tm.github_id as i64),
+            })
+            .collect::<Vec<_>>();
+        debug!("Team {} members loaded: {:?}", team, team_members);
+
+        // get team members review capacity
+        let team_review_prefs = get_prefs(
+            &db_client,
+            &team_members
+                .iter()
+                .map(|tm| tm.login.clone())
+                .collect::<Vec<String>>(),
+            "apiraino",
+            true,
+        )
+        .await;
+
+        // 2. Add missing team members to the review preferences table
+        for member in &team_members {
+            if !team_review_prefs
+                .iter()
+                .find(|rec| rec.username == member.login)
+                .is_some()
+            {
+                debug!(
+                    "Team member {:?} was NOT found in the prefs DB table",
+                    member
+                );
+
+                // ensure this person exists in the users DB table first
+                let team_member = team_members
+                    .iter()
+                    .find(|m| m.login == member.login)
+                    .expect(&format!(
+                        "Could not find member {:?} in team {}",
+                        member, team
+                    ));
+                let _ = record_username(&db_client, team_member.id.unwrap() as i64, &member.login)
+                    .await;
+
+                // Create a record in the review_capacity DB table for this member with some defaults
+                let _ = add_prefs(&db_client, team_member.id.unwrap() as i64).await?;
+                info!("Added team member {}", &team_member.login);
+            }
+        }
+
+        // 3. delete prefs for members not present in the team roster anymore
+        let removed_members = team_review_prefs
+            .iter()
+            .filter(|tm| {
+                !team_members.contains(&User {
+                    id: Some(tm.user_id),
+                    login: tm.username.clone(),
+                })
+            })
+            .map(|tm| tm.user_id)
+            .collect::<Vec<i64>>();
+        if !removed_members.is_empty() {
+            let _ = delete_prefs(&db_client, &removed_members).await?;
+            info!("Delete preferences for team members {:?}", &removed_members);
+        }
+        info!("Finished updating review prefs for team {}", team);
+    }
+
+    info!("Import/Sync job finished");
+    Ok(())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,7 @@ pub(crate) struct Config {
     pub(crate) note: Option<NoteConfig>,
     pub(crate) mentions: Option<MentionsConfig>,
     pub(crate) no_merges: Option<NoMergesConfig>,
+    pub(crate) review_prefs: Option<ReviewPrefsConfig>,
 }
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]
@@ -148,6 +149,12 @@ pub(crate) struct RelabelConfig {
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]
 pub(crate) struct ShortcutConfig {
+    #[serde(default)]
+    _empty: (),
+}
+
+#[derive(PartialEq, Eq, Debug, serde::Deserialize)]
+pub(crate) struct ReviewPrefsConfig {
     #[serde(default)]
     _empty: (),
 }
@@ -431,6 +438,7 @@ mod tests {
                 review_requested: None,
                 mentions: None,
                 no_merges: None,
+                review_prefs: None
             }
         );
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -273,4 +273,19 @@ CREATE UNIQUE INDEX jobs_name_scheduled_at_unique_index
         name, scheduled_at
     );
 ",
+    "
+CREATE table review_capacity (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    user_id BIGINT REFERENCES users(user_id),
+    active boolean NOT NULL DEFAULT true,
+    assigned_prs INT[] NOT NULL DEFAULT array[]::INT[],
+    max_assigned_prs INTEGER NOT NULL DEFAULT 5,
+    num_assigned_prs INTEGER,
+    pto_date_start date,
+    pto_date_end date,
+    allow_ping_after_days INTEGER NOT NULL DEFAULT 15,
+    publish_prefs boolean NOT NULL DEFAULT false,
+    checksum TEXT
+);
+",
 ];

--- a/src/db/notifications.rs
+++ b/src/db/notifications.rs
@@ -15,7 +15,7 @@ pub struct Notification {
     pub team_name: Option<String>,
 }
 
-pub async fn record_username(db: &DbClient, user_id: i64, username: String) -> anyhow::Result<()> {
+pub async fn record_username(db: &DbClient, user_id: i64, username: &str) -> anyhow::Result<()> {
     db.execute(
         "INSERT INTO users (user_id, username) VALUES ($1, $2) ON CONFLICT DO NOTHING",
         &[&user_id, &username],

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -41,6 +41,7 @@ mod notify_zulip;
 mod ping;
 mod prioritize;
 mod relabel;
+pub mod review_prefs;
 mod review_requested;
 mod review_submitted;
 mod rfc_helper;
@@ -158,6 +159,8 @@ macro_rules! issue_handlers {
 //
 // This is for events that happen only on issues (e.g. label changes).
 // Each module in the list must contain the functions `parse_input` and `handle_input`.
+// - `parse_input` should parse and validate the input, return an object with everything needed to perform an action
+// - `handle_input`: performs the action (optionally) using the input object received
 issue_handlers! {
     assign,
     autolabel,
@@ -165,6 +168,7 @@ issue_handlers! {
     mentions,
     no_merges,
     notify_zulip,
+    review_prefs,
     review_requested,
 }
 

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -100,7 +100,7 @@ pub async fn handle(ctx: &Context, event: &Event) -> anyhow::Result<()> {
                 continue;
             }
 
-            if let Err(err) = notifications::record_username(&client, user.id.unwrap(), user.login)
+            if let Err(err) = notifications::record_username(&client, user.id.unwrap(), &user.login)
                 .await
                 .context("failed to record username")
             {

--- a/src/handlers/review_prefs.rs
+++ b/src/handlers/review_prefs.rs
@@ -1,0 +1,316 @@
+use crate::{
+    config::ReviewPrefsConfig,
+    github::{IssuesAction, IssuesEvent, Selection},
+    handlers::Context,
+    ReviewCapacityUser,
+};
+use anyhow::Context as _;
+use tokio_postgres::Client as DbClient;
+use tracing as log;
+
+// This module updates the PR work queue of reviewers
+// - Adds the PR to the work queue of the user (when the PR has been assigned)
+// - Removes the PR from the work queue of the user (when the PR is unassigned or closed)
+// - Rollbacks the PR assignment in case the specific user ("r? user") is inactive/not available
+
+/// Remove review preferences for these team members
+pub async fn delete_prefs(db: &DbClient, user_ids: &Vec<i64>) -> anyhow::Result<()> {
+    db.execute(
+        "DELETE FROM review_capacity where user_id = any($1)",
+        &[&user_ids],
+    )
+    .await
+    .context("Delete DB error")?;
+    Ok(())
+}
+
+/// Add stub record for a team member review capacity
+pub async fn add_prefs(db: &DbClient, user_id: i64) -> anyhow::Result<()> {
+    db.execute(
+        "INSERT INTO review_capacity (user_id) VALUES ($1)",
+        &[&user_id],
+    )
+    .await
+    .context("Insert DB error")?;
+    Ok(())
+}
+
+/// Update review capacity for a team member
+pub async fn set_prefs(
+    db: &DbClient,
+    prefs: &ReviewCapacityUser,
+) -> anyhow::Result<ReviewCapacityUser> {
+    let q = "
+UPDATE review_capacity r
+SET max_assigned_prs = $2, pto_date_start = $3, pto_date_end = $4, active = $5, allow_ping_after_days = $6, publish_prefs = $7
+FROM users u
+WHERE r.user_id=$1 AND u.user_id=r.user_id
+RETURNING u.username, r.*";
+    log::debug!("pref {:?}", prefs);
+    let rec = db
+        .query_one(
+            q,
+            &[
+                &prefs.user_id,
+                &prefs.max_assigned_prs,
+                &prefs.pto_date_start,
+                &prefs.pto_date_end,
+                &prefs.active,
+                &prefs.allow_ping_after_days,
+                &prefs.publish_prefs,
+            ],
+        )
+        .await
+        .context("Update DB error")?;
+    Ok(rec.into())
+}
+
+/// Get review preferences for a number of team members
+/// - me: sort the current user at the top of the list
+/// - is_admin: if `true` return also preferences marked as not public
+pub async fn get_prefs(
+    db: &DbClient,
+    users: &Vec<String>,
+    me: &str,
+    is_admin: bool,
+) -> Vec<ReviewCapacityUser> {
+    let q = format!(
+        "
+SELECT username,r.*
+FROM review_capacity r
+JOIN users on r.user_id=users.user_id
+WHERE username = any($1)
+ORDER BY case when username='{}' then 1 else 2 end, username;",
+        me
+    );
+
+    let rows = db
+        .query(&q, &[&users])
+        .await
+        .context("Error retrieving review preferences")
+        .unwrap();
+    rows.into_iter()
+        .filter_map(|row| {
+            let rec = ReviewCapacityUser::from(row);
+            if rec.username == me || rec.publish_prefs || (!rec.publish_prefs && is_admin) {
+                Some(rec)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Get review preferences for a number of team members
+pub async fn get_review_candidates_by_username(
+    db: &DbClient,
+    usernames: Vec<String>,
+) -> anyhow::Result<Vec<ReviewCapacityUser>> {
+    let q = format!(
+        "
+SELECT u.username, r.*
+FROM review_capacity r
+JOIN users u on u.user_id=r.user_id
+WHERE username = ANY('{{ {} }}')",
+        usernames.join(",")
+    );
+    let rows = db.query(&q, &[]).await.unwrap();
+    Ok(rows
+        .into_iter()
+        .filter_map(|row| Some(ReviewCapacityUser::from(row)))
+        .collect())
+}
+
+/// Get review preferences for a number of team members, filter by review capacity
+pub async fn get_review_candidate_by_capacity(
+    db: &DbClient,
+    usernames: Vec<String>,
+) -> anyhow::Result<ReviewCapacityUser> {
+    let q = format!(
+        "
+SELECT username, r.*, sum(r.max_assigned_prs - r.num_assigned_prs) as avail_slots
+FROM review_capacity r
+JOIN users on users.user_id=r.user_id
+WHERE active = true
+AND current_date NOT BETWEEN pto_date_start AND pto_date_end
+AND username = ANY('{{ {} }}')
+AND num_assigned_prs < max_assigned_prs
+GROUP BY username, r.id
+ORDER BY avail_slots DESC
+LIMIT 1",
+        usernames.join(",")
+    );
+    let rec = db.query_one(&q, &[]).await.context("Select DB error")?;
+    Ok(rec.into())
+}
+
+/// Get all assignees of a pull request
+async fn get_review_pr_assignees(
+    db: &DbClient,
+    issue_num: u64,
+) -> anyhow::Result<Vec<ReviewCapacityUser>> {
+    let q = format!(
+        "
+SELECT u.username, r.*
+FROM review_capacity r
+JOIN users u on u.user_id=r.user_id
+WHERE {} = ANY (assigned_prs);",
+        issue_num,
+    );
+
+    let rows = db.query(&q, &[]).await.unwrap();
+    Ok(rows
+        .into_iter()
+        .filter_map(|row| Some(ReviewCapacityUser::from(row)))
+        .collect())
+}
+
+pub(super) struct ReviewPrefsInput {}
+
+pub(super) async fn parse_input(
+    _ctx: &Context,
+    event: &IssuesEvent,
+    config: Option<&ReviewPrefsConfig>,
+) -> Result<Option<ReviewPrefsInput>, String> {
+    log::debug!("[review_prefs] parse_input");
+    let _config = match config {
+        Some(config) => config,
+        None => return Ok(None),
+    };
+
+    log::debug!(
+        "[review_prefs] now matching the action for event {:?}",
+        event
+    );
+    match event.action {
+        IssuesAction::Assigned => {
+            log::debug!("[review_prefs] IssuesAction::Assigned: Will add to work queue");
+            Ok(Some(ReviewPrefsInput {}))
+        }
+        IssuesAction::Unassigned | IssuesAction::Closed => {
+            log::debug!("[review_prefs] IssuesAction::Unassigned | IssuesAction::Closed: Will remove from work queue");
+            Ok(Some(ReviewPrefsInput {}))
+        }
+        _ => {
+            log::debug!("[review_prefs] Other action on PR {:?}", event.action);
+            Ok(None)
+        }
+    }
+}
+
+async fn update_assigned_prs(
+    db: &DbClient,
+    user_id: i64,
+    assigned_prs: &Vec<i32>,
+) -> anyhow::Result<ReviewCapacityUser> {
+    let q = "
+UPDATE review_capacity r
+SET assigned_prs = $2, num_assigned_prs = $3
+FROM users u
+WHERE r.user_id=$1 AND u.user_id=r.user_id
+RETURNING u.username, r.*";
+    let num_assigned_prs = assigned_prs.len() as i32;
+    let rec = db
+        .query_one(q, &[&user_id, assigned_prs, &num_assigned_prs])
+        .await
+        .context("Update DB error")?;
+    Ok(rec.into())
+}
+
+pub(super) async fn handle_input<'a>(
+    ctx: &Context,
+    _config: &ReviewPrefsConfig,
+    event: &IssuesEvent,
+    _inputs: ReviewPrefsInput,
+) -> anyhow::Result<()> {
+    log::debug!("[review_prefs] handle_input");
+    let db_client = ctx.db.get().await;
+
+    // Note:
+    // When assigning or unassigning a PR, we don't receive the assignee(s) removed from the PR
+    // so we need to run two queries:
+
+    // 1) unassign this PR from everyone
+    let current_assignees = get_review_pr_assignees(&db_client, event.issue.number)
+        .await
+        .unwrap();
+    for mut rec in current_assignees {
+        if let Some(index) = rec
+            .assigned_prs
+            .iter()
+            .position(|value| *value == event.issue.number as i32)
+        {
+            rec.assigned_prs.swap_remove(index);
+        }
+        update_assigned_prs(&db_client, rec.user_id, &rec.assigned_prs)
+            .await
+            .unwrap();
+    }
+
+    // If the action is to unassign/close a PR, nothing else to do
+    if event.action == IssuesAction::Closed || event.action == IssuesAction::Unassigned {
+        return Ok(());
+    }
+
+    // 2) assign the PR to the requested team members
+    let usernames = event
+        .issue
+        .assignees
+        .iter()
+        .map(|x| x.login.clone())
+        .collect::<Vec<String>>();
+    let requested_assignees = get_review_candidates_by_username(&db_client, usernames)
+        .await
+        .unwrap();
+    // iterate the list of requested assignees and try to assign the issue to each of them
+    // in case of failure, emit a comment (for each failure)
+    for mut assignee_prefs in requested_assignees {
+        log::debug!(
+            "Trying to assign to {}, with prefs {:?}",
+            &assignee_prefs.username,
+            &assignee_prefs
+        );
+
+        // If Github just assigned a PR to an inactive/unavailable user
+        // publish a comment notifying the error and rollback the PR assignment
+        if event.action == IssuesAction::Assigned
+            && (!assignee_prefs.active || !assignee_prefs.is_available())
+        {
+            log::debug!(
+                "PR assigned to {}, which is not available: will revert this.",
+                &assignee_prefs.username
+            );
+            event
+                .issue
+                .post_comment(
+                    &ctx.github,
+                    &format!(
+                        "Could not assign PR to user {}, please reroll for the team",
+                        &assignee_prefs.username
+                    ),
+                )
+                .await
+                .context("Failed posting a comment on Github")?;
+            event
+                .issue
+                .remove_assignees(&ctx.github, Selection::One(&assignee_prefs.username))
+                .await
+                .context("Failed unassigning the PR")?;
+        }
+
+        let iss_num = event.issue.number as i32;
+        if !assignee_prefs.assigned_prs.contains(&iss_num) {
+            assignee_prefs.assigned_prs.push(iss_num)
+        }
+
+        update_assigned_prs(
+            &db_client,
+            assignee_prefs.user_id,
+            &assignee_prefs.assigned_prs,
+        )
+        .await
+        .unwrap();
+    }
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,11 +285,13 @@ pub struct ReviewCapacityUser {
 
 impl ReviewCapacityUser {
     pub(crate) fn is_available(&self) -> bool {
+match (self.active, self.pto_date_start, self.pto_date_end) {
+    (true, Some(pto_date_start), Some(pto_date_end)) => {
         let today = chrono::Utc::today().naive_utc();
-        let is_available = (self.pto_date_end.is_some() && self.pto_date_start.is_some())
-            && (self.pto_date_end.unwrap() < today || self.pto_date_start.unwrap() > today);
-        self.active && is_available
-    }
+        today < pto_date_start || pto_date_end < today
+    } 
+    _ => false;
+}
 
     pub fn default(username: String) -> Self {
         Self {


### PR DESCRIPTION
**UPDATE 2023-12-12**: this second proposal was discussed with @jdno, we agreed a plan detailing how to split it further. I'm going to close this PR and refactor another patch according to this plan.

----

This is the implementation of a new workflow for assigning pull requests to the Rust project contributors.

This new workflow will assign a pull request to be reviewed based on the number of assigned pull requests to team members.

Everytime a pull request assignment is invoked with `r? <team>` or `r? <team_member>` the Triagebot will check the current workload of the candidates and assign the pull request to the team member less busy.

The new workflow is DISABLED by default. It can be enabled by setting the env variable `USE_NEW_PR_ASSIGNMENT` (any value) and restarting the Triagebot.

Teams that are subject to the new PR review assignment are listed as a comma separated list in the env variable `NEW_PR_ASSIGNMENT_TEAMS`. See `.env.sample` for a usage example.

Team members workload is tracked in a new DB table `review_capacity`.

Both the initial population and the synchronization of this table are handled by a command line tool that will speak to the Triagebot through a number of HTTP endpoints. These HTTP endpoints must be PRIVATE and accessible ONLY to the sync tool. This should be handled at the infrastructure level, the endpoints are not authenticated.