### PR TITLE
Regroup FCPs in T-compiler triage agenda

### DIFF
--- a/src/agenda.rs
+++ b/src/agenda.rs
@@ -108,7 +108,7 @@ pub fn prioritization<'a>() -> Box<dyn Action> {
                         }),
                     },
                     QueryMap {
-                        name: "fcp_finished",
+                        name: "fcp_finished_tcompiler",
                         kind: QueryKind::List,
                         query: Arc::new(github::Query {
                             filters: vec![("state", "all")],
@@ -117,7 +117,26 @@ pub fn prioritization<'a>() -> Box<dyn Action> {
                                 "disposition-merge",
                                 "to-announce",
                             ],
-                            exclude_labels: vec!["t-libs", "t-libs-api", "t-rustdoc"],
+                            exclude_labels: vec![
+                                "t-libs",
+                                "t-libs-api",
+                                "t-rustdoc",
+                                "t-lang",
+                                "t-style",
+                            ],
+                        }),
+                    },
+                    QueryMap {
+                        name: "fcp_finished_not_tcompiler",
+                        kind: QueryKind::List,
+                        query: Arc::new(github::Query {
+                            filters: vec![("state", "all")],
+                            include_labels: vec![
+                                "finished-final-comment-period",
+                                "disposition-merge",
+                                "to-announce",
+                            ],
+                            exclude_labels: vec!["t-libs", "t-libs-api", "t-rustdoc", "t-compiler"],
                         }),
                     },
                 ],

--- a/templates/prioritization_agenda.tt
+++ b/templates/prioritization_agenda.tt
@@ -33,8 +33,12 @@ note_id: xxx
 {{-issues::render(issues=in_fcp, indent="  ", empty="No FCP requests this time.")}}
 - Accepted MCPs
 {{-issues::render(issues=mcp_accepted, indent="  ", empty="No new accepted proposals this time.")}}
+- MCPs blocked on unresolved concerns
+  - <Here group MCPs blocked on unresolved concerns>
 - Finalized FCPs (disposition merge)
-{{-issues::render(issues=fcp_finished, indent="  ", empty="No new finished FCP (disposition merge) this time.")}}
+{{-issues::render(issues=fcp_finished_tcompiler, indent="  ", empty="No new finished FCP (disposition merge) this time.")}}
+- Other teams finalized FCPs
+{{-issues::render(issues=fcp_finished_not_tcompiler, indent="  ", empty="No new finished FCP (disposition merge) this time.")}}
 
 ### WG checkins
 
@@ -86,7 +90,7 @@ don't know
 
 [T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
 {{-issues::render(issues=prs_waiting_on_team_t_compiler, empty="No PRs waiting on `T-compiler` this time.")}}
-- Other issues [in progress or waiting on other teams](https://hackmd.io/XYr1BrOWSiqCrl8RCWXRaQ)
+- [Issues in progress or waiting on other teams](https://hackmd.io/XYr1BrOWSiqCrl8RCWXRaQ)
 
 ## Issues of Note
 


### PR DESCRIPTION
Mentioned in a [past T-compiler meeting](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202024-02-08/near/420477380). We are splitting the FCPs from other team (mentioned in the triage agenda as a FIY) in a separate group to not clutter those that are instead waiting on T-compiler

r? @jackh726 