### PR TITLE
Revert "Use a safer command for rebase"

### DIFF
--- a/src/handlers/no_merges.rs
+++ b/src/handlers/no_merges.rs
@@ -88,7 +88,7 @@ so these commits will need to be removed for this pull request to be merged.
 You can start a rebase with the following commands:
 ```shell-session
 $ # rebase
-$ git pull --rebase https://github.com/rust-lang/rust.git master
+$ git rebase -i master
 $ # delete any merge commits in the editor that appears
 $ git push --force-with-lease
 ```
@@ -228,7 +228,7 @@ There are merge commits (commits with multiple parents) in your changes. We have
 You can start a rebase with the following commands:
 ```shell-session
 $ # rebase
-$ git pull --rebase https://github.com/rust-lang/rust.git master
+$ git rebase -i master
 $ # delete any merge commits in the editor that appears
 $ git push --force-with-lease
 ```


### PR DESCRIPTION
Reverts rust-lang/triagebot#1808. As found by RalfJ, we cannot hardcore this message for a specific repository :man_facepalming: A silly mistake on my part.