### PR TITLE
Add MCP unresolved concerns to T-compiler meeting agenda

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -65,6 +65,7 @@ pub struct FCPDetails {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct MCPDetails {
     pub zulip_link: String,
+    pub concerns: Option<Vec<(String, String)>>,
 }
 
 lazy_static! {

--- a/templates/_issue.tt
+++ b/templates/_issue.tt
@@ -1,1 +1,4 @@
-{% macro render(issue, with_age="") %}"{{issue.title}}" [{{issue.repo_name}}#{{issue.number}}]({{issue.html_url}}){% if issue.mcp_details.zulip_link %} ([Zulip]({{issue.mcp_details.zulip_link}})){% endif %}{% if with_age %} (last review activity: {{issue.updated_at_hts}}){% endif %}{% endmacro %}
+{% macro render(issue, with_age="") %}"{{issue.title}}" [{{issue.repo_name}}#{{issue.number}}]({{issue.html_url}}){% if issue.mcp_details.zulip_link %} ([Zulip]({{issue.mcp_details.zulip_link}})){% endif %}{% if with_age %} (last review activity: {{issue.updated_at_hts}}){%- endif -%}
+{% if issue.mcp_details.concerns %}{%- for concern in issue.mcp_details.concerns %}
+    - concern: [{{- concern.0 -}}]({{- concern.1 -}})
+{%- endfor -%}{% endif -%}{% endmacro %}

--- a/templates/prioritization_agenda.tt
+++ b/templates/prioritization_agenda.tt
@@ -48,7 +48,7 @@ note_id: xxx
 
 ## Backport nominations
 
-[T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
+[T-compiler beta](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Abeta-nominated+-label%3Abeta-accepted+label%3AT-compiler) / [T-compiler stable](https://github.com/rust-lang/rust/issues?q=is%3Aall+label%3Astable-nominated+-label%3Astable-accepted+label%3AT-compiler)
 {{-issues::render(issues=beta_nominated_t_compiler, branch=":beta:", empty="No beta nominations for `T-compiler` this time.")}}
 <!--
 /poll Approve beta backport of #12345?


### PR DESCRIPTION
Some more automation when generating the T-compiler meeting agenda: now adding the unresolved concerns to the team MCPs (to help having a quick overview during the meeting).

Discussed the idea during a meeting [on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.E2.9C.94.20.5Bweekly.5D.202023-10-26/near/398696909).

The parsing of the MCP concerns is a bit brittle, I'm basically grepping through the comments looking for the markers we introduced in #1747 but I hope it's good enough for now

r? @ehuss @Mark-Simulacrum 

Thanks!