### PR TITLE
Ignore inline HTML and HTML blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,15 +1738,22 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.7.2"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca36dea94d187597e104a5c8e4b07576a8a45aa5db48a65e12940d3eb7461f55"
+checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "getopts",
  "memchr",
+ "pulldown-cmark-escape",
  "unicase",
 ]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quote"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Mark Rousskov <mark.simulacrum@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-pulldown-cmark = "0.7.0"
+pulldown-cmark = "0.12.0"
 log = "0.4"
 regex = "1.6.0"

--- a/parser/src/command.rs
+++ b/parser/src/command.rs
@@ -350,7 +350,13 @@ fn review_errors() {
 #[test]
 fn review_ignored() {
     // Checks for things that shouldn't be detected.
-    for input in ["r", "reviewer? abc", "r foo"] {
+    for input in [
+        "r",
+        "reviewer? abc",
+        "r foo",
+        "<a>\n r? @bot\n</a>",
+        "<!--\nr? foo\n-->",
+    ] {
         let mut input = Input::new(input, vec!["bot"]);
         assert_eq!(input.next(), None);
     }

--- a/parser/src/ignore_block.rs
+++ b/parser/src/ignore_block.rs
@@ -1,4 +1,4 @@
-use pulldown_cmark::{Event, Parser, Tag};
+use pulldown_cmark::{Event, Parser, Tag, TagEnd};
 use std::ops::Range;
 
 #[derive(Debug)]
@@ -14,18 +14,18 @@ impl IgnoreBlocks {
             if let Event::Start(Tag::CodeBlock(_)) = event {
                 let start = range.start;
                 while let Some((event, range)) = parser.next() {
-                    if let Event::End(Tag::CodeBlock(_)) = event {
+                    if let Event::End(TagEnd::CodeBlock) = event {
                         ignore.push(start..range.end);
                         break;
                     }
                 }
-            } else if let Event::Start(Tag::BlockQuote) = event {
+            } else if let Event::Start(Tag::BlockQuote(_)) = event {
                 let start = range.start;
                 let mut count = 1;
                 while let Some((event, range)) = parser.next() {
-                    if let Event::Start(Tag::BlockQuote) = event {
+                    if let Event::Start(Tag::BlockQuote(_)) = event {
                         count += 1;
-                    } else if let Event::End(Tag::BlockQuote) = event {
+                    } else if let Event::End(TagEnd::BlockQuote(_)) = event {
                         count -= 1;
                         if count == 0 {
                             ignore.push(start..range.end);

--- a/parser/src/ignore_block.rs
+++ b/parser/src/ignore_block.rs
@@ -33,6 +33,8 @@ impl IgnoreBlocks {
                         }
                     }
                 }
+            } else if let Event::InlineHtml(_) = event {
+                ignore.push(range);
             } else if let Event::Code(_) = event {
                 ignore.push(range);
             }
@@ -92,7 +94,13 @@ fn cbs_1() {
 fn cbs_2() {
     assert_eq!(
         bodies("`hey you` <b>me too</b>"),
-        [Ignore::Yes("`hey you`"), Ignore::No(" <b>me too</b>")]
+        [
+            Ignore::Yes("`hey you`"),
+            Ignore::No(" "),
+            Ignore::Yes("<b>"),
+            Ignore::No("me too"),
+            Ignore::Yes("</b>")
+        ]
     );
 }
 
@@ -100,7 +108,13 @@ fn cbs_2() {
 fn cbs_3() {
     assert_eq!(
         bodies(r"`hey you\` <b>`me too</b>"),
-        [Ignore::Yes(r"`hey you\`"), Ignore::No(" <b>`me too</b>")]
+        [
+            Ignore::Yes("`hey you\\`"),
+            Ignore::No(" "),
+            Ignore::Yes("<b>"),
+            Ignore::No("`me too"),
+            Ignore::Yes("</b>")
+        ]
     );
 }
 


### PR DESCRIPTION
This PR adds inline HTML (`<a>`) and HTML blocks to the ignore logic when parsing commands.

This is particularly useful for rust-lang/rust [pull request template](https://github.com/rust-lang/rust/blob/master/.github/pull_request_template.md?plain=1) which currently hacks around triagebot finding `r?` in the HTML comment.

This PR also updates `pulldown-cmark` to `0.12`.

Related to https://github.com/rust-lang/triagebot/issues/1832
r? @ehuss