### PR TITLE
Add build profile optimized for binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,12 @@ default-features = false
 
 [profile.release]
 debug = 2
+
+[profile.opt-size]
+inherits = "release"
+opt-level = "z"
+lto = "on"
+codegen-units = 1
+panic = "abort"
+incremental = false
+strip = true


### PR DESCRIPTION
This patch adds a new build profile optimized for binary size.

If we exclude the `triagebot` application, when building the other binaries under `./src/bin` I think it can make sense to optimize for binary size rathen than performance. When taken to the extreme (as in this patch), the differenze is just _huge_, see the following table (rust nightly 1.77):

```
$ la -h target/{release,opt-size}/{compiler,types,lang,prioritization-agenda}
-rwxr-xr-x 2 me me 4.0M Jan 24 17:13 target/opt-size/compiler
-rwxr-xr-x 2 me me 4.1M Jan 24 17:13 target/opt-size/lang
-rwxr-xr-x 2 me me 4.1M Jan 24 17:13 target/opt-size/prioritization-agenda
-rwxr-xr-x 2 me me 4.0M Jan 24 17:13 target/opt-size/types
-rwxr-xr-x 2 me me 140M Jan 24 17:21 target/release/compiler
-rwxr-xr-x 2 me me 141M Jan 24 17:21 target/release/lang
-rwxr-xr-x 2 me me 141M Jan 24 17:21 target/release/prioritization-agenda
-rwxr-xr-x 2 me me 140M Jan 24 17:21 target/release/types
```

I like to run the build of these ancillary tools with `cargo build --bins --profile=opt-size`.

Opinions?

Thanks for a review.