### PR TITLE
Emphasis Zulip thread more in MCP opening comment

### DIFF
--- a/src/handlers/major_change.rs
+++ b/src/handlers/major_change.rs
@@ -259,8 +259,9 @@ async fn handle(
     if new_proposal {
         let topic_url = zulip_req.url();
         let comment = format!(
-            "This issue is not meant to be used for technical discussion. \
-        There is a Zulip [stream] for that. Use this issue to leave \
+            "> [!IMPORTANT] \n\
+        > This issue is *not meant to be used for technical discussion*. \
+        There is a **Zulip [stream]** for that. Use this issue to leave \
         procedural comments, such as volunteering to review, indicating that you \
         second the proposal (or third, etc), or raising a concern that you would \
         like to be addressed. \


### PR DESCRIPTION
Instead of locking the MCP GitHub issue, like was done in #1876 (until a subsequent revert), I think we should put more emphasis on the Zulip thread in MCP opening comment.

Currently it's kind of hidden between a wall of text, I propose that we use [GitHub blockquote annotations](https://github.com/orgs/community/discussions/16925#discussion-4085374) to increase the emphasis on it. I also included some minor stylistic changes to help break the wall of text.

I choose "Important" as I feel like it's the only one that fits our goal.

cc @apiraino
r? @ehuss