### PR TITLE
Use rfcbot style for FCPs in the prioritization agenda

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -74,6 +74,7 @@ pub struct FCPDetails {
     pub initiating_comment_html_url: String,
     pub initiating_comment_content: String,
     pub disposition: String,
+    pub should_mention: bool,
     pub pending_reviewers: Vec<FCPReviewerDetails>,
     pub concerns: Vec<FCPConcernDetails>,
 }

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -9,7 +9,6 @@ use tera::{Context, Tera};
 use crate::{
     github::{self, GithubClient, Repository},
     http_client::{CompilerMeeting, HttpClient},
-    rfcbot,
 };
 
 #[async_trait]
@@ -63,13 +62,19 @@ pub struct FCPConcernDetails {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+pub struct FCPReviewerDetails {
+    pub github_login: String,
+    pub zulip_id: Option<u64>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 pub struct FCPDetails {
     pub bot_tracking_comment_html_url: String,
     pub bot_tracking_comment_content: String,
     pub initiating_comment_html_url: String,
     pub initiating_comment_content: String,
     pub disposition: String,
-    pub pending_reviewers: Vec<rfcbot::Reviewer>,
+    pub pending_reviewers: Vec<FCPReviewerDetails>,
     pub concerns: Vec<FCPConcernDetails>,
 }
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -1755,18 +1755,9 @@ impl<'q> IssuesQuery for Query<'q> {
                         .get_comment(&client, fk_initiating_comment.try_into()?)
                         .await?;
 
-                    // To avoid constant (and counter-productive) pings we will only ping when
-                    //  - we are 2 weeks into the FCP
-                    //  - or when there are no concerns and we are at least 4 weeks into the FCP.
-                    //
-                    // FIXME: This should get T-compiler approval before being enabled by default
-                    let should_mention = std::env::var("TRIAGEBOT_COMPILER_MENTION").is_ok() && {
-                        let now = chrono::offset::Utc::now();
-                        let time_diff = now - init_comment.created_at;
-                        time_diff.num_weeks() == 2
-                            || (time_diff.num_weeks() >= 4 && fcp.concerns.is_empty())
-                    };
-
+                    // TODO: agree with the team(s) a policy to emit actual mentions to remind FCP
+                    // voting member to cast their vote
+                    let should_mention = false;
                     Some(crate::actions::FCPDetails {
                         bot_tracking_comment_html_url,
                         bot_tracking_comment_content,

--- a/src/rfcbot.rs
+++ b/src/rfcbot.rs
@@ -15,7 +15,7 @@ pub struct FCP {
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Reviewer {
-    pub id: u32,
+    pub id: u64,
     pub login: String,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/rfcbot.rs
+++ b/src/rfcbot.rs
@@ -24,10 +24,16 @@ pub struct Review {
     pub approved: bool,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Concern {
+    pub name: String,
+    pub comment: StatusComment,
+    pub reviewer: Reviewer,
+}
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct FCPIssue {
     pub id: u32,
     pub number: u32,
-    pub fk_milestone: Option<String>,
+    pub fk_milestone: Option<u32>,
     pub fk_user: u32,
     pub fk_assignee: Option<u32>,
     pub open: bool,
@@ -57,6 +63,7 @@ pub struct StatusComment {
 pub struct FullFCP {
     pub fcp: FCP,
     pub reviews: Vec<Review>,
+    pub concerns: Vec<Concern>,
     pub issue: FCPIssue,
     pub status_comment: StatusComment,
 }

--- a/templates/_issues_rfcbot.tt
+++ b/templates/_issues_rfcbot.tt
@@ -5,7 +5,7 @@
 {%- if issue.fcp_details is object %}
 {{indent}}- {{issue.fcp_details.disposition}}: [{{issue.title}} ({{issue.repo_name}}#{{issue.number}})]({{issue.fcp_details.bot_tracking_comment_html_url}})
 {{indent}}{{indent}}-{% for reviewer in issue.fcp_details.pending_reviewers %} @{% if issue.fcp_details.should_mention %}{% else %}_{% endif %}**|{{reviewer.zulip_id}}**{%else%} no pending checkboxs{% endfor %}
-{{indent}}{{indent}}-{% for concern in issue.fcp_details.concerns %} [{{concern.name}} (by {{concern.reviewer_login}})]({{concern.concern_url}}){%else%} no pending concerns{% endfor -%}
+{{indent}}{{indent}}-{% if issue.fcp_details.concerns|length > 0 %} concerns:{% endif %}{% for concern in issue.fcp_details.concerns %} [{{concern.name}} (by {{concern.reviewer_login}})]({{concern.concern_url}}){%else%} no pending concerns{% endfor -%}
 {% else %}
 {{indent}}- {{issue::render(issue=issue)}}
 {%- endif -%}

--- a/templates/_issues_rfcbot.tt
+++ b/templates/_issues_rfcbot.tt
@@ -4,7 +4,7 @@
 {%- for issue in issues %}
 {%- if issue.fcp_details is object %}
 {{indent}}- {{issue.fcp_details.disposition}}: [{{issue.title}} ({{issue.repo_name}}#{{issue.number}})]({{issue.fcp_details.bot_tracking_comment_html_url}})
-{{indent}}{{indent}}-{% for reviewer in issue.fcp_details.pending_reviewers %} @**{{reviewer.login}}**{%else%} no pending checkboxs{% endfor %}
+{{indent}}{{indent}}-{% for reviewer in issue.fcp_details.pending_reviewers %} @**|{{reviewer.zulip_id}}**{%else%} no pending checkboxs{% endfor %}
 {{indent}}{{indent}}-{% for concern in issue.fcp_details.concerns %} [{{concern.name}} (by {{concern.reviewer_login}})]({{concern.concern_url}}){%else%} no pending concerns{% endfor -%}
 {% else %}
 {{indent}}- "{{issue.title}}" {{issue.repo_name}}#{{issue.number}}

--- a/templates/_issues_rfcbot.tt
+++ b/templates/_issues_rfcbot.tt
@@ -7,8 +7,8 @@
 {{indent}}{{indent}}-{% for reviewer in issue.fcp_details.pending_reviewers %} @{% if issue.fcp_details.should_mention %}{% else %}_{% endif %}**|{{reviewer.zulip_id}}**{%else%} no pending checkboxs{% endfor %}
 {{indent}}{{indent}}-{% for concern in issue.fcp_details.concerns %} [{{concern.name}} (by {{concern.reviewer_login}})]({{concern.concern_url}}){%else%} no pending concerns{% endfor -%}
 {% else %}
-{{indent}}- "{{issue.title}}" {{issue.repo_name}}#{{issue.number}}
-{%endif-%}
+{{indent}}- {{issue::render(issue=issue)}}
+{%- endif -%}
 {%else%}
 {{empty}}
 {%endfor-%}

--- a/templates/_issues_rfcbot.tt
+++ b/templates/_issues_rfcbot.tt
@@ -1,0 +1,15 @@
+{% import "_issue.tt" as issue %}
+
+{% macro render(issues, indent="", empty="None.") %}
+{%- for issue in issues %}
+{%- if issue.fcp_details is object %}
+{{indent}}- {{issue.fcp_details.disposition}}: [{{issue.title}} ({{issue.repo_name}}#{{issue.number}})]({{issue.fcp_details.bot_tracking_comment_html_url}})
+{{indent}}{{indent}}-{% for reviewer in issue.fcp_details.pending_reviewers %} @**{{reviewer.login}}**{%else%} no pending checkboxs{% endfor %}
+{{indent}}{{indent}}-{% for concern in issue.fcp_details.concerns %} [{{concern.name}} (by {{concern.reviewer_login}})]({{concern.concern_url}}){%else%} no pending concerns{% endfor -%}
+{% else %}
+{{indent}}- "{{issue.title}}" {{issue.repo_name}}#{{issue.number}}
+{%endif-%}
+{%else%}
+{{empty}}
+{%endfor-%}
+{% endmacro %}

--- a/templates/_issues_rfcbot.tt
+++ b/templates/_issues_rfcbot.tt
@@ -4,7 +4,7 @@
 {%- for issue in issues %}
 {%- if issue.fcp_details is object %}
 {{indent}}- {{issue.fcp_details.disposition}}: [{{issue.title}} ({{issue.repo_name}}#{{issue.number}})]({{issue.fcp_details.bot_tracking_comment_html_url}})
-{{indent}}{{indent}}-{% for reviewer in issue.fcp_details.pending_reviewers %} @**|{{reviewer.zulip_id}}**{%else%} no pending checkboxs{% endfor %}
+{{indent}}{{indent}}-{% for reviewer in issue.fcp_details.pending_reviewers %} @{% if issue.fcp_details.should_mention %}{% else %}_{% endif %}**|{{reviewer.zulip_id}}**{%else%} no pending checkboxs{% endfor %}
 {{indent}}{{indent}}-{% for concern in issue.fcp_details.concerns %} [{{concern.name}} (by {{concern.reviewer_login}})]({{concern.concern_url}}){%else%} no pending concerns{% endfor -%}
 {% else %}
 {{indent}}- "{{issue.title}}" {{issue.repo_name}}#{{issue.number}}

--- a/templates/prioritization_agenda.tt
+++ b/templates/prioritization_agenda.tt
@@ -1,5 +1,6 @@
 {% import "_issues.tt" as issues %}
 {% import "_meetings.tt" as meetings %}
+{% import "_issues_rfcbot.tt" as issues_rfcbot %}
 
 ---
 tags: weekly, rustc
@@ -28,9 +29,9 @@ note_id: xxx
 - Old MCPs (not seconded, take a look)
 {{-issues::render(issues=mcp_old_not_seconded, indent="  ", with_age=true, empty="No old proposals this time.")}}
 - Pending FCP requests (check your boxes!)
-{{-issues::render(issues=in_pre_fcp, indent="  ", empty="No pending FCP requests this time.")}}
+{{-issues_rfcbot::render(issues=in_pre_fcp, indent="  ", empty="No pending FCP requests this time.")}}
 - Things in FCP (make sure you're good with it)
-{{-issues::render(issues=in_fcp, indent="  ", empty="No FCP requests this time.")}}
+{{-issues_rfcbot::render(issues=in_fcp, indent="  ", empty="No FCP requests this time.")}}
 - Accepted MCPs
 {{-issues::render(issues=mcp_accepted, indent="  ", empty="No new accepted proposals this time.")}}
 - MCPs blocked on unresolved concerns


### PR DESCRIPTION
This PR add the necessary information to replicate the rfcbot style when showing FCPs and uses it in the prioritization agenda.

~~One thing at isn't perfect is that we are using the Github login and not the Zulip login, using the Zulip username would require accessing the team database which I didn't wanted to do yet but could be done as a follow up PR.~~ (fixed, https://github.com/rust-lang/triagebot/pull/1784#issuecomment-2016833448)

r? @apiraino 
 
--------

They would now look like this (modulo the mentions). ~~Full example [here](https://hackmd.io/@Urgau/rytauC3Aa).~~

- merge: [Add a new `--build-id` flag to rustc (compiler-team#635)](https://github.com/rust-lang/compiler-team/issues/635#issuecomment-1777545767)
    * `@wesleywiser` `@davidtwco` `@Aaron1011` `@petrochenkov`
    * [other-existing-options (by petrochenkov)](https://github.com/rust-lang/compiler-team/issues/635#issuecomment-1779597156) [option-name (by wesleywiser)](https://github.com/rust-lang/compiler-team/issues/635#issuecomment-1785349936)
- merge: [Retire the mailing list and make all decisions on zulip (compiler-team#649)](https://github.com/rust-lang/compiler-team/issues/649#issuecomment-1618781780)
    * no pending checkboxs
    * [automatic-sync (by compiler-errors)](https://github.com/rust-lang/compiler-team/issues/649#issuecomment-1618902660) [single-point-of-failure-via-stream-archival (by pnkfelix)](https://github.com/rust-lang/compiler-team/issues/649#issuecomment-1664056989) 