### PR TITLE
Initial implementation of relnotes handler

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -180,7 +180,8 @@ impl GithubClient {
             body: &'a str,
             labels: Vec<String>,
         }
-        self.json(self.client.post(repo.url(&self)).json(&NewIssue {
+        let url = format!("{}/issues", repo.url(&self));
+        self.json(self.post(&url).json(&NewIssue {
             title,
             body,
             labels,

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -43,6 +43,7 @@ mod prioritize;
 pub mod project_goals;
 pub mod pull_requests_assignment_update;
 mod relabel;
+mod relnotes;
 mod review_requested;
 mod review_submitted;
 mod rfc_helper;
@@ -102,6 +103,14 @@ pub async fn handle(ctx: &Context, event: &Event) -> Vec<HandlerError> {
     if let Err(e) = rfc_helper::handle(ctx, event).await {
         log::error!(
             "failed to process event {:?} with rfc_helper handler: {:?}",
+            event,
+            e
+        );
+    }
+
+    if let Err(e) = relnotes::handle(ctx, event).await {
+        log::error!(
+            "failed to process event {:?} with relnotes handler: {:?}",
             event,
             e
         );

--- a/src/handlers/relnotes.rs
+++ b/src/handlers/relnotes.rs
@@ -28,9 +28,7 @@ struct RelnotesState {
 }
 
 pub async fn handle(ctx: &Context, event: &Event) -> anyhow::Result<()> {
-    let e = if let Event::Issue(e) = event {
-        e
-    } else {
+    let Event::Issue(e) = event else {
         return Ok(());
     };
 

--- a/src/handlers/relnotes.rs
+++ b/src/handlers/relnotes.rs
@@ -1,0 +1,116 @@
+//! This handler implements collecting release notes from issues and PRs that are tagged with
+//! `relnotes`. Any such tagging will open a new issue in rust-lang/rust responsible for tracking
+//! the inclusion in releases notes.
+//!
+//! The new issue will be closed when T-release has added the text proposed (tracked in the issue
+//! description) into the final release notes PR.
+//!
+//! The issue description will be edited manually by teams through the GitHub UI -- in the future,
+//! we might add triagebot support for maintaining that text via commands or similar.
+//!
+//! These issues will also be automatically milestoned when their corresponding PR or issue is. In
+//! the absence of a milestone, T-release is responsible for ascertaining which release is
+//! associated with the issue.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    db::issue_data::IssueData,
+    github::{Event, IssuesAction},
+    handlers::Context,
+};
+
+const RELNOTES_KEY: &str = "relnotes";
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+struct RelnotesState {
+    relnotes_issue: Option<u64>,
+}
+
+pub async fn handle(ctx: &Context, event: &Event) -> anyhow::Result<()> {
+    let e = if let Event::Issue(e) = event {
+        e
+    } else {
+        return Ok(());
+    };
+
+    let repo = e.issue.repository();
+    if !(repo.organization == "rust-lang" && repo.repository == "rust") {
+        return Ok(());
+    }
+
+    if e.issue
+        .title
+        .starts_with("Tracking issue for release notes")
+    {
+        // Ignore these issues -- they're otherwise potentially self-recursive.
+        return Ok(());
+    }
+
+    let mut client = ctx.db.get().await;
+    let mut state: IssueData<'_, RelnotesState> =
+        IssueData::load(&mut client, &e.issue, RELNOTES_KEY).await?;
+
+    if let Some(paired) = state.data.relnotes_issue {
+        // Already has a paired release notes issue.
+
+        if let IssuesAction::Milestoned = &e.action {
+            if let Some(milestone) = &e.issue.milestone {
+                ctx.github
+                    .set_milestone(&e.issue.repository().to_string(), &milestone, paired)
+                    .await?;
+            }
+        }
+
+        return Ok(());
+    }
+
+    if let IssuesAction::Labeled { label } = &e.action {
+        if label.name == "relnotes" || label.name == "relnotes-perf" {
+            let title = format!(
+                "Tracking issue for release notes of #{}: {}",
+                e.issue.number, e.issue.title
+            );
+            let body = format!(
+                "
+This issue tracks the release notes text for #{}.
+
+- [ ] Issue is nominated for the responsible team (and T-release nomination is removed).
+- [ ] Proposed text is drafted by team responsible for underlying change.
+- [ ] Issue is nominated for release team review of clarity for wider audience.
+- [ ] Release team includes text in release notes/blog posts.
+
+Release notes text:
+
+The section title will be de-duplicated by the release team with other release notes issues.
+Prefer to use the standard titles from [previous releases](https://doc.rust-lang.org/nightly/releases.html).
+More than one section can be included if needed.
+
+```markdown
+# Compatibility Notes
+- [{}]({})
+```
+
+Release blog section (if any, leave blank if no section is expected):
+
+```markdown
+```
+",
+                e.issue.number, e.issue.title, e.issue.html_url,
+            );
+            let resp = ctx
+                .github
+                .new_issue(
+                    &e.issue.repository(),
+                    &title,
+                    &body,
+                    vec!["relnotes".to_owned(), "I-release-nominated".to_owned()],
+                )
+                .await?;
+            state.data.relnotes_issue = Some(resp.number);
+            state.save().await?;
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This follows up on recent discussion with T-libs-api (in particular) to make it easier for T-release and teams to propose specific text for inclusion in release notes. The strategy proposed here is a dedicated issue for release note text discussion + revision. Follow-up work to this will automate pulling the relevant context into the release notes PR (likely through changes to https://github.com/rust-lang/relnotes/), but manually extracting it should already be pretty easy due to the prominent title.

There are many future improvements, e.g.:

* Automatic nomination for the right team based on initial PR labels
* Automatic creation for any FCP (this feels right to me, but it is more work than teams typically do today).
* Random assignment to (subset of?) team members rather than nomination?
* Live-ish rendering of the proposed content, perhaps by replacing the code blocks with some other delimiter.

But my hope is that we can iterate on this in practice as we gain experience.

cc @rust-lang/release 

r? @ehuss 