### PR TITLE
Improve query for getting users for review

### DIFF
--- a/src/handlers/pull_requests_assignment_update.rs
+++ b/src/handlers/pull_requests_assignment_update.rs
@@ -80,7 +80,6 @@ WHERE r.user_id = $1;";
     let row = db
         .query_one(q, &[&(user_id as i64)])
         .await
-        .context("Error retrieving review preferences")
-        .unwrap();
+        .context("Error retrieving review preferences")?;
     Ok(row.into())
 }


### PR DESCRIPTION
The previous query had a problem where if some user was missing in the `review_prefs` table, it would not be returned from the query. This is problematic, because for several reasons, the `review_prefs` table might be incomplete, and in general, it should be possible to get users even if they are not in the `review_prefs` table.

There is one problem with the new query though, because there is no index on the `users.username` column, this will result in a sequential scan on the `users` table. It's probably still fast enough, but I wanted to mention it.

The `LEAST` clause was not required, I think. The added `COALESCE` is needed to treat the number of PRs for people missing in `review_prefs` as zero, otherwise they would be again ignored.

You can experiment with this in https://onecompiler.com/postgresql/43722tb3w.