### PR TITLE
Set milestone of the issue to newly created relnotes tracking issue

### DIFF
--- a/src/handlers/relnotes.rs
+++ b/src/handlers/relnotes.rs
@@ -115,6 +115,11 @@ cc {} -- origin issue/PR authors and assignees for starting to draft text
                     vec!["relnotes".to_owned(), "relnotes-tracking-issue".to_owned()],
                 )
                 .await?;
+            if let Some(milestone) = &e.issue.milestone {
+                ctx.github
+                    .set_milestone(&e.issue.repository().to_string(), &milestone, resp.number)
+                    .await?;
+            }
             state.data.relnotes_issue = Some(resp.number);
             state.save().await?;
         }


### PR DESCRIPTION
This PR set milestone of the issue (if it has one) to newly created relnotes tracking issue.

This is useful if the triggering label(s) is/are added **after** the PR or issue has received the milestone (because it has already been merged or a milestone has already been assigned to that issue), otherwise we may never set it as we may never receive a new webhook event for that PR/issue.