### PR TITLE
Guard against overflowing GitHub ID comments

### DIFF
--- a/src/rfcbot.rs
+++ b/src/rfcbot.rs
@@ -7,9 +7,9 @@ pub struct FCP {
     pub id: u32,
     pub fk_issue: u32,
     pub fk_initiator: u32,
-    pub fk_initiating_comment: u32,
+    pub fk_initiating_comment: i32,
     pub disposition: Option<String>,
-    pub fk_bot_tracking_comment: u32,
+    pub fk_bot_tracking_comment: i32,
     pub fcp_start: Option<String>,
     pub fcp_closed: bool,
 }
@@ -50,7 +50,7 @@ pub struct FCPIssue {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct StatusComment {
-    pub id: u64,
+    pub id: i32,
     pub fk_issue: u32,
     pub fk_user: u32,
     pub body: String,


### PR DESCRIPTION
Recently we overflowed the ID counter for comments on GitHub.

This causes some comment IDs from this URL https://rfcbot.rs/api/all to be negative numbers.

This patch is a follow-up to this commit https://github.com/rust-lang/rfcbot-rs/commit/f9d84fa85b54296896bcbb2cf04049f783912ea6 to avoid some tooling (notably meetings agenda generators) crashing when retrieving comments with invalid IDs. It will not retrieve a comment that has an invalid ID (e.g. `-2132153390`) 

More info about this incident at: https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/rfcbot.20asleep/near/442898636

cc: @traviscross (we discussed this)

r? @jackh726 (thanks!)