### PR TITLE
Make a DB migration optional

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -345,6 +345,6 @@ CREATE EXTENSION IF NOT EXISTS intarray;",
 CREATE UNIQUE INDEX IF NOT EXISTS review_prefs_user_id ON review_prefs(user_id);
  ",
     "
-ALTER TABLE review_prefs ADD COLUMN max_assigned_prs INTEGER DEFAULT NULL;
+ALTER TABLE review_prefs ADD COLUMN IF NOT EXISTS max_assigned_prs INTEGER DEFAULT NULL;
 ",
 ];


### PR DESCRIPTION
This should avoid the migration process to block if the field already exists.

Let's keep it here for now and decide if it's needed.

cc @jackh726 