### PR TITLE
Lock Major Change Proposal issue

### DIFF
--- a/src/handlers/major_change.rs
+++ b/src/handlers/major_change.rs
@@ -294,6 +294,10 @@ async fn handle(
             .post_comment(&ctx.github, &comment)
             .await
             .context("post major change comment")?;
+        issue
+            .lock(&ctx.github, None)
+            .await
+            .context("lock major change issue")?;
     }
 
     let zulip_req = zulip_req.send(&ctx.github.raw());


### PR DESCRIPTION
This PR makes it so that every new major change proposal issue is locked by default.

This is done to affirm more strongly that discussion should happen on the generated Zulip thread instead.

This is particularly relevant for outsiders who *(I think)* just skip the part about no technical discussion on the issue, as it will systemically prevent them from doing so.

The locking of the issue doesn't affect "collaborators", aka members of the repo with at least "write" access (which is the case for all t-compiler/t-types members).

cc @apiraino
r? @ehuss