### PR TITLE
Add simple test infrastructure for testing DB queries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,27 @@ jobs:
       run: rustup update stable && rustup default stable && rustup component add rustfmt
     - run: cargo fmt --all --check
 
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      TEST_DB_URL: postgres://postgres:postgres@localhost:5432/postgres
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup toolchain install stable --profile minimal
+      - uses: Swatinem/rust-cache@v2
+      - name: Run tests
+        run: cargo test --workspace --all-targets
+
   ci:
     name: CI
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ The general overview of what you will need to do:
 3. [Configure webhook forwarding](#configure-webhook-forwarding)
 4. Configure the `.env` file:
 
-   1. Copy `.env.sample` to `.env`
-   2. `GITHUB_TOKEN`: This is a token needed for Triagebot to send requests to GitHub. Go to GitHub Settings > Developer Settings > Personal Access Token, and create a new token. The `repo` permission should be sufficient.
-      If this is not set, Triagebot will also look in `~/.gitconfig` in the `github.oauth-token` setting.
-   3. `DATABASE_URL`: This is the URL to the database. See [Configuring a database](#configuring-a-database).
-   4. `GITHUB_WEBHOOK_SECRET`: Enter the secret you entered in the webhook above.
-   5. `RUST_LOG`: Set this to `debug`.
+    1. Copy `.env.sample` to `.env`
+    2. `GITHUB_TOKEN`: This is a token needed for Triagebot to send requests to GitHub. Go to GitHub Settings > Developer Settings > Personal Access Token, and create a new token. The `repo` permission should be sufficient.
+       If this is not set, Triagebot will also look in `~/.gitconfig` in the `github.oauth-token` setting.
+    3. `DATABASE_URL`: This is the URL to the database. See [Configuring a database](#configuring-a-database).
+    4. `GITHUB_WEBHOOK_SECRET`: Enter the secret you entered in the webhook above.
+    5. `RUST_LOG`: Set this to `debug`.
 
 5. Run `cargo run --bin triagebot`. This starts the http server listening for webhooks on port 8000.
 6. Add a `triagebot.toml` file to the main branch of your GitHub repo with whichever services you want to try out.
@@ -109,15 +109,28 @@ You need to sign up for a free account, and also deal with configuring the GitHu
 3. Configure GitHub webhooks in the test repo you created.
    In short:
 
-   1. Go to the settings page for your GitHub repo.
-   2. Go to the webhook section.
-   3. Click "Add webhook"
-   4. Include the settings:
+    1. Go to the settings page for your GitHub repo.
+    2. Go to the webhook section.
+    3. Click "Add webhook"
+    4. Include the settings:
 
-      * Payload URL: This is the URL to your Triagebot server, for example http://7e9ea9dc.ngrok.io/github-hook. This URL is displayed when you ran the `ngrok` command above.
-      * Content type: application/json
-      * Secret: Enter a shared secret (some longish random text)
-      * Events: "Send me everything"
+        * Payload URL: This is the URL to your Triagebot server, for example http://7e9ea9dc.ngrok.io/github-hook. This URL is displayed when you ran the `ngrok` command above.
+        * Content type: application/json
+        * Secret: Enter a shared secret (some longish random text)
+        * Events: "Send me everything"
+
+### Cargo tests
+
+You can run Cargo tests using `cargo test`. If you also want to run tests that access a Postgres database, you can specify an environment variables `TEST_DB_URL`, which should contain a connection string pointing to a running Postgres database instance:
+
+```bash
+$ docker run --rm -it -p5432:5432 \
+  -e POSTGRES_USER=triagebot \
+  -e POSTGRES_PASSWORD=triagebot \
+  -e POSTGRES_DB=triagebot \
+  postgres:14
+$ TEST_DB_URL=postgres://triagebot:triagebot@localhost:5432/triagebot cargo test
+```
 
 ## License
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -93,7 +93,7 @@ impl ClientPool {
     }
 }
 
-async fn make_client(db_url: &str) -> anyhow::Result<tokio_postgres::Client> {
+pub async fn make_client(db_url: &str) -> anyhow::Result<tokio_postgres::Client> {
     if db_url.contains("rds.amazonaws.com") {
         let mut builder = TlsConnector::builder();
         for cert in make_certificates() {

--- a/src/db.rs
+++ b/src/db.rs
@@ -235,8 +235,9 @@ pub async fn schedule_job(
     Ok(())
 }
 
-pub async fn run_scheduled_jobs(ctx: &Context, db: &DbClient) -> anyhow::Result<()> {
-    let jobs = get_jobs_to_execute(&db).await.unwrap();
+pub async fn run_scheduled_jobs(ctx: &Context) -> anyhow::Result<()> {
+    let db = &ctx.db.get().await;
+    let jobs = get_jobs_to_execute(&db).await?;
     tracing::trace!("jobs to execute: {:#?}", jobs);
 
     for job in jobs.iter() {

--- a/src/handlers/assign.rs
+++ b/src/handlers/assign.rs
@@ -39,6 +39,7 @@ use tracing as log;
 #[cfg(test)]
 mod tests {
     mod tests_candidates;
+    mod tests_db;
     mod tests_from_diff;
 }
 

--- a/src/handlers/assign/tests/tests_db.rs
+++ b/src/handlers/assign/tests/tests_db.rs
@@ -1,0 +1,30 @@
+#[cfg(test)]
+mod tests {
+    use crate::handlers::assign::filter_by_capacity;
+    use crate::tests::run_test;
+    use std::collections::HashSet;
+
+    #[tokio::test]
+    async fn find_reviewers_no_review_prefs() {
+        run_test(|ctx| async move {
+            ctx.add_user("usr1", 1).await;
+            ctx.add_user("usr2", 1).await;
+            let _users =
+                filter_by_capacity(ctx.db_client(), &candidates(&["usr1", "usr2"])).await?;
+            // FIXME: this test fails, because the query is wrong
+            // check_users(users, &["usr1", "usr2"]);
+            Ok(ctx)
+        })
+        .await;
+    }
+
+    fn candidates(users: &[&'static str]) -> HashSet<&'static str> {
+        users.into_iter().copied().collect()
+    }
+
+    fn check_users(users: HashSet<String>, expected: &[&'static str]) {
+        let mut users: Vec<String> = users.into_iter().collect();
+        users.sort();
+        assert_eq!(users, expected);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,9 @@ mod team_data;
 pub mod triage;
 pub mod zulip;
 
+#[cfg(test)]
+mod tests;
+
 /// The name of a webhook event.
 #[derive(Debug)]
 pub enum EventName {

--- a/src/main.rs
+++ b/src/main.rs
@@ -401,13 +401,12 @@ fn spawn_job_runner(ctx: Arc<Context>) {
         loop {
             let ctx = ctx.clone();
             let res = task::spawn(async move {
-                let pool = db::ClientPool::new();
                 let mut interval =
                     time::interval(time::Duration::from_secs(JOB_PROCESSING_CADENCE_IN_SECS));
 
                 loop {
                     interval.tick().await;
-                    db::run_scheduled_jobs(&ctx, &*pool.get().await)
+                    db::run_scheduled_jobs(&ctx)
                         .await
                         .context("run database scheduled jobs")
                         .unwrap();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,6 @@
 use crate::db;
 use crate::db::make_client;
+use crate::db::notifications::record_username;
 use std::future::Future;
 use tokio_postgres::Config;
 
@@ -48,6 +49,16 @@ impl TestContext {
             original_db_url: db_url.to_string(),
             conn_handle,
         }
+    }
+
+    pub fn db_client(&self) -> &tokio_postgres::Client {
+        &self.client
+    }
+
+    pub async fn add_user(&self, name: &str, id: u64) {
+        record_username(&self.client, id, name)
+            .await
+            .expect("Cannot create user");
     }
 
     async fn finish(self) {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,82 @@
+use crate::db;
+use crate::db::make_client;
+use std::future::Future;
+use tokio_postgres::Config;
+
+/// Represents a connection to a Postgres database that can be
+/// used in integration tests to test logic that interacts with
+/// a database.
+pub struct TestContext {
+    client: tokio_postgres::Client,
+    db_name: String,
+    original_db_url: String,
+    conn_handle: tokio::task::JoinHandle<()>,
+}
+
+impl TestContext {
+    async fn new(db_url: &str) -> Self {
+        let mut config: Config = db_url.parse().expect("Cannot parse connection string");
+
+        // Create a new database that will be used for this specific test
+        let client = make_client(&db_url)
+            .await
+            .expect("Cannot connect to database");
+        let db_name = format!("db{}", uuid::Uuid::new_v4().to_string().replace("-", ""));
+        client
+            .execute(&format!("CREATE DATABASE {db_name}"), &[])
+            .await
+            .expect("Cannot create database");
+        drop(client);
+
+        // We need to connect to the database against, because Postgres doesn't allow
+        // changing the active database mid-connection.
+        config.dbname(&db_name);
+        let (mut client, connection) = config
+            .connect(tokio_postgres::NoTls)
+            .await
+            .expect("Cannot connect to the newly created database");
+        let conn_handle = tokio::spawn(async move {
+            connection.await.unwrap();
+        });
+
+        db::run_migrations(&mut client)
+            .await
+            .expect("Cannot run database migrations");
+        Self {
+            client,
+            db_name,
+            original_db_url: db_url.to_string(),
+            conn_handle,
+        }
+    }
+
+    async fn finish(self) {
+        // Cleanup the test database
+        // First, we need to stop using the database
+        drop(self.client);
+        self.conn_handle.await.unwrap();
+
+        // Then we need to connect to the default database and drop our test DB
+        let client = make_client(&self.original_db_url)
+            .await
+            .expect("Cannot connect to database");
+        client
+            .execute(&format!("DROP DATABASE {}", self.db_name), &[])
+            .await
+            .unwrap();
+    }
+}
+
+pub async fn run_test<F, Fut>(f: F)
+where
+    F: FnOnce(TestContext) -> Fut,
+    Fut: Future<Output = anyhow::Result<TestContext>>,
+{
+    if let Ok(db_url) = std::env::var("TEST_DB_URL") {
+        let ctx = TestContext::new(&db_url).await;
+        let ctx = f(ctx).await.expect("Test failed");
+        ctx.finish().await;
+    } else {
+        eprintln!("Skipping test because TEST_DB_URL was not passed");
+    }
+}


### PR DESCRIPTION
Especially with the recent review preferences changes, I think that the queries that we run in triagebot are now becoming too complex for them to be tested only in production, and we should start doing at least some basic testing.

There have been previous attempts at introducing more comprehensive tests (https://github.com/rust-lang/triagebot/pull/1678, https://github.com/rust-lang/triagebot/pull/1698). These were quite large in scope and got stuck discussing various things.

This PR attempts to do something much smaller. It doesn't add full end-to-end tests, but simply enables us to connect to an actual Postgres DB, setup some fixtures and then check that triagebot is doing what we expect it to. Thsi is essentially the same thing that I already do in new bors, with the only difference that there it is handled by sqlx, so it's one line of code :) But given previous discussions in the linked PRs, I wanted to avoid switching to sqlx here.

Note that I don't see any point in testing triagebot against SQLite. A lot of issues that we encounter in production are database and query issues. If we tested against SQLite, we would both have to implement all queries for it, which is additional work, and even then we would be testing something completely different than what gets run on production. Even if we get rid of the more esoteric things that we use now (Postgres arrays), there are still non-trivial differences between SQLite and Postgres (hell, even between different Postgres versions...), so I am quite sute that it wouldn't be worth it. Spinning up Postgres locally with Docker is trivial these days, but I made the tests opt-in anyway, so that it is not even required for running `cargo test`.

This PR contains a (currently commented out) test for the SQL query which should be hopefully fixed by https://github.com/rust-lang/triagebot/pull/1891.

Best reviewed commit by commit. The first commit is the only one that could change production behavior, AFAIK, as the background job now shares the client pool with the main client logic. I think that should be fine, but if you want, I can get rid of that.