### PR TITLE
Add config options to change labels for draft/closed/reopened PRs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,8 @@ pub(crate) struct Config {
     pub(crate) github_releases: Option<GitHubReleasesConfig>,
     pub(crate) review_submitted: Option<ReviewSubmittedConfig>,
     pub(crate) review_requested: Option<ReviewRequestedConfig>,
+    pub(crate) converted_to_draft: Option<ConvertedToDraftConfig>,
+    pub(crate) ready_for_review: Option<ReadyForReviewConfig>,
     pub(crate) shortcut: Option<ShortcutConfig>,
     pub(crate) note: Option<NoteConfig>,
     pub(crate) mentions: Option<MentionsConfig>,
@@ -209,6 +211,8 @@ pub(crate) struct AutolabelLabelConfig {
     #[serde(default)]
     pub(crate) new_pr: bool,
     #[serde(default)]
+    pub(crate) new_draft_pr: bool,
+    #[serde(default)]
     pub(crate) new_issue: bool,
 }
 
@@ -285,6 +289,20 @@ pub(crate) struct ReviewSubmittedConfig {
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct ReviewRequestedConfig {
+    pub(crate) remove_labels: Vec<String>,
+    pub(crate) add_labels: Vec<String>,
+}
+
+#[derive(PartialEq, Eq, Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ConvertedToDraftConfig {
+    pub(crate) remove_labels: Vec<String>,
+    pub(crate) add_labels: Vec<String>,
+}
+
+#[derive(PartialEq, Eq, Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ReadyForReviewConfig {
     pub(crate) remove_labels: Vec<String>,
     pub(crate) add_labels: Vec<String>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,6 +34,7 @@ pub(crate) struct Config {
     pub(crate) review_requested: Option<ReviewRequestedConfig>,
     pub(crate) converted_to_draft: Option<ConvertedToDraftConfig>,
     pub(crate) ready_for_review: Option<ReadyForReviewConfig>,
+    pub(crate) closed_pr: Option<ClosedPrConfig>,
     pub(crate) shortcut: Option<ShortcutConfig>,
     pub(crate) note: Option<NoteConfig>,
     pub(crate) mentions: Option<MentionsConfig>,
@@ -307,6 +308,13 @@ pub(crate) struct ConvertedToDraftConfig {
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct ReadyForReviewConfig {
+    pub(crate) remove_labels: Vec<String>,
+    pub(crate) add_labels: Vec<String>,
+}
+
+#[derive(PartialEq, Eq, Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ClosedPrConfig {
     pub(crate) remove_labels: Vec<String>,
     pub(crate) add_labels: Vec<String>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -213,6 +213,10 @@ pub(crate) struct AutolabelLabelConfig {
     #[serde(default)]
     pub(crate) new_draft_pr: bool,
     #[serde(default)]
+    pub(crate) reopened_pr: bool,
+    #[serde(default)]
+    pub(crate) reopened_draft_pr: bool,
+    #[serde(default)]
     pub(crate) new_issue: bool,
 }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -26,6 +26,7 @@ impl fmt::Display for HandlerError {
 mod assign;
 mod autolabel;
 mod close;
+mod converted_to_draft;
 pub mod docs_update;
 mod github_releases;
 mod glacier;
@@ -39,6 +40,7 @@ mod notification;
 mod notify_zulip;
 mod ping;
 mod prioritize;
+mod ready_for_review;
 mod relabel;
 mod review_requested;
 mod review_submitted;
@@ -167,6 +169,8 @@ issue_handlers! {
     no_merges,
     notify_zulip,
     review_requested,
+    converted_to_draft,
+    ready_for_review,
     validate_config,
 }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -26,6 +26,7 @@ impl fmt::Display for HandlerError {
 mod assign;
 mod autolabel;
 mod close;
+mod closed_pr;
 mod converted_to_draft;
 pub mod docs_update;
 mod github_releases;
@@ -171,6 +172,7 @@ issue_handlers! {
     review_requested,
     converted_to_draft,
     ready_for_review,
+    closed_pr,
     validate_config,
 }
 

--- a/src/handlers/autolabel.rs
+++ b/src/handlers/autolabel.rs
@@ -69,17 +69,18 @@ pub(super) async fn parse_input(
                         name: label.to_owned(),
                     });
                 }
-                if cfg.new_pr && event.action == IssuesAction::Opened {
-                    autolabels.push(Label {
-                        name: label.to_owned(),
-                    });
-                }
             }
 
-            if event.issue.pull_request.is_none()
-                && cfg.new_issue
-                && event.action == IssuesAction::Opened
+            if event.issue.is_pr()
+                && matches!(event.action, IssuesAction::Opened)
+                && ((cfg.new_pr && !event.issue.draft) || (cfg.new_draft_pr && event.issue.draft))
             {
+                autolabels.push(Label {
+                    name: label.to_owned(),
+                });
+            }
+
+            if !event.issue.is_pr() && cfg.new_issue && event.action == IssuesAction::Opened {
                 autolabels.push(Label {
                     name: label.to_owned(),
                 });

--- a/src/handlers/autolabel.rs
+++ b/src/handlers/autolabel.rs
@@ -26,7 +26,10 @@ pub(super) async fn parse_input(
     // FIXME: This will re-apply labels after a push that the user had tried to
     // remove. Not much can be done about that currently; the before/after on
     // synchronize may be straddling a rebase, which will break diff generation.
-    if event.action == IssuesAction::Opened || event.action == IssuesAction::Synchronize {
+    if matches!(
+        &event.action,
+        IssuesAction::Opened | IssuesAction::Reopened | IssuesAction::Synchronize
+    ) {
         let files = event
             .issue
             .diff(&ctx.github)
@@ -74,6 +77,16 @@ pub(super) async fn parse_input(
             if event.issue.is_pr()
                 && matches!(event.action, IssuesAction::Opened)
                 && ((cfg.new_pr && !event.issue.draft) || (cfg.new_draft_pr && event.issue.draft))
+            {
+                autolabels.push(Label {
+                    name: label.to_owned(),
+                });
+            }
+
+            if event.issue.is_pr()
+                && matches!(event.action, IssuesAction::Reopened)
+                && ((cfg.reopened_pr && !event.issue.draft)
+                    || (cfg.reopened_draft_pr && event.issue.draft))
             {
                 autolabels.push(Label {
                     name: label.to_owned(),

--- a/src/handlers/closed_pr.rs
+++ b/src/handlers/closed_pr.rs
@@ -1,0 +1,44 @@
+use crate::config::ClosedPrConfig;
+use crate::github::{IssuesAction, IssuesEvent, Label};
+use crate::handlers::Context;
+
+pub(crate) struct ClosedPrInput {}
+
+pub(crate) async fn parse_input(
+    _ctx: &Context,
+    event: &IssuesEvent,
+    _config: Option<&ClosedPrConfig>,
+) -> Result<Option<ClosedPrInput>, String> {
+    // PR author requests a review from one of the assignees
+
+    match &event.action {
+        IssuesAction::Closed if event.issue.is_pr() => Ok(Some(ClosedPrInput {})),
+        _ => Ok(None),
+    }
+}
+
+pub(crate) async fn handle_input(
+    ctx: &Context,
+    config: &ClosedPrConfig,
+    event: &IssuesEvent,
+    ClosedPrInput {}: ClosedPrInput,
+) -> anyhow::Result<()> {
+    event
+        .issue
+        .add_labels(
+            &ctx.github,
+            config
+                .add_labels
+                .iter()
+                .cloned()
+                .map(|name| Label { name })
+                .collect(),
+        )
+        .await?;
+
+    for label in &config.remove_labels {
+        event.issue.remove_label(&ctx.github, label).await?;
+    }
+
+    Ok(())
+}

--- a/src/handlers/converted_to_draft.rs
+++ b/src/handlers/converted_to_draft.rs
@@ -1,0 +1,44 @@
+use crate::config::ConvertedToDraftConfig;
+use crate::github::{IssuesAction, IssuesEvent, Label};
+use crate::handlers::Context;
+
+pub(crate) struct ConvertedToDraftInput {}
+
+pub(crate) async fn parse_input(
+    _ctx: &Context,
+    event: &IssuesEvent,
+    _config: Option<&ConvertedToDraftConfig>,
+) -> Result<Option<ConvertedToDraftInput>, String> {
+    // PR author requests a review from one of the assignees
+
+    match &event.action {
+        IssuesAction::ConvertedToDraft => Ok(Some(ConvertedToDraftInput {})),
+        _ => Ok(None),
+    }
+}
+
+pub(crate) async fn handle_input(
+    ctx: &Context,
+    config: &ConvertedToDraftConfig,
+    event: &IssuesEvent,
+    ConvertedToDraftInput {}: ConvertedToDraftInput,
+) -> anyhow::Result<()> {
+    event
+        .issue
+        .add_labels(
+            &ctx.github,
+            config
+                .add_labels
+                .iter()
+                .cloned()
+                .map(|name| Label { name })
+                .collect(),
+        )
+        .await?;
+
+    for label in &config.remove_labels {
+        event.issue.remove_label(&ctx.github, label).await?;
+    }
+
+    Ok(())
+}

--- a/src/handlers/ready_for_review.rs
+++ b/src/handlers/ready_for_review.rs
@@ -1,0 +1,44 @@
+use crate::config::ReadyForReviewConfig;
+use crate::github::{IssuesAction, IssuesEvent, Label};
+use crate::handlers::Context;
+
+pub(crate) struct ReadyForReviewInput {}
+
+pub(crate) async fn parse_input(
+    _ctx: &Context,
+    event: &IssuesEvent,
+    _config: Option<&ReadyForReviewConfig>,
+) -> Result<Option<ReadyForReviewInput>, String> {
+    // PR author requests a review from one of the assignees
+
+    match &event.action {
+        IssuesAction::ReadyForReview => Ok(Some(ReadyForReviewInput {})),
+        _ => Ok(None),
+    }
+}
+
+pub(crate) async fn handle_input(
+    ctx: &Context,
+    config: &ReadyForReviewConfig,
+    event: &IssuesEvent,
+    ReadyForReviewInput {}: ReadyForReviewInput,
+) -> anyhow::Result<()> {
+    event
+        .issue
+        .add_labels(
+            &ctx.github,
+            config
+                .add_labels
+                .iter()
+                .cloned()
+                .map(|name| Label { name })
+                .collect(),
+        )
+        .await?;
+
+    for label in &config.remove_labels {
+        event.issue.remove_label(&ctx.github, label).await?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Adds the following options:

```toml
[autolabel."<label>"]
reopened_pr = true
new_draft_pr = true
reopened_draft_pr = true

[converted-to-draft]
remove_labels = []
add_labels = []

[ready-for-review]
remove_labels = []
add_labels = []

[closed-pr]
remove_labels = []
add_labels = []
```