### PR TITLE
Handle deleted labels

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -1168,7 +1168,9 @@ pub enum IssuesAction {
     },
     Unlabeled {
         /// The label removed from the issue
-        label: Label,
+        ///
+        /// The `label` is `None` when a label is deleted from the repository.
+        label: Option<Label>,
     },
     Locked,
     Unlocked,

--- a/src/handlers/notify_zulip.rs
+++ b/src/handlers/notify_zulip.rs
@@ -32,7 +32,7 @@ pub(super) async fn parse_input(
     };
 
     match &event.action {
-        IssuesAction::Labeled { label } | IssuesAction::Unlabeled { label } => {
+        IssuesAction::Labeled { label } | IssuesAction::Unlabeled { label: Some(label) } => {
             let applied_label = label.clone();
             Ok(config
                 .labels


### PR DESCRIPTION
This fixes a bug when a label is deleted from a repository. In that situation, the `label` field is absent in the `issues` event. This was causing a deserialization error when processing the webhook event.

According to the webhook docs, the `labeled` event is also optional, but I can't figure out a situation where that might happen, so I didn't bother changing it.
