### PR TITLE
Remove redundant imports

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -9,7 +9,6 @@ use regex::Regex;
 use reqwest::header::{AUTHORIZATION, USER_AGENT};
 use reqwest::{Client, Request, RequestBuilder, Response, StatusCode};
 use std::collections::{HashMap, HashSet};
-use std::convert::TryInto;
 use std::{
     fmt,
     time::{Duration, SystemTime},

--- a/src/handlers/assign/tests/tests_from_diff.rs
+++ b/src/handlers/assign/tests/tests_from_diff.rs
@@ -1,7 +1,6 @@
 //! Tests for `find_reviewers_from_diff`
 
 use super::super::*;
-use crate::config::AssignConfig;
 use crate::github::parse_diff;
 use std::fmt::Write;
 

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -11,7 +11,6 @@ use crate::{
 };
 use anyhow::Context as _;
 use std::collections::HashSet;
-use std::convert::TryInto;
 use tracing as log;
 
 pub async fn handle(ctx: &Context, event: &Event) -> anyhow::Result<()> {

--- a/src/handlers/rustc_commits.rs
+++ b/src/handlers/rustc_commits.rs
@@ -7,7 +7,6 @@ use crate::{
 };
 use async_trait::async_trait;
 use std::collections::VecDeque;
-use std::convert::TryInto;
 use tracing as log;
 
 const BORS_GH_ID: u64 = 3372342;

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -5,7 +5,6 @@ use crate::handlers::docs_update::docs_update;
 use crate::handlers::pull_requests_assignment_update::get_review_prefs;
 use crate::handlers::Context;
 use anyhow::{format_err, Context as _};
-use std::convert::TryInto;
 use std::env;
 use std::fmt::Write as _;
 use tracing as log;


### PR DESCRIPTION
A recent release of nightly has started warning about redundant imports. This removes that warning.
