### PR TITLE
Remove rustc-dev-guide as a submodule

### DIFF
--- a/src/handlers/docs_update.rs
+++ b/src/handlers/docs_update.rs
@@ -21,7 +21,6 @@ const SUBMODULES: &[&str] = &[
     "src/doc/nomicon",
     "src/doc/reference",
     "src/doc/rust-by-example",
-    "src/doc/rustc-dev-guide",
 ];
 
 const TITLE: &str = "Update books";


### PR DESCRIPTION
Companion PR to https://github.com/rust-lang/rust/pull/134907.