### PR TITLE
Add no GitHub mentions in commits handler

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,7 @@ pub(crate) struct Config {
     pub(crate) bot_pull_requests: Option<BotPullRequests>,
     pub(crate) rendered_link: Option<RenderedLinkConfig>,
     pub(crate) canonicalize_issue_links: Option<CanonicalizeIssueLinksConfig>,
+    pub(crate) no_mentions: Option<NoMentionsConfig>,
 }
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]
@@ -420,6 +421,11 @@ pub(crate) struct RenderedLinkConfig {
 #[serde(deny_unknown_fields)]
 pub(crate) struct CanonicalizeIssueLinksConfig {}
 
+#[derive(PartialEq, Eq, Debug, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields)]
+pub(crate) struct NoMentionsConfig {}
+
 fn get_cached_config(repo: &str) -> Option<Result<Arc<Config>, ConfigurationError>> {
     let cache = CONFIG_CACHE.read().unwrap();
     cache.get(repo).and_then(|(config, fetch_time)| {
@@ -545,6 +551,8 @@ mod tests {
 
             [rendered-link]
             trigger-files = ["posts/"]
+
+            [no-mentions]
         "#;
         let config = toml::from_str::<Config>(&config).unwrap();
         let mut ping_teams = HashMap::new();
@@ -608,6 +616,7 @@ mod tests {
                     trigger_files: vec!["posts/".to_string()]
                 }),
                 canonicalize_issue_links: Some(CanonicalizeIssueLinksConfig {}),
+                no_mentions: Some(NoMentionsConfig {}),
             }
         );
     }
@@ -671,7 +680,8 @@ mod tests {
                 merge_conflicts: None,
                 bot_pull_requests: None,
                 rendered_link: None,
-                canonicalize_issue_links: None
+                canonicalize_issue_links: None,
+                no_mentions: None,
             }
         );
     }

--- a/src/handlers/check_commits.rs
+++ b/src/handlers/check_commits.rs
@@ -94,12 +94,7 @@ async fn handle_warnings(
                 .await?;
         }
 
-        // Format the warnings for user consumption on Github
-        let warnings: Vec<_> = warnings
-            .iter()
-            .map(|warning| format!("* {warning}"))
-            .collect();
-        let warning = format!(":warning: **Warning** :warning:\n\n{}", warnings.join("\n"));
+        let warning = warning_from_warnings(&warnings);
         let comment = event.issue.post_comment(&ctx.github, &warning).await?;
 
         // Save new state in the database
@@ -125,4 +120,13 @@ async fn handle_warnings(
     }
 
     Ok(())
+}
+
+// Format the warnings for user consumption on Github
+fn warning_from_warnings(warnings: &[String]) -> String {
+    let warnings: Vec<_> = warnings
+        .iter()
+        .map(|warning| format!("* {warning}"))
+        .collect();
+    format!(":warning: **Warning** :warning:\n\n{}", warnings.join("\n"))
 }

--- a/src/handlers/check_commits/modified_submodule.rs
+++ b/src/handlers/check_commits/modified_submodule.rs
@@ -1,6 +1,6 @@
 use crate::github::FileDiff;
 
-const SUBMODULE_WARNING_MSG: &str = "These commits modify **submodules**.";
+const SUBMODULE_WARNING_MSG: &str = "Some commits in this PR modify **submodules**.";
 
 /// Returns a message if the PR modifies a git submodule.
 pub(super) fn modifies_submodule(diff: &[FileDiff]) -> Option<String> {

--- a/src/handlers/check_commits/no_mentions.rs
+++ b/src/handlers/check_commits/no_mentions.rs
@@ -1,0 +1,56 @@
+//! Purpose: When opening a PR, or pushing new changes, check for github mentions
+//! in commits and notify the user of our no-mentions in commits policy.
+
+use std::fmt::Write;
+
+use crate::{config::NoMentionsConfig, github::GithubCommit};
+
+pub(super) fn mentions_in_commits(
+    _conf: &NoMentionsConfig,
+    commits: &[GithubCommit],
+) -> Option<String> {
+    let mut mentions_commits = Vec::new();
+
+    for commit in commits {
+        if !parser::get_mentions(&commit.commit.message).is_empty() {
+            mentions_commits.push(&*commit.sha);
+        }
+    }
+
+    if mentions_commits.is_empty() {
+        None
+    } else {
+        Some(mentions_in_commits_warn(mentions_commits))
+    }
+}
+
+fn mentions_in_commits_warn(commits: Vec<&str>) -> String {
+    let mut warning = format!("There are username mentions (such as `@user`) in the commit messages of the following commits.\n  *Please remove the mentions to avoid spamming these users.*\n");
+
+    for commit in commits {
+        let _ = writeln!(warning, "    - {commit}");
+    }
+
+    warning
+}
+
+#[test]
+fn test_warning_printing() {
+    let commits_to_warn = vec![
+        "4d6ze57403udfrzefrfe6574",
+        "f54efz57405u46z6ef465z4f6ze57",
+        "404u57403uzf5fe5f4f5e57405u4zf",
+    ];
+
+    let msg = mentions_in_commits_warn(commits_to_warn);
+
+    assert_eq!(
+        msg,
+        r#"There are username mentions (such as `@user`) in the commit messages of the following commits.
+  *Please remove the mentions to avoid spamming these users.*
+    - 4d6ze57403udfrzefrfe6574
+    - f54efz57405u46z6ef465z4f6ze57
+    - 404u57403uzf5fe5f4f5e57405u4zf
+"#
+    );
+}


### PR DESCRIPTION
This PR implements a no-mentions in commits handler. This is so that people are not spammed by GitHub when someone pushes a commit with their GitHub handle in it.

This is coming from https://github.com/rust-lang/rust/issues/137990. I should note that I also have been annoyed by that in the past.

The implementation is heavily inspired by the `[no-merges]` one.

The warning is gated behind the `[no-mentions]` config and produces such warning:

> There are mentions (`@mention`) in your commits. We have a no mention policy so these commits will need to be removed for this pull request to be merged.
>
> The following commits have mentions is them:
>  - commit1
>  - commit2

r? @ehuss