### PR TITLE
Revert "Lock Major Change Proposal issue"

### DIFF
--- a/src/handlers/major_change.rs
+++ b/src/handlers/major_change.rs
@@ -294,10 +294,6 @@ async fn handle(
             .post_comment(&ctx.github, &comment)
             .await
             .context("post major change comment")?;
-        issue
-            .lock(&ctx.github, None)
-            .await
-            .context("lock major change issue")?;
     }
 
     let zulip_req = zulip_req.send(&ctx.github.raw());


### PR DESCRIPTION
This PR reverts commit https://github.com/rust-lang/triagebot/commit/d5649f42835bad5e9438a584dddda0a570f6e75f from https://github.com/rust-lang/triagebot/pull/1858 as [it was found](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Lock.20discussions.20on.20MCPs/near/491957647) that if the PR is not member of the org he cannot edit the MCP description.

I think it's more important to let author edit the MCP description than preventing people from potential posting comment on the issue.

r? @ehuss