### PR TITLE
Add max assigned prs field

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -335,4 +335,5 @@ CREATE table review_prefs (
 CREATE EXTENSION intarray;
 CREATE UNIQUE INDEX review_prefs_user_id ON review_prefs(user_id);
  ",
+    "ALTER TABLE review_prefs ADD COLUMN max_assigned_prs INTEGER DEFAULT NULL;",
 ];

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -280,7 +280,7 @@ macro_rules! command_handlers {
 //
 // This is for handlers for commands parsed by the `parser` crate.
 // Each variant of `parser::command::Command` must be in this list,
-// preceded by the module containing the coresponding `handle_command` function
+// preceded by the module containing the corresponding `handle_command` function
 command_handlers! {
     assign: Assign,
     glacier: Glacier,


### PR DESCRIPTION
### TODO

- [ ] Test all possible ways to assign/unassign a PR
  - `@rustbot claim`
  - `r? <user>`
  - `r? <team>`
  - Click the assignment widget and **assign to** <user>
  - Click the assignment widget and **unassign from** <user>
- [ ] Test that the max # of assigned PRs is respected