### PR TITLE
only update zulip when tracking issues are opened

### DIFF
--- a/src/handlers/project_goals.rs
+++ b/src/handlers/project_goals.rs
@@ -226,7 +226,7 @@ pub async fn handle(ctx: &Context, event: &Event) -> anyhow::Result<()> {
             issue,
             ..
         }) => {
-            if issue.labels.iter().any(|l| l.name == C_TRACKING_ISSUE) {
+            if !issue.labels.iter().any(|l| l.name == C_TRACKING_ISSUE) {
                 return Ok(());
             }
             let zulip_topic_name = zulip_topic_name(issue);


### PR DESCRIPTION
The existing logic was only updating zulip when NON-tracking issues are opened.

Context: https://rust-lang.zulipchat.com/#narrow/stream/435869-project-goals/topic/update.20book.20as.20goals.20have.20been.20accepted.20.28goals.23133.29/near/470630981