### PR TITLE
Add bypass for user ghost

### DIFF
--- a/src/handlers/assign.rs
+++ b/src/handlers/assign.rs
@@ -781,6 +781,11 @@ async fn find_reviewer_from_names(
     // These are all ideas for improving the selection here. However, I'm not
     // sure they are really worth the effort.
 
+    // Special case user "ghost", we always skip filtering
+    if candidates.contains("ghost") {
+        return Ok("ghost".to_string());
+    }
+
     // filter out team members without capacity
     let filtered_candidates = filter_by_capacity(db, &candidates)
         .await


### PR DESCRIPTION
[rust#135893](https://togithub.com/rust-lang/rust/pull/135893#issuecomment-2607978275) reveals a regression in the PR assignment after we deployed #1879 - I hadn't carefully considered the user `ghost`, a special assignee we use to skip assigning PRs to humans.

This patch skips any capacity check for the `ghost` user. As far as I could see it's the only place where such check exists.

r? @jackh726 