### PR TITLE
Allow setting review assignment limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,32 @@ gh webhook forward --repo=ehuss/triagebot-test --events=* \
 
 Where the value in `--secret` is the secret value you place in `GITHUB_WEBHOOK_SECRET` in the `.env` file, and `--repo` is the repo you want to test against.
 
+You can test webhooks with `cURL`. For example to test the Zulip hooks (commands sent to the
+Triagebot from the Rust lang Zulip), you start the triagebot on localhost:8000 and then simulate a
+Zulip hook payload:
+``` sh
+curl http://localhost:8000/zulip-hook \
+    -H "Content-Type: application/json" \
+    -d '{
+        "data": "<CMD>",
+        "token": "<ZULIP_TOKEN>",
+        "message": {
+            "sender_id": <YOUR_ID>,
+            "recipient_id": <YOUR_ID>,
+            "sender_full_name": "Randolph Carter",
+            "sender_email": "r.carter@rust-lang.org",
+            "type": "stream"
+            }
+        }'
+```
+
+Where:
+- `CMD` is the exact command you would issue @triagebot on Zulip (ex. open a direct chat with the
+  bot and send "work show")
+- `ZULIP_TOKEN`: can be anything. Must correspond to the env var `$ZULIP_TOKEN` on your workstation
+- `YOUR_ID`: your GitHub user ID. Must be existing in your local triagebot database (table `users` and as
+  foreign key also in `review_prefs`)
+
 #### ngrok
 
 The following is an example of using <https://ngrok.com/> to provide webhook forwarding.

--- a/src/db.rs
+++ b/src/db.rs
@@ -344,4 +344,5 @@ CREATE EXTENSION IF NOT EXISTS intarray;",
     "
 CREATE UNIQUE INDEX IF NOT EXISTS review_prefs_user_id ON review_prefs(user_id);
  ",
+    "ALTER TABLE review_prefs ADD COLUMN max_assigned_prs INT DEFAULT NULL;",
 ];

--- a/src/handlers/pull_requests_assignment_update.rs
+++ b/src/handlers/pull_requests_assignment_update.rs
@@ -84,3 +84,20 @@ WHERE r.user_id = $1;";
         .unwrap();
     Ok(row.into())
 }
+
+pub async fn set_review_prefs(
+    db: &DbClient,
+    user_id: u64,
+    pref_max_prs: u32,
+) -> anyhow::Result<u64, anyhow::Error> {
+    let q = "
+UPDATE review_prefs r
+SET max_assigned_prs = $1
+ROM users u
+WHERE r.user_id=$2 AND u.user_id=r.user_id;";
+    let res = db
+        .execute(q, &[&(pref_max_prs as i32), &(user_id as i64)])
+        .await
+        .context("Error retrieving review preferences")?;
+    Ok(res)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,17 +131,27 @@ pub struct ReviewPrefs {
     pub username: String,
     pub user_id: i64,
     pub assigned_prs: Vec<i32>,
+    pub max_assigned_prs: Option<u32>,
 }
 
-impl ReviewPrefs {
-    fn to_string(&self) -> String {
+impl fmt::Display for ReviewPrefs {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let prs = self
             .assigned_prs
             .iter()
             .map(|pr| format!("#{}", pr))
             .collect::<Vec<String>>()
             .join(", ");
-        format!("Username: {}\nAssigned PRs: {}", self.username, prs)
+        let max = if self.max_assigned_prs.is_none() {
+            "<not set>"
+        } else {
+            &format!("{}", self.max_assigned_prs.expect("NaN"))
+        };
+        write!(
+            f,
+            "Username: {}\nAssigned PRs: {}\nCurrent review capacity: {}",
+            self.username, prs, max
+        )
     }
 }
 
@@ -152,6 +162,7 @@ impl From<tokio_postgres::row::Row> for ReviewPrefs {
             username: row.get("username"),
             user_id: row.get("user_id"),
             assigned_prs: row.get("assigned_prs"),
+            max_assigned_prs: row.get("max_assigned_prs"),
         }
     }
 }


### PR DESCRIPTION
Part of #1753 

With this patch we allow team members to set their own review capacity. 

This will work by sending a message to the triagebot bot on Zulip. Usage:
- `work set #`: will set the number of max PRs assigned to me

This setting will only work for a subset of Github users that volunteered (see [here](https://github.com/rust-lang/triagebot/pull/1790/files#diff-3e34a2cbc9338bb237b61758076b2df481617021529ca7e0a044abd61de431cdR244-R253)).

An update the documentation on the forge will follow up.

(I cannot test it, don't have yet a testing infrastructure with also a Zulip instance)

r? @jackh726 

thank you