### PR TITLE
Automatically fixup linked issues in subtree repository

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -46,6 +46,7 @@ pub(crate) struct Config {
     pub(crate) merge_conflicts: Option<MergeConflictConfig>,
     pub(crate) bot_pull_requests: Option<BotPullRequests>,
     pub(crate) rendered_link: Option<RenderedLinkConfig>,
+    pub(crate) relink: Option<RelinkConfig>,
 }
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]
@@ -414,6 +415,11 @@ pub(crate) struct RenderedLinkConfig {
     pub(crate) trigger_files: Vec<String>,
 }
 
+#[derive(PartialEq, Eq, Debug, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RelinkConfig {}
+
 fn get_cached_config(repo: &str) -> Option<Result<Arc<Config>, ConfigurationError>> {
     let cache = CONFIG_CACHE.read().unwrap();
     cache.get(repo).and_then(|(config, fetch_time)| {
@@ -535,6 +541,8 @@ mod tests {
 
             [shortcut]
 
+            [relink]
+
             [rendered-link]
             trigger-files = ["posts/"]
         "#;
@@ -598,7 +606,8 @@ mod tests {
                 bot_pull_requests: None,
                 rendered_link: Some(RenderedLinkConfig {
                     trigger_files: vec!["posts/".to_string()]
-                })
+                }),
+                relink: Some(RelinkConfig {}),
             }
         );
     }
@@ -662,6 +671,7 @@ mod tests {
                 merge_conflicts: None,
                 bot_pull_requests: None,
                 rendered_link: None,
+                relink: None
             }
         );
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,7 +46,7 @@ pub(crate) struct Config {
     pub(crate) merge_conflicts: Option<MergeConflictConfig>,
     pub(crate) bot_pull_requests: Option<BotPullRequests>,
     pub(crate) rendered_link: Option<RenderedLinkConfig>,
-    pub(crate) relink: Option<RelinkConfig>,
+    pub(crate) canonicalize_issue_links: Option<CanonicalizeIssueLinksConfig>,
 }
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]
@@ -418,7 +418,7 @@ pub(crate) struct RenderedLinkConfig {
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
-pub(crate) struct RelinkConfig {}
+pub(crate) struct CanonicalizeIssueLinksConfig {}
 
 fn get_cached_config(repo: &str) -> Option<Result<Arc<Config>, ConfigurationError>> {
     let cache = CONFIG_CACHE.read().unwrap();
@@ -541,7 +541,7 @@ mod tests {
 
             [shortcut]
 
-            [relink]
+            [canonicalize-issue-links]
 
             [rendered-link]
             trigger-files = ["posts/"]
@@ -607,7 +607,7 @@ mod tests {
                 rendered_link: Some(RenderedLinkConfig {
                     trigger_files: vec!["posts/".to_string()]
                 }),
-                relink: Some(RelinkConfig {}),
+                canonicalize_issue_links: Some(CanonicalizeIssueLinksConfig {}),
             }
         );
     }
@@ -671,7 +671,7 @@ mod tests {
                 merge_conflicts: None,
                 bot_pull_requests: None,
                 rendered_link: None,
-                relink: None
+                canonicalize_issue_links: None
             }
         );
     }

--- a/src/github.rs
+++ b/src/github.rs
@@ -522,7 +522,7 @@ impl IssueRepository {
         )
     }
 
-    fn full_repo_name(&self) -> String {
+    pub(crate) fn full_repo_name(&self) -> String {
         format!("{}/{}", self.organization, self.repository)
     }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -27,6 +27,7 @@ impl fmt::Display for HandlerError {
 mod assign;
 mod autolabel;
 mod bot_pull_requests;
+mod canonicalize_issue_links;
 mod check_commits;
 mod close;
 pub mod docs_update;
@@ -47,7 +48,6 @@ mod prioritize;
 pub mod project_goals;
 pub mod pull_requests_assignment_update;
 mod relabel;
-mod relink;
 mod relnotes;
 mod rendered_link;
 mod review_requested;
@@ -113,16 +113,6 @@ pub async fn handle(ctx: &Context, event: &Event) -> Vec<HandlerError> {
             event,
             e
         );
-    }
-
-    if let Some(relink_config) = config.as_ref().ok().and_then(|c| c.relink.as_ref()) {
-        if let Err(e) = relink::handle(ctx, event, relink_config).await {
-            log::error!(
-                "failed to process event {:?} with relink handler: {:?}",
-                event,
-                e
-            );
-        }
     }
 
     if let Some(rendered_link_config) = config.as_ref().ok().and_then(|c| c.rendered_link.as_ref())
@@ -235,6 +225,7 @@ macro_rules! issue_handlers {
 issue_handlers! {
     assign,
     autolabel,
+    canonicalize_issue_links,
     major_change,
     mentions,
     no_merges,

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -47,6 +47,7 @@ mod prioritize;
 pub mod project_goals;
 pub mod pull_requests_assignment_update;
 mod relabel;
+mod relink;
 mod relnotes;
 mod rendered_link;
 mod review_requested;
@@ -112,6 +113,16 @@ pub async fn handle(ctx: &Context, event: &Event) -> Vec<HandlerError> {
             event,
             e
         );
+    }
+
+    if let Some(relink_config) = config.as_ref().ok().and_then(|c| c.relink.as_ref()) {
+        if let Err(e) = relink::handle(ctx, event, relink_config).await {
+            log::error!(
+                "failed to process event {:?} with relink handler: {:?}",
+                event,
+                e
+            );
+        }
     }
 
     if let Some(rendered_link_config) = config.as_ref().ok().and_then(|c| c.rendered_link.as_ref())

--- a/src/handlers/relink.rs
+++ b/src/handlers/relink.rs
@@ -1,0 +1,102 @@
+//! This handler is used to "relink" linked GitHub issues into their long form
+//! so that when pulling subtree into the main repository we don't accidentaly
+//! closes issue in the wrong repository.
+//!
+//! Example: `Fixes #123` (in rust-lang/clippy) would now become `Fixes rust-lang/clippy#123`
+
+use std::borrow::Cow;
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+use crate::{
+    config::RelinkConfig,
+    github::{Event, IssuesAction, IssuesEvent},
+    handlers::Context,
+};
+
+// Taken from https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue?quot#linking-a-pull-request-to-an-issue-using-a-keyword
+static LINKED_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new("(?i)(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved) +(#[0-9]+)")
+        .unwrap()
+});
+
+pub async fn handle(ctx: &Context, event: &Event, config: &RelinkConfig) -> anyhow::Result<()> {
+    let Event::Issue(e) = event else {
+        return Ok(());
+    };
+
+    if !e.issue.is_pr() {
+        return Ok(());
+    }
+
+    if let Err(e) = relink_pr(&ctx, &e, config).await {
+        tracing::error!("Error relinking pr: {:?}", e);
+    }
+
+    Ok(())
+}
+
+async fn relink_pr(ctx: &Context, e: &IssuesEvent, _config: &RelinkConfig) -> anyhow::Result<()> {
+    if e.action == IssuesAction::Opened
+        || e.action == IssuesAction::Reopened
+        || e.action == IssuesAction::Edited
+    {
+        let full_repo_name = e.issue.repository().full_repo_name();
+
+        let new_body = fix_linked_issues(&e.issue.body, full_repo_name.as_str());
+
+        if e.issue.body != new_body {
+            e.issue.edit_body(&ctx.github, &new_body).await?;
+        }
+    }
+
+    Ok(())
+}
+
+fn fix_linked_issues<'a>(body: &'a str, full_repo_name: &str) -> Cow<'a, str> {
+    let replace_by = format!("$1 {full_repo_name}$2");
+    LINKED_RE.replace_all(body, replace_by)
+}
+
+#[test]
+fn fixed_body() {
+    let full_repo_name = "rust-lang/rust";
+
+    let body = r#"
+    This is a PR.
+
+    Fix #123
+    fixed #456
+    Fixes    #7895
+    Resolves #00000 Closes #888
+    "#;
+
+    let fixed_body = r#"
+    This is a PR.
+
+    Fix rust-lang/rust#123
+    fixed rust-lang/rust#456
+    Fixes rust-lang/rust#7895
+    Resolves rust-lang/rust#00000 Closes rust-lang/rust#888
+    "#;
+
+    let new_body = fix_linked_issues(body, full_repo_name);
+    assert_eq!(new_body, fixed_body);
+}
+
+#[test]
+fn untouched_body() {
+    let full_repo_name = "rust-lang/rust";
+
+    let body = r#"
+    This is a PR.
+
+    Fix rust-lang#123
+    Fixesd #7895
+    Resolves #abgt
+    "#;
+
+    let new_body = fix_linked_issues(body, full_repo_name);
+    assert_eq!(new_body, body);
+}


### PR DESCRIPTION
This PR adds a new handler to "relink" linked GitHub issues into their unambiguous form so that when pulling commits from a subtree into the main repository we don't accidentally closes issues in the wrong repository.

Example: `Fixes #123` (in rust-lang/clippy) would be automatically changed to `Fixes rust-lang/clippy#123`

r? @ehuss