### PR TITLE
Limit validate_config actions.

### DIFF
--- a/src/handlers/validate_config.rs
+++ b/src/handlers/validate_config.rs
@@ -4,6 +4,7 @@
 
 use crate::{
     config::{ValidateConfig, CONFIG_FILE_NAME},
+    github::IssuesAction,
     handlers::{Context, IssuesEvent},
 };
 use tracing as log;
@@ -13,6 +14,12 @@ pub(super) async fn parse_input(
     event: &IssuesEvent,
     _config: Option<&ValidateConfig>,
 ) -> Result<Option<()>, String> {
+    if !matches!(
+        event.action,
+        IssuesAction::Opened | IssuesAction::Reopened | IssuesAction::Synchronize
+    ) {
+        return Ok(None);
+    }
     // All processing needs to be done in parse_input (instead of
     // handle_input) because we want this to *always* run. handle_input
     // requires the config to exist in triagebot.toml, but we want this to run


### PR DESCRIPTION
This limits which actions the validate_config handler will handle. There was a problem where it was validating the config on every action. This means that if there is an invalid config, and *any* action was performed on the PR (like adding a label, or assigning someone), it would post a comment about the invalid config.

This is particularly a problem with old closed PRs that modified `triagebot.toml`. Minor actions like adding milestones or labels shouldn't re-trigger validation.

Fixes https://github.com/rust-lang/triagebot/issues/1802
