### PR TITLE
Add an issue transfer command

### DIFF
--- a/parser/src/command.rs
+++ b/parser/src/command.rs
@@ -13,6 +13,7 @@ pub mod prioritize;
 pub mod relabel;
 pub mod second;
 pub mod shortcut;
+pub mod transfer;
 
 #[derive(Debug, PartialEq)]
 pub enum Command<'a> {
@@ -26,6 +27,7 @@ pub enum Command<'a> {
     Shortcut(Result<shortcut::ShortcutCommand, Error<'a>>),
     Close(Result<close::CloseCommand, Error<'a>>),
     Note(Result<note::NoteCommand, Error<'a>>),
+    Transfer(Result<transfer::TransferCommand, Error<'a>>),
 }
 
 #[derive(Debug)]
@@ -132,6 +134,11 @@ impl<'a> Input<'a> {
             Command::Close,
             &original_tokenizer,
         ));
+        success.extend(parse_single_command(
+            transfer::TransferCommand::parse,
+            Command::Transfer,
+            &original_tokenizer,
+        ));
 
         if success.len() > 1 {
             panic!(
@@ -207,6 +214,7 @@ impl<'a> Command<'a> {
             Command::Shortcut(r) => r.is_ok(),
             Command::Close(r) => r.is_ok(),
             Command::Note(r) => r.is_ok(),
+            Command::Transfer(r) => r.is_ok(),
         }
     }
 

--- a/parser/src/command/transfer.rs
+++ b/parser/src/command/transfer.rs
@@ -1,0 +1,38 @@
+//! Parses the `@bot transfer reponame` command.
+
+use crate::error::Error;
+use crate::token::{Token, Tokenizer};
+use std::fmt;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct TransferCommand(pub String);
+
+#[derive(Debug)]
+pub enum ParseError {
+    MissingRepo,
+}
+
+impl std::error::Error for ParseError {}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ParseError::MissingRepo => write!(f, "missing repository name"),
+        }
+    }
+}
+
+impl TransferCommand {
+    pub fn parse<'a>(input: &mut Tokenizer<'a>) -> Result<Option<Self>, Error<'a>> {
+        if !matches!(input.peek_token()?, Some(Token::Word("transfer"))) {
+            return Ok(None);
+        }
+        input.next_token()?;
+        let repo = if let Some(Token::Word(repo)) = input.next_token()? {
+            repo.to_owned()
+        } else {
+            return Err(input.error(ParseError::MissingRepo));
+        };
+        Ok(Some(TransferCommand(repo)))
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,6 +44,7 @@ pub(crate) struct Config {
     #[serde(default = "ValidateConfig::default")]
     pub(crate) validate_config: Option<ValidateConfig>,
     pub(crate) pr_tracking: Option<ReviewPrefsConfig>,
+    pub(crate) transfer: Option<TransferConfig>,
 }
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]
@@ -344,6 +345,11 @@ pub(crate) struct ReviewPrefsConfig {
     _empty: (),
 }
 
+#[derive(PartialEq, Eq, Debug, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TransferConfig {}
+
 fn get_cached_config(repo: &str) -> Option<Result<Arc<Config>, ConfigurationError>> {
     let cache = CONFIG_CACHE.read().unwrap();
     cache.get(repo).and_then(|(config, fetch_time)| {
@@ -520,6 +526,7 @@ mod tests {
                 no_merges: None,
                 validate_config: Some(ValidateConfig {}),
                 pr_tracking: None,
+                transfer: None,
             }
         );
     }

--- a/src/github.rs
+++ b/src/github.rs
@@ -2203,11 +2203,17 @@ impl GithubClient {
     }
 
     /// Issues an ad-hoc GraphQL query.
-    pub async fn graphql_query<T: serde::de::DeserializeOwned>(
+    ///
+    /// You are responsible for checking the `errors` array when calling this
+    /// function to determine if there is an error. Only use this if you are
+    /// looking for specific error codes, or don't care about errors. Use
+    /// [`GithubClient::graphql_query`] if you would prefer to have a generic
+    /// error message.
+    pub async fn graphql_query_with_errors(
         &self,
         query: &str,
         vars: serde_json::Value,
-    ) -> anyhow::Result<T> {
+    ) -> anyhow::Result<serde_json::Value> {
         self.json(self.post(&self.graphql_url).json(&serde_json::json!({
             "query": query,
             "variables": vars,
@@ -2215,12 +2221,32 @@ impl GithubClient {
         .await
     }
 
+    /// Issues an ad-hoc GraphQL query.
+    ///
+    /// See [`GithubClient::graphql_query_with_errors`] if you need to check
+    /// for specific errors.
+    pub async fn graphql_query(
+        &self,
+        query: &str,
+        vars: serde_json::Value,
+    ) -> anyhow::Result<serde_json::Value> {
+        let result: serde_json::Value = self.graphql_query_with_errors(query, vars).await?;
+        if let Some(errors) = result["errors"].as_array() {
+            let messages: Vec<_> = errors
+                .iter()
+                .map(|err| err["message"].as_str().unwrap_or_default())
+                .collect();
+            anyhow::bail!("error: {}", messages.join("\n"));
+        }
+        Ok(result)
+    }
+
     /// Returns the object ID of the given user.
     ///
     /// Returns `None` if the user doesn't exist.
     pub async fn user_object_id(&self, user: &str) -> anyhow::Result<Option<String>> {
         let user_info: serde_json::Value = self
-            .graphql_query(
+            .graphql_query_with_errors(
                 "query($user:String!) {
                     user(login:$user) {
                         id
@@ -2273,7 +2299,7 @@ impl GithubClient {
         // work on forks. This GraphQL query seems to work fairly reliably,
         // and seems to cost only 1 point.
         match self
-            .graphql_query::<serde_json::Value>(
+            .graphql_query_with_errors(
                 "query($repository_owner:String!, $repository_name:String!, $user_id:ID!) {
                         repository(owner: $repository_owner, name: $repository_name) {
                             defaultBranchRef {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -47,6 +47,7 @@ mod review_submitted;
 mod rfc_helper;
 pub mod rustc_commits;
 mod shortcut;
+mod transfer;
 pub mod types_planning_updates;
 mod validate_config;
 
@@ -292,6 +293,7 @@ command_handlers! {
     shortcut: Shortcut,
     close: Close,
     note: Note,
+    transfer: Transfer,
 }
 
 pub struct Context {

--- a/src/handlers/transfer.rs
+++ b/src/handlers/transfer.rs
@@ -1,0 +1,53 @@
+//! Handles the `@rustbot transfer reponame` command to transfer an issue to
+//! another repository.
+
+use crate::{config::TransferConfig, github::Event, handlers::Context};
+use parser::command::transfer::TransferCommand;
+
+pub(super) async fn handle_command(
+    ctx: &Context,
+    _config: &TransferConfig,
+    event: &Event,
+    input: TransferCommand,
+) -> anyhow::Result<()> {
+    let issue = event.issue().unwrap();
+    if issue.is_pr() {
+        issue
+            .post_comment(&ctx.github, "Only issues can be transferred.")
+            .await?;
+        return Ok(());
+    }
+    if !event
+        .user()
+        .is_team_member(&ctx.github)
+        .await
+        .ok()
+        .unwrap_or(false)
+    {
+        issue
+            .post_comment(
+                &ctx.github,
+                "Only team members may use the `transfer` command.",
+            )
+            .await?;
+        return Ok(());
+    }
+
+    let repo = input.0;
+    let repo = repo.strip_prefix("rust-lang/").unwrap_or(&repo);
+    if repo.contains('/') {
+        issue
+            .post_comment(&ctx.github, "Cross-organization transfers are not allowed.")
+            .await?;
+        return Ok(());
+    }
+
+    if let Err(e) = issue.transfer(&ctx.github, "rust-lang", &repo).await {
+        issue
+            .post_comment(&ctx.github, &format!("Failed to transfer issue:\n{e:?}"))
+            .await?;
+        return Ok(());
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This adds a command to transfer an issue from one repository to another. People occasionally file issues in the wrong repo, and it is convenient to transfer them. Unfortunately you need write access to *both* repositories to transfer. Often that isn't the case (like transferring between cargo and clippy or vice-versa). 

The command is `@rustbot transfer reponame`. The source repository needs a `[transfer]` table to enable the feature. 

It is restricted to any team member. I'm not sure if that's the right balance of permissions, but I think it is a good starting place, since this is a fairly destructive command.

Unfortunately due to the way the API works, there is no visual indication that the issue has transferred (unlike the Web UI button, which shows a big notice). I think we'll just need to emphasize in the documentation that after the running the command you need to manually reload the page to view it in the new location.

Closes #166