### PR TITLE
Read Zulip config from env vars

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,3 +11,13 @@ GITHUB_WEBHOOK_SECRET=MUST_BE_CONFIGURED
 # For example write blahblahblah here, if you want for this bot to
 # respond to @blahblahblah claim.
 # TRIAGEBOT_USERNAME=CAN_BE_CONFIGURED
+
+# Set your own Zulip instance (local testing only)
+# ZULIP_URL=https://testinstance.zulichat.com
+
+# Used for authenticating a bot
+# ZULIP_BOT_EMAIL=bot@testinstance.zulipchat.com
+# ZULIP_API_TOKEN=yyy
+
+# Authenticates inbound webhooks from Github
+# ZULIP_TOKEN=xxx

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ gh webhook forward --repo=ehuss/triagebot-test --events=* \
 
 Where the value in `--secret` is the secret value you place in `GITHUB_WEBHOOK_SECRET` in the `.env` file, and `--repo` is the repo you want to test against.
 
+### Zulip testing
+
+If you are modifying code that sends message to Zulip and want to test your changes, you can register a [new free Zulip instance](https://zulip.com/new/). Before launching the triagebot locally, set the Zulip env vars to connect to your test instance (see example in `.env.sample`).
+
 #### ngrok
 
 The following is an example of using <https://ngrok.com/> to provide webhook forwarding.


### PR DESCRIPTION
Sometimes we want to test the triagebot against a test Zulip instance (f.e. #1853) but currently the Zulip config is hardcoded. This patch allows settings env vars to use a custom Zulip instance. If these env vars are not set, the triagebot will work as usual and connect to the production Zulip instance.

I've tested this with a binary that I didn't include in the repository, it simply uses the public api is `zulip.rs`:
<details><summary>code</summary>
<p>

```
use triagebot::github::GithubClient;
use triagebot::zulip;

#[tokio::main(flavor = "current_thread")]
async fn main() -> anyhow::Result<()> {
    let gh = GithubClient::new_from_env();

    let zulip_topic_name = "New topic";
    let message = "This is a message";

    let zulip_req = crate::zulip::MessageApiRequest {
        recipient: crate::zulip::Recipient::Stream {
            id: 123456, // #ChannelName
            topic: &zulip_topic_name,
        },
        content: &message,
    };

    // .send() reads env vars ZULIP_URL, ZULIP_API_TOKEN, ZULIP_BOT_EMAIL
    let response = zulip_req.send(&gh.raw()).await?;
    println!("RESP: {:?}", response.text().await);

    Ok(())
}
```

</p>
</details> 


maybe r? @ehuss  (or anyone who has time for a review)