### PR TITLE
Don't panic when there is no zulip token

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -25,6 +25,7 @@ lazy_static::lazy_static! {
     };
 }
 
+#[derive(Clone)]
 pub struct ClientPool {
     connections: Arc<Mutex<Vec<tokio_postgres::Client>>>,
     permits: Arc<Semaphore>,

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,5 +1,6 @@
 use crate::config::{self, Config, ConfigurationError};
 use crate::github::{Event, GithubClient, IssueCommentAction, IssuesAction, IssuesEvent};
+use crate::zulip::ZulipTokens;
 use octocrab::Octocrab;
 use parser::command::{assign::AssignCommand, Command, Input};
 use std::fmt;
@@ -291,9 +292,11 @@ command_handlers! {
     note: Note,
 }
 
+#[derive(Clone)]
 pub struct Context {
     pub github: GithubClient,
     pub db: crate::db::ClientPool,
     pub username: String,
     pub octocrab: Octocrab,
+    pub zulip: Option<ZulipTokens>,
 }


### PR DESCRIPTION
triagebot currently uses `env::var().unwrap()` inside code that handles zulip things, which is not ideal (and leads to panics spamming logs for people like me, who run triagebot themselves).

I'm not _happy_ with this PR, but it probably solves the issue...

Ideally there would be a better system for enabling/disabling subsystems for the bot (via a per-instance-config and/or env vars), but I do not have energy to work on anything like that.