### PR TITLE
Extend automatic rendered link to the blog.rust-lang.org repo

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -44,9 +44,9 @@ pub mod project_goals;
 pub mod pull_requests_assignment_update;
 mod relabel;
 mod relnotes;
+mod rendered_link;
 mod review_requested;
 mod review_submitted;
-mod rfc_helper;
 pub mod rustc_commits;
 mod shortcut;
 mod transfer;
@@ -100,9 +100,9 @@ pub async fn handle(ctx: &Context, event: &Event) -> Vec<HandlerError> {
         );
     }
 
-    if let Err(e) = rfc_helper::handle(ctx, event).await {
+    if let Err(e) = rendered_link::handle(ctx, event).await {
         log::error!(
-            "failed to process event {:?} with rfc_helper handler: {:?}",
+            "failed to process event {:?} with rendered_link handler: {:?}",
             event,
             e
         );


### PR DESCRIPTION
This PR extends the automatic addition of the "Rendered" link to the [blog.rust-lang.org repo](https://github.com/rust-lang/blog.rust-lang.org), as is currently done for the [rfcs repo](https://github.com/rust-lang/rfcs).