### PR TITLE
Adjust GitHub rate limiting behavior.

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -108,7 +108,8 @@ pub fn to_human(d: DateTime<Utc>) -> String {
 #[async_trait]
 impl<'a> Action for Step<'a> {
     async fn call(&self) -> anyhow::Result<String> {
-        let gh = GithubClient::new_from_env();
+        let mut gh = GithubClient::new_from_env();
+        gh.set_retry_rate_limit(true);
 
         let mut context = Context::new();
         let mut results = HashMap::new();


### PR DESCRIPTION
This introduces two changes around GitHub rate limiting:

- Retries are only performed with 403 or 429 responses. GitHub's docs state that rate-limits will only return those responses. Previously, the client would retry *any* non-successful request (like a 404), which was frequently causing several needless requests to GitHub.
- Disable retries on the server. Since a rate-limit retry could take several minutes, that would almost certainly mean it would get cancelled due to the 10 second webhook rate limit. I don't think the other endpoints really need it either (a retry can sleep for a very long time). It is still enabled for the prioritization CLI tool.

