### PR TITLE
Fix MCP concern syntax hint

### DIFF
--- a/src/handlers/major_change.rs
+++ b/src/handlers/major_change.rs
@@ -270,7 +270,7 @@ async fn handle(
         \n \
         ``` \
         \n \
-        @rustbot concern reason-for-concern \
+        @rfcbot concern reason-for-concern \
         \n \
         <description of the concern> \
         \n \
@@ -280,7 +280,7 @@ async fn handle(
         \n \
         ``` \
         \n \
-        @rustbot resolve reason-for-concern \
+        @rfcbot resolve reason-for-concern \
         \n \
         ``` \
         \n\n \


### PR DESCRIPTION
Fixing a typo when suggesting the syntax to raise concerns on compiler MCPs (template was implemented in #1747)

