### PR TITLE
Squelch dead-code warning.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,10 @@ impl fmt::Display for EventName {
 }
 
 #[derive(Debug)]
-pub struct WebhookError(anyhow::Error);
+pub struct WebhookError(
+    #[allow(dead_code)] // Used in debug display
+    anyhow::Error,
+);
 
 impl From<anyhow::Error> for WebhookError {
     fn from(e: anyhow::Error) -> WebhookError {


### PR DESCRIPTION
Nightly recently enhanced the dead_code analysis to look at tuple struct fields, causing this type to generate a warning. However, the field is used for its debug display.
