### PR TITLE
Fix overflowing integer when retrieving comments for FCP

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -648,7 +648,7 @@ impl Issue {
         self.state == IssueState::Open
     }
 
-    pub async fn get_comment(&self, client: &GithubClient, id: i32) -> anyhow::Result<Comment> {
+    pub async fn get_comment(&self, client: &GithubClient, id: u64) -> anyhow::Result<Comment> {
         let comment_url = format!("{}/issues/comments/{}", self.repository().url(client), id);
         let comment = client.json(client.get(&comment_url)).await?;
         Ok(comment)
@@ -2106,24 +2106,18 @@ impl<'q> IssuesQuery for Query<'q> {
                     );
                     let bot_tracking_comment_content = quote_reply(&fcp.status_comment.body);
                     let fk_initiating_comment = fcp.fcp.fk_initiating_comment;
-                    let (initiating_comment_html_url, initiating_comment_content) =
-                        if u32::try_from(fk_initiating_comment).is_err() {
-                            // We blew out the GH comment incremental counter (a i32 on their end)
-                            // See: https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/rfcbot.20asleep
-                            log::debug!("Ignoring overflowed comment id from GitHub");
-                            ("".to_string(), "".to_string())
-                        } else {
-                            let comment = issue
-                                .get_comment(&client, fk_initiating_comment.try_into()?)
-                                .await
-                                .with_context(|| {
-                                    format!(
-                                        "failed to get first comment id={} for fcp={}",
-                                        fk_initiating_comment, fcp.fcp.id
-                                    )
-                                })?;
-                            (comment.html_url, quote_reply(&comment.body))
-                        };
+                    let (initiating_comment_html_url, initiating_comment_content) = {
+                        let comment = issue
+                            .get_comment(&client, fk_initiating_comment)
+                            .await
+                            .with_context(|| {
+                                format!(
+                                    "failed to get first comment id={} for fcp={}",
+                                    fk_initiating_comment, fcp.fcp.id
+                                )
+                            })?;
+                        (comment.html_url, quote_reply(&comment.body))
+                    };
 
                     // TODO: agree with the team(s) a policy to emit actual mentions to remind FCP
                     // voting member to cast their vote

--- a/src/rfcbot.rs
+++ b/src/rfcbot.rs
@@ -7,9 +7,9 @@ pub struct FCP {
     pub id: u32,
     pub fk_issue: u32,
     pub fk_initiator: u32,
-    pub fk_initiating_comment: i32,
+    pub fk_initiating_comment: u64,
     pub disposition: Option<String>,
-    pub fk_bot_tracking_comment: i32,
+    pub fk_bot_tracking_comment: u64,
     pub fcp_start: Option<String>,
     pub fcp_closed: bool,
 }
@@ -50,7 +50,7 @@ pub struct FCPIssue {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct StatusComment {
-    pub id: i32,
+    pub id: u64,
     pub fk_issue: u32,
     pub fk_user: u32,
     pub body: String,


### PR DESCRIPTION
This is a patch I've been using locally since long, should be the final nail in the coffin to fix the overflowing GH ID issue we started experiencing a while ago.

I'd like to upstream it after some testing.