### PR TITLE
Hide no-merge comments once merge commits removed

### DIFF
--- a/src/interactions.rs
+++ b/src/interactions.rs
@@ -26,7 +26,8 @@ impl<'a> ErrorComment<'a> {
             "Please file an issue on GitHub at [triagebot](https://github.com/rust-lang/triagebot) if there's \
             a problem with this bot, or reach out on [#t-infra](https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra) on Zulip."
         )?;
-        self.issue.post_comment(client, &body).await
+        self.issue.post_comment(client, &body).await?;
+        Ok(())
     }
 }
 
@@ -45,7 +46,8 @@ impl<'a> PingComment<'a> {
         for user in self.users {
             write!(body, "@{} ", user)?;
         }
-        self.issue.post_comment(client, &body).await
+        self.issue.post_comment(client, &body).await?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This PR implements the a GraphQL call to minimize a comment, modifies the return of `post_comment` to return the node-id (inside the more general `Comment`).

And then use those pre-requires to hide all the no-merge comments once the merge commits are removed.

Fixes https://github.com/rust-lang/triagebot/issues/1833
r? @ehuss