### PR TITLE
Add T-types beta backports

### DIFF
--- a/src/agenda.rs
+++ b/src/agenda.rs
@@ -181,6 +181,26 @@ pub fn prioritization<'a>() -> Box<dyn Action> {
                             exclude_labels: vec!["stable-accepted"],
                         }),
                     },
+                    // beta nomination t-types
+                    QueryMap {
+                        name: "beta_nominated_t_types",
+                        kind: QueryKind::List,
+                        query: Arc::new(github::Query {
+                            filters: vec![],
+                            include_labels: vec!["beta-nominated", "T-types"],
+                            exclude_labels: vec!["beta-accepted"],
+                        }),
+                    },
+                    // stable nomination queries
+                    QueryMap {
+                        name: "stable_nominated_t_types",
+                        kind: QueryKind::List,
+                        query: Arc::new(github::Query {
+                            filters: vec![],
+                            include_labels: vec!["stable-nominated", "T-Types"],
+                            exclude_labels: vec!["stable-accepted"],
+                        }),
+                    },
                     // prs waiting on team queries
                     QueryMap {
                         name: "prs_waiting_on_team_t_compiler",

--- a/templates/prioritization_agenda.tt
+++ b/templates/prioritization_agenda.tt
@@ -65,6 +65,23 @@ decline
 don't know
 -->
 
+[T-types stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-types) / [T-types beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-types)
+{{-issues::render(issues=beta_nominated_t_types, branch=":beta:", empty="No beta nominations for `T-types` this time.")}}
+<!--
+/poll Approve beta backport of #12345?
+approve
+decline
+don't know
+-->
+{{-issues::render(issues=stable_nominated_t_types, branch=":stable:", empty="No stable nominations for `T-types` this time.")}}
+<!--
+/poll Approve stable backport of #12345?
+approve
+approve but does not justify new dot release
+decline
+don't know
+-->
+
 ## PRs S-waiting-on-team
 
 [T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)


### PR DESCRIPTION
As discussed [on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/144729-t-types/topic/T-types.20backports.3F), during the weekly triage T-compiler meetings, we will keep an eye on the T-types backports (since de facto there is a lot of overlap between the two teams).

r? @spastorino 