### PR TITLE
Allow a single notify-zulip notification to send multiple Zulip messages

### DIFF
--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -337,7 +337,7 @@ pub struct Member {
     pub user_id: u64,
 }
 
-#[derive(serde::Serialize)]
+#[derive(Copy, Clone, serde::Serialize)]
 #[serde(tag = "type")]
 #[serde(rename_all = "snake_case")]
 pub enum Recipient<'a> {


### PR DESCRIPTION
This would unblock rust-lang/rust#116957:

**Hard Requirements**:

We would like to

1. **ping** the rustdoc team (via `@*T-rustdoc*`),
2. **link** to the nominated PR (via the short link `#NNN`),
3. create a Zulip **poll**.

**Problems**:

* Unfortunately, neither pings nor short links inside the “question” (title) of a poll get recognized by Zulip.
  Example: [Here](https://rust-lang.zulipchat.com/#narrow/stream/266220-t-rustdoc/topic/Nominate.20.23123905.20for.20beta/near/433147678), you can see that neither `@*T-rustdoc*` nor `#123905` got autolinked.
* Furthermore, it's not possible to sidestep the issue above by moving the ping and the PR ref “out of” the poll and into a separate — preceding — paragraph. If we tried that, Zulip would not detect the poll. This seems to be a known limitation: [Create a poll | Zulip help center § Troubleshooting \[archive link\]](https://web.archive.org/web/20231102162048/https://zulip.com/help/create-a-poll#troubleshooting) ([the live site](https://zulip.com/help/create-a-poll) no longer mentions this explicitly, only implicitly).

**Solution**:

Send two separate Zulip messages. This requires modifications to **triagebot**.

---

This PR enables users to specify a *sequence* of strings for the fields `notify-zulip.⟨label⟩.message_on_⟨add|remove|close|reopen⟩` in order to make triagebot post a sequence of Zulip messages. For backward compatibility, you can still specify a single string. I haven't renamed any of the fields (like `message_on_$` to `messages_on_$`) to avoid churn. A bare string gets treated as a sequence of length 1 containing that very string.

In TypeScript syntax, I've relaxed the type of the optional (!) fields `message_on_$` from `string | null` to `string | string[] | null`.

---

r? @Mark-Simulacrum or infra