### PR TITLE
Fix newline in message

### DIFF
--- a/src/handlers/assign.rs
+++ b/src/handlers/assign.rs
@@ -58,7 +58,7 @@ const WELCOME_WITHOUT_REVIEWER: &str = "@Mark-Simulacrum (NB. this repo may be m
 const RETURNING_USER_WELCOME_MESSAGE: &str = "r? @{assignee}
 
 {bot} has assigned @{assignee}.
-They will have a look at your PR within the next two weeks and either review your PR or
+They will have a look at your PR within the next two weeks and either review your PR or \
 reassign to another reviewer.
 
 Use r? to explicitly pick a reviewer";


### PR DESCRIPTION
The hard newline renders badly and wasn't intended anyway. Follow up to https://github.com/rust-lang/triagebot/pull/1769