### PR TITLE
Use a transaction when applying migrations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -243,7 +243,7 @@ async fn serve_req(
 
 async fn run_server(addr: SocketAddr) -> anyhow::Result<()> {
     let pool = db::ClientPool::new();
-    db::run_migrations(&*pool.get().await)
+    db::run_migrations(&mut *pool.get().await)
         .await
         .context("database migrations")?;
 


### PR DESCRIPTION
Recently, migrations in triagebot have been causing some issues. When I checked the code I noticed that transactions weren't used, which caused two issues:
1) The migration command could have succeeded partially. In one PR, the command contained several SQL queries, where the first one has succeeded, and the rest of them didn't (in fact they could not succeed, because multiple statements are not supported in a single call to `execute`). This would be rolled back if it was wrapped in a transaction.
2) It was possible that a migration has happened, but the ID wasn't updated in the DB, for some reason.

This PR wraps each migration in a separate transaction.

CC @apiraino