### PR TITLE
Handle open/close PR events in PR tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe7acc34ff59877422326db7d6f2d845a582b16396b6b08194942bf34c6528ab"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4159dd617a7fbc9be6a692fe69dc2954f8e6bb6bb5e4d7578467441390d77fd0"
+dependencies = [
+ "darling 0.20.10",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,7 +450,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e8e65b71a8bd2751712ab38326b73a5f98405b6b5f8fd4dae658e58c1576d09"
 dependencies = [
  "counter",
- "darling",
+ "darling 0.14.4",
  "graphql-parser",
  "once_cell",
  "ouroboros",
@@ -454,8 +479,18 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core 0.20.10",
+ "darling_macro 0.20.10",
 ]
 
 [[package]]
@@ -473,14 +508,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.4",
  "quote",
  "syn 1.0.91",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core 0.20.10",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -504,7 +564,7 @@ checksum = "5fe87ce4529967e0ba1dcf8450bab64d97dfd5010a6256187ffe2e43e6f0e049"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1592,7 +1652,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1684,6 +1744,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1709,9 +1779,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -1757,9 +1827,9 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1837,7 +1907,7 @@ checksum = "7f7473c2cfcf90008193dd0e3e16599455cb601a9fce322b5bb55de799664925"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2029,6 +2099,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2124,7 +2200,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2320,6 +2396,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2362,9 +2444,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.37"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2509,7 +2591,7 @@ checksum = "8d9ef545650e79f30233c0003bcc2504d7efac6dad25fca40744de773fe2049c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2724,7 +2806,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2772,6 +2854,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bon",
  "bytes",
  "chrono",
  "comrak",
@@ -3375,5 +3458,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.98",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ parser = { path = "parser" }
 rust_team_data = { git = "https://github.com/rust-lang/team" }
 glob = "0.3.0"
 toml = "0.8.8"
-hyper = { version = "0.14.4", features = ["server", "stream"]}
+hyper = { version = "0.14.4", features = ["server", "stream"] }
 tokio = { version = "1.7.1", features = ["macros", "time", "rt"] }
 futures = { version = "0.3", default-features = false, features = ["std"] }
 async-trait = "0.1.31"
@@ -54,6 +54,9 @@ features = ["derive"]
 [dependencies.tera]
 version = "1.3.1"
 default-features = false
+
+[dev-dependencies]
+bon = "3"
 
 [profile.release]
 debug = 2

--- a/src/github.rs
+++ b/src/github.rs
@@ -15,7 +15,7 @@ use std::{
 };
 use tracing as log;
 
-#[derive(Debug, PartialEq, Eq, serde::Deserialize)]
+#[derive(Debug, PartialEq, Eq, serde::Deserialize, Clone)]
 pub struct User {
     pub login: String,
     pub id: u64,
@@ -364,13 +364,13 @@ pub struct Issue {
     /// The API URL for discussion comments.
     ///
     /// Example: `https://api.github.com/repos/octocat/Hello-World/issues/1347/comments`
-    comments_url: String,
+    pub comments_url: String,
     /// The repository for this issue.
     ///
     /// Note that this is constructed via the [`Issue::repository`] method.
     /// It is not deserialized from the GitHub API.
     #[serde(skip)]
-    repository: OnceCell<IssueRepository>,
+    pub repository: OnceCell<IssueRepository>,
 
     /// The base commit for a PR (the branch of the destination repo).
     #[serde(default)]

--- a/src/handlers/assign/tests/tests_db.rs
+++ b/src/handlers/assign/tests/tests_db.rs
@@ -3,14 +3,18 @@ mod tests {
     use crate::handlers::assign::filter_by_capacity;
     use crate::tests::run_test;
     use std::collections::HashSet;
+    use tokio_postgres::GenericClient;
 
     #[tokio::test]
     async fn find_reviewers_no_review_prefs() {
         run_test(|ctx| async move {
             ctx.add_user("usr1", 1).await;
-            ctx.add_user("usr2", 1).await;
-            let _users =
-                filter_by_capacity(ctx.db_client(), &candidates(&["usr1", "usr2"])).await?;
+            ctx.add_user("usr2", 2).await;
+            let _users = filter_by_capacity(
+                ctx.db_client().await.client(),
+                &candidates(&["usr1", "usr2"]),
+            )
+            .await?;
             // FIXME: this test fails, because the query is wrong
             // check_users(users, &["usr1", "usr2"]);
             Ok(ctx)

--- a/src/handlers/pr_tracking.rs
+++ b/src/handlers/pr_tracking.rs
@@ -238,7 +238,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn remove_pr_from_workqueue_on_assign() {
+    async fn remove_pr_from_workqueue_on_unassign() {
         run_test(|ctx| async move {
             let user = user("Martin", 2);
             set_assigned_prs(&ctx, &user, &[10]).await;
@@ -305,6 +305,7 @@ mod tests {
         .await;
     }
 
+    // Make sure that we only consider pull requests, not issues.
     #[tokio::test]
     async fn ignore_issue_assignments() {
         run_test(|ctx| async move {

--- a/src/tests/github.rs
+++ b/src/tests/github.rs
@@ -1,0 +1,80 @@
+use crate::github::{Issue, IssueState, PullRequestDetails, User};
+use bon::builder;
+use chrono::Utc;
+
+pub fn default_test_user() -> User {
+    User {
+        login: "triagebot-tester".to_string(),
+        id: 1,
+    }
+}
+
+pub fn user(login: &str, id: u64) -> User {
+    User {
+        login: login.to_string(),
+        id,
+    }
+}
+
+#[builder]
+pub fn issue(
+    state: Option<IssueState>,
+    number: Option<u64>,
+    author: Option<User>,
+    body: Option<&str>,
+    assignees: Option<Vec<User>>,
+    pr: Option<bool>,
+) -> Issue {
+    let number = number.unwrap_or(1);
+    let state = state.unwrap_or(IssueState::Open);
+    let author = author.unwrap_or(default_test_user());
+    let body = body.unwrap_or("").to_string();
+    let assignees = assignees.unwrap_or_default();
+    let pull_request = if pr.unwrap_or(false) {
+        Some(PullRequestDetails::new())
+    } else {
+        None
+    };
+
+    Issue {
+        number,
+        body,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        merge_commit_sha: None,
+        title: format!("Issue #{number}"),
+        html_url: "<html-url>".to_string(),
+        user: author,
+        labels: vec![],
+        assignees,
+        pull_request,
+        merged: false,
+        draft: false,
+        comments: None,
+        comments_url: "".to_string(),
+        repository: Default::default(),
+        base: None,
+        head: None,
+        state,
+        milestone: None,
+        mergeable: None,
+    }
+}
+
+#[builder]
+pub fn pull_request(
+    state: Option<IssueState>,
+    number: Option<u64>,
+    author: Option<User>,
+    body: Option<&str>,
+    assignees: Option<Vec<User>>,
+) -> Issue {
+    issue()
+        .maybe_state(state)
+        .maybe_number(number)
+        .maybe_author(author)
+        .maybe_body(body)
+        .maybe_assignees(assignees)
+        .pr(true)
+        .call()
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,22 +1,22 @@
 use crate::db;
-use crate::db::make_client;
 use crate::db::notifications::record_username;
+use crate::db::{make_client, ClientPool, PooledClient};
 use std::future::Future;
-use tokio_postgres::Config;
+use tokio_postgres::config::Host;
+use tokio_postgres::{Config, GenericClient};
 
 /// Represents a connection to a Postgres database that can be
 /// used in integration tests to test logic that interacts with
 /// a database.
 pub struct TestContext {
-    client: tokio_postgres::Client,
+    pool: ClientPool,
     db_name: String,
     original_db_url: String,
-    conn_handle: tokio::task::JoinHandle<()>,
 }
 
 impl TestContext {
     async fn new(db_url: &str) -> Self {
-        let mut config: Config = db_url.parse().expect("Cannot parse connection string");
+        let config: Config = db_url.parse().expect("Cannot parse connection string");
 
         // Create a new database that will be used for this specific test
         let client = make_client(&db_url)
@@ -31,32 +31,36 @@ impl TestContext {
 
         // We need to connect to the database against, because Postgres doesn't allow
         // changing the active database mid-connection.
-        config.dbname(&db_name);
-        let (mut client, connection) = config
-            .connect(tokio_postgres::NoTls)
-            .await
-            .expect("Cannot connect to the newly created database");
-        let conn_handle = tokio::spawn(async move {
-            connection.await.unwrap();
-        });
-
-        db::run_migrations(&mut client)
+        // There does not seem to be a way to turn the config back into a connection
+        // string, so construct it manually.
+        let test_db_url = format!(
+            "postgresql://{}:{}@{}/{}",
+            config.get_user().unwrap(),
+            String::from_utf8(config.get_password().unwrap().to_vec()).unwrap(),
+            match &config.get_hosts()[0] {
+                Host::Tcp(host) => host,
+                Host::Unix(_) =>
+                    panic!("Unix sockets in Postgres connection string are not supported"),
+            },
+            db_name
+        );
+        let pool = ClientPool::new(test_db_url);
+        db::run_migrations(&mut *pool.get().await)
             .await
             .expect("Cannot run database migrations");
         Self {
-            client,
+            pool,
             db_name,
             original_db_url: db_url.to_string(),
-            conn_handle,
         }
     }
 
-    pub fn db_client(&self) -> &tokio_postgres::Client {
-        &self.client
+    pub async fn db_client(&self) -> PooledClient {
+        self.pool.get().await
     }
 
     pub async fn add_user(&self, name: &str, id: u64) {
-        record_username(&self.client, id, name)
+        record_username(self.db_client().await.client(), id, name)
             .await
             .expect("Cannot create user");
     }
@@ -64,8 +68,7 @@ impl TestContext {
     async fn finish(self) {
         // Cleanup the test database
         // First, we need to stop using the database
-        drop(self.client);
-        self.conn_handle.await.unwrap();
+        drop(self.pool);
 
         // Then we need to connect to the default database and drop our test DB
         let client = make_client(&self.original_db_url)


### PR DESCRIPTION
This should improve the robustness of PR tracking, as before it was not taking (re)open/close/merge PR events into account. This PR also extends the test infrastructure. We still don't test the input/output GitHub API calls, but even just testing the DB is better than nothing.

Best reviewed commit by commit.

r? @apiraino :)