### PR TITLE
Handle when user has no PR prefs set

### DIFF
--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -214,7 +214,13 @@ async fn query_pr_assignments(
     let db_client = ctx.db.get().await;
 
     let record = match subcommand {
-        "show" => get_review_prefs(&db_client, gh_id).await?,
+        "show" => {
+            let rec = get_review_prefs(&db_client, gh_id).await;
+            if rec.is_err() {
+                anyhow::bail!("No preferences set.")
+            }
+            rec?
+        }
         _ => anyhow::bail!("Invalid subcommand."),
     };
 


### PR DESCRIPTION
Should close #1787 

I am not 100% sure but by looking at where the callsite `unwrap()`s I think I had just forgot to handle the case when a user has no preferences set for the PR review assignment.

r? @Mark-Simulacrum 