### PR TITLE
Allow anyone to relabel `CI-spurious-*`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,5 +1,5 @@
 [relabel]
-allow-unauthenticated = ["bug", "invalid", "question", "enhancement"]
+allow-unauthenticated = ["bug", "invalid", "question", "enhancement", "CI-spurious-*"]
 
 [assign]
 


### PR DESCRIPTION
As suggested by @Noratrieb in reference to me attempting to set this label in https://github.com/rust-lang/rust/pull/136780#issuecomment-2707364425, allow unauthenticated users to relabel `CI-spurious-*`.