### PR TITLE
Add detail about how to raise MCP concerns

### DIFF
--- a/src/handlers/major_change.rs
+++ b/src/handlers/major_change.rs
@@ -264,6 +264,27 @@ async fn handle(
         procedural comments, such as volunteering to review, indicating that you \
         second the proposal (or third, etc), or raising a concern that you would \
         like to be addressed. \
+        \n\n \
+        Concerns or objections to the proposal should be discussed on Zulip and formally registered \
+        here by adding a comment with the following syntax: \
+        \n \
+        ``` \
+        \n \
+        @rustbot concern reason-for-concern \
+        \n \
+        <description of the concern> \
+        \n \
+        ``` \
+        \n \
+        Concerns can be lifted with: \
+        \n \
+        ``` \
+        \n \
+        @rustbot resolve reason-for-concern \
+        \n \
+        ``` \
+        \n\n \
+        See documentation at [https://forge.rust-lang.org](https://forge.rust-lang.org/compiler/mcp.html#what-kinds-of-comments-should-go-on-the-tracking-issue-in-compiler-team-repo) \
         \n\n{} \
         \n\n[stream]: {}",
             config.open_extra_text.as_deref().unwrap_or_default(),


### PR DESCRIPTION
During the weekly T-compiler triage meetings we list all MCPs in different stages of progress. Some of them are blocked on concerns not yet resolved. We would like to list these open concerns so that meeting attendees have a glance why an MCP is not seconded or does not move forward.

In order to automate this when creating the meeting agenda it is useful if people respect a standard syntax for that so I can machine parse the issue comments and with a bit of regexps extract the relevant info.

<details><summary>Current message when opening a MCP:
</summary>
<p>

![screenshot-20231113-150350](https://github.com/rust-lang/triagebot/assets/6098822/4f351c37-8d8a-4cf6-a120-402300f0cbec)

</p>
</details> 

<details><summary>The new version should look like this</summary>
<p>

![screenshot-20231113-150509](https://github.com/rust-lang/triagebot/assets/6098822/937ebef5-d4a8-4cdb-b640-27d75dc86c3d)

</p>
</details> 

Note: the `@rustbot` syntax here won't trigger anything, It's just a psychological trick to make it look like that a command is executed but in reality it's just to facilitate the machine parsing for me.

Idea [mentioned on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.E2.9C.94.20.5Bweekly.5D.202023-10-26/near/398697369).

Documentation update for forge.rust-lang.org: https://github.com/rust-lang/rust-forge/pull/709

Thanks for looking at this patch!

r? @Mark-Simulacrum / @ehuss 