### PR TITLE
fix(transfer): dont create labels if missing

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -1055,7 +1055,7 @@ impl Issue {
             .graphql_query(
                 "mutation ($issueId: ID!, $repoId: ID!) {
                   transferIssue(
-                    input: {createLabelsIfMissing: true, issueId: $issueId, repositoryId: $repoId}
+                    input: {createLabelsIfMissing: false, issueId: $issueId, repositoryId: $repoId}
                   ) {
                     issue {
                       id


### PR DESCRIPTION
This is quite annoying if the target repo doesn't need those labels, or have a completely different label management approach.

While issues need to relabel anyway after transfer, it requires more steps to delete a label. I don't think it is worth.


Alternatively, we could have an argument `@rustbot transfer cargo createMissingLabels=1` in the future, if people really want missing labels created.