### PR TITLE
Log more information about why commits_in_range isn't working.

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -1331,6 +1331,19 @@ impl Repository {
                 .json(client.get(&url))
                 .await
                 .with_context(|| format!("failed to fetch commits for {url}"))?;
+            // This is a temporary debugging measure to investigate why the
+            // `/commits` endpoint is not returning the expected values in
+            // production.
+            let v: String = this_page
+                .iter()
+                .map(|commit| {
+                    format!(
+                        "({}, {}, {:?}) ",
+                        commit.sha, commit.commit.author.date, commit.parents
+                    )
+                })
+                .collect();
+            log::info!("page {page}: {v}");
             if let Some(idx) = this_page.iter().position(|commit| commit.sha == start) {
                 this_page.truncate(idx);
                 commits.extend(this_page);


### PR DESCRIPTION
This is a followup to https://github.com/rust-lang/triagebot/pull/1801 to further investigate why it is not working correctly. From what I can tell, the `/commits` endpoint seems to be returning results out of order. I'm expecting them to be in commit order, but that doesn't seem to be the case (but I still can't reproduce locally). This adds a log message to help me confirm that theory. If that is the case, I will likely need to add something that traverses the parent commits to get the correct set of commits, or perhaps consider using the GraphQL endpoint which might be more reliable.
