### PR TITLE
Quote review suggestions in comments

### DIFF
--- a/src/handlers/assign.rs
+++ b/src/handlers/assign.rs
@@ -61,10 +61,10 @@ const RETURNING_USER_WELCOME_MESSAGE: &str = "r? @{assignee}
 They will have a look at your PR within the next two weeks and either review your PR or \
 reassign to another reviewer.
 
-Use r? to explicitly pick a reviewer";
+Use `r?` to explicitly pick a reviewer";
 
 const RETURNING_USER_WELCOME_MESSAGE_NO_REVIEWER: &str =
-    "@{author}: no appropriate reviewer found, use r? to override";
+    "@{author}: no appropriate reviewer found, use `r?` to override";
 
 const ON_VACATION_WARNING: &str = "{username} is on vacation. Please do not assign them to PRs.";
 
@@ -642,7 +642,7 @@ impl fmt::Display for FindReviewerError {
                     f,
                     "No reviewers could be found from initial request `{}`\n\
                      This repo may be misconfigured.\n\
-                     Use r? to specify someone else to assign.",
+                     Use `r?` to specify someone else to assign.",
                     initial.join(",")
                 )
             }
@@ -652,7 +652,7 @@ impl fmt::Display for FindReviewerError {
                     "Could not assign reviewer from: `{}`.\n\
                      User(s) `{}` are either the PR author, already assigned, or on vacation, \
                      and there are no other candidates.\n\
-                     Use r? to specify someone else to assign.",
+                     Use `r?` to specify someone else to assign.",
                     initial.join(","),
                     filtered.join(","),
                 )


### PR DESCRIPTION
This looks like an innocent cosmetic change now but it become critical when we will implement the new review assignment.

In case a pull request review cannot be assigned (for any reason), the triagebot will post a comment on GitHub. The text of the comment does not quote correctly the "r?" wording, example "Use r? to specify someone else to assign.".

That could trigger an infinite loop where the words "r? to" are interpreted by the triagebot receiving the webhook after posting that command.

Quoting with markdown will prevent this loop.

I am not sure this patch solves 100% of the all cases but it should cover most of them.

r? @jackh726 