### PR TITLE
Fix sender login

### DIFF
--- a/src/handlers/bot_pull_requests.rs
+++ b/src/handlers/bot_pull_requests.rs
@@ -21,7 +21,7 @@ pub(crate) async fn handle(ctx: &Context, event: &Event) -> anyhow::Result<()> {
 
     // If it's not the github-actions bot, we don't expect this handler to be needed. Skip the
     // event.
-    if event.sender.login != "app/github-actions" {
+    if event.sender.login != "github-actions[bot]" {
         return Ok(());
     }
 


### PR DESCRIPTION
This is pulled from a sample event which had { login: "github-actions[bot]", id: 41898282 }

cc https://github.com/rust-lang/triagebot/issues/1864#issuecomment-2533735743