### PR TITLE
Implement setting review assignment limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,32 @@ Where the value in `--secret` is the secret value you place in `GITHUB_WEBHOOK_S
 
 If you are modifying code that sends message to Zulip and want to test your changes, you can register a [new free Zulip instance](https://zulip.com/new/). Before launching the triagebot locally, set the Zulip env vars to connect to your test instance (see example in `.env.sample`).
 
+You can also test Zulip webhooks locally with `curl`. For example, to test the Zulip hooks (commands sent to the
+Triagebot from the Rust lang Zulip), you start the triagebot on `localhost:8000` and then simulate a
+Zulip hook payload:
+``` sh
+curl http://localhost:8000/zulip-hook \
+    -H "Content-Type: application/json" \
+    -d '{
+        "data": "<CMD>",
+        "token": "<ZULIP_TOKEN>",
+        "message": {
+            "sender_id": <YOUR_ID>,
+            "recipient_id": <YOUR_ID>,
+            "sender_full_name": "Randolph Carter",
+            "sender_email": "r.carter@rust-lang.org",
+            "type": "stream"
+            }
+        }'
+```
+
+Where:
+- `CMD` is the exact command you would issue @triagebot on Zulip (ex. open a direct chat with the
+  bot and send "work show")
+- `ZULIP_TOKEN`: can be anything. Must correspond to the env var `$ZULIP_TOKEN` on your workstation
+- `YOUR_ID`: your GitHub user ID. Must be existing in your local triagebot database (table `users` and as
+  foreign key also in `review_prefs`)
+
 #### ngrok
 
 The following is an example of using <https://ngrok.com/> to provide webhook forwarding.

--- a/src/db.rs
+++ b/src/db.rs
@@ -10,6 +10,7 @@ use tokio_postgres::Client as DbClient;
 pub mod issue_data;
 pub mod jobs;
 pub mod notifications;
+pub mod review_prefs;
 pub mod rustc_commits;
 pub mod users;
 

--- a/src/db/review_prefs.rs
+++ b/src/db/review_prefs.rs
@@ -1,0 +1,37 @@
+use crate::github::UserId;
+use anyhow::Context;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct ReviewPrefs {
+    pub id: uuid::Uuid,
+    pub user_id: i64,
+    pub max_assigned_prs: Option<i32>,
+}
+
+impl From<tokio_postgres::row::Row> for ReviewPrefs {
+    fn from(row: tokio_postgres::row::Row) -> Self {
+        Self {
+            id: row.get("id"),
+            user_id: row.get("user_id"),
+            max_assigned_prs: row.get("max_assigned_prs"),
+        }
+    }
+}
+
+/// Get team member review preferences.
+/// If they are missing, returns `Ok(None)`.
+pub async fn get_review_prefs(
+    db: &tokio_postgres::Client,
+    user_id: UserId,
+) -> anyhow::Result<Option<ReviewPrefs>> {
+    let query = "
+SELECT id, user_id, max_assigned_prs
+FROM review_prefs
+WHERE review_prefs.user_id = $1;";
+    let row = db
+        .query_opt(query, &[&(user_id as i64)])
+        .await
+        .context("Error retrieving review preferences")?;
+    Ok(row.map(|r| r.into()))
+}

--- a/src/db/review_prefs.rs
+++ b/src/db/review_prefs.rs
@@ -1,4 +1,5 @@
-use crate::github::UserId;
+use crate::db::users::record_username;
+use crate::github::{User, UserId};
 use anyhow::Context;
 use serde::Serialize;
 
@@ -34,4 +35,95 @@ WHERE review_prefs.user_id = $1;";
         .await
         .context("Error retrieving review preferences")?;
     Ok(row.map(|r| r.into()))
+}
+
+/// Updates review preferences of the specified user, or creates them
+/// if they do not exist yet.
+pub async fn upsert_review_prefs(
+    db: &tokio_postgres::Client,
+    user: User,
+    max_assigned_prs: Option<u32>,
+) -> anyhow::Result<u64, anyhow::Error> {
+    // We need to have the user stored in the DB to have a valid FK link in review_prefs
+    record_username(db, user.id, &user.login).await?;
+
+    let max_assigned_prs = max_assigned_prs.map(|v| v as i32);
+    let query = "
+INSERT INTO review_prefs(user_id, max_assigned_prs)
+VALUES ($1, $2)
+ON CONFLICT (user_id)
+DO UPDATE
+SET max_assigned_prs = excluded.max_assigned_prs";
+
+    let res = db
+        .execute(query, &[&(user.id as i64), &max_assigned_prs])
+        .await
+        .context("Error upserting review preferences")?;
+    Ok(res)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::db::review_prefs::{get_review_prefs, upsert_review_prefs};
+    use crate::db::users::get_user;
+    use crate::tests::github::user;
+    use crate::tests::run_test;
+
+    #[tokio::test]
+    async fn insert_prefs_create_user() {
+        run_test(|ctx| async {
+            let db = ctx.db_client().await;
+
+            let user = user("Martin", 1);
+            upsert_review_prefs(&db, user.clone(), Some(1)).await?;
+
+            assert_eq!(get_user(&db, user.id).await?.unwrap(), user);
+
+            Ok(ctx)
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn insert_max_assigned_prs() {
+        run_test(|ctx| async {
+            let db = ctx.db_client().await;
+
+            upsert_review_prefs(&db, user("Martin", 1), Some(5)).await?;
+            assert_eq!(
+                get_review_prefs(&db, 1).await?.unwrap().max_assigned_prs,
+                Some(5)
+            );
+
+            Ok(ctx)
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn update_max_assigned_prs() {
+        run_test(|ctx| async {
+            let db = ctx.db_client().await;
+
+            upsert_review_prefs(&db, user("Martin", 1), Some(5)).await?;
+            assert_eq!(
+                get_review_prefs(&db, 1).await?.unwrap().max_assigned_prs,
+                Some(5)
+            );
+            upsert_review_prefs(&db, user("Martin", 1), Some(10)).await?;
+            assert_eq!(
+                get_review_prefs(&db, 1).await?.unwrap().max_assigned_prs,
+                Some(10)
+            );
+
+            upsert_review_prefs(&db, user("Martin", 1), None).await?;
+            assert_eq!(
+                get_review_prefs(&db, 1).await?.unwrap().max_assigned_prs,
+                None
+            );
+
+            Ok(ctx)
+        })
+        .await;
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,10 @@
 #![allow(clippy::new_without_default)]
 
-use crate::github::{PullRequestDetails, UserId};
+use crate::github::PullRequestDetails;
 
 use anyhow::Context;
 use handlers::HandlerError;
 use interactions::ErrorComment;
-use serde::Serialize;
 use std::fmt;
 use tracing as log;
 
@@ -123,40 +122,6 @@ impl From<anyhow::Error> for WebhookError {
     fn from(e: anyhow::Error) -> WebhookError {
         WebhookError(e)
     }
-}
-
-#[derive(Debug, Serialize)]
-pub struct ReviewPrefs {
-    pub id: uuid::Uuid,
-    pub user_id: i64,
-    pub max_assigned_prs: Option<i32>,
-}
-
-impl From<tokio_postgres::row::Row> for ReviewPrefs {
-    fn from(row: tokio_postgres::row::Row) -> Self {
-        Self {
-            id: row.get("id"),
-            user_id: row.get("user_id"),
-            max_assigned_prs: row.get("max_assigned_prs"),
-        }
-    }
-}
-
-/// Get team member review preferences.
-/// If they are missing, returns `Ok(None)`.
-pub async fn get_review_prefs(
-    db: &tokio_postgres::Client,
-    user_id: UserId,
-) -> anyhow::Result<Option<ReviewPrefs>> {
-    let query = "
-SELECT id, user_id, max_assigned_prs
-FROM review_prefs
-WHERE review_prefs.user_id = $1;";
-    let row = db
-        .query_opt(query, &[&(user_id as i64)])
-        .await
-        .context("Error retrieving review preferences")?;
-    Ok(row.map(|r| r.into()))
 }
 
 pub fn deserialize_payload<T: serde::de::DeserializeOwned>(v: &str) -> anyhow::Result<T> {

--- a/src/team_data.rs
+++ b/src/team_data.rs
@@ -1,6 +1,6 @@
 use crate::github::GithubClient;
 use anyhow::Context as _;
-use rust_team_data::v1::{Teams, ZulipMapping, BASE_URL};
+use rust_team_data::v1::{People, Teams, ZulipMapping, BASE_URL};
 use serde::de::DeserializeOwned;
 
 async fn by_url<T: DeserializeOwned>(client: &GithubClient, path: &str) -> anyhow::Result<T> {
@@ -35,4 +35,10 @@ pub async fn teams(client: &GithubClient) -> anyhow::Result<Teams> {
     by_url(client, "/teams.json")
         .await
         .context("team-api: teams.json")
+}
+
+pub async fn people(client: &GithubClient) -> anyhow::Result<People> {
+    by_url(client, "/people.json")
+        .await
+        .context("team-api: people.json")
 }

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -333,6 +333,9 @@ async fn workqueue_commands(
                 }
             )
         }
+        "help" => r"work show => show your assigned PRs
+work set-pr-limit <number>|unlimited => set the maximum number of PRs you can be assigned to"
+            .to_string(),
         _ => anyhow::bail!("Invalid subcommand."),
     };
 

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -301,11 +301,11 @@ async fn workqueue_commands(
                     if words.next().is_some() {
                         anyhow::bail!("Too many parameters.");
                     }
-                    if value == "none" {
+                    if value == "unlimited" {
                         None
                     } else {
                         Some(value.parse::<u32>().context(
-                            "Wrong parameter format. Must be a positive integer or `none` to unset the limit.",
+                            "Wrong parameter format. Must be a positive integer or `unlimited` to unset the limit.",
                         )?)
                     }
                 }

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -1,6 +1,6 @@
 use crate::db::notifications::add_metadata;
 use crate::db::notifications::{self, delete_ping, move_indices, record_ping, Identifier};
-use crate::get_review_prefs;
+use crate::db::review_prefs::get_review_prefs;
 use crate::github::{get_id_for_username, GithubClient};
 use crate::handlers::docs_update::docs_update;
 use crate::handlers::pr_tracking::get_assigned_prs;


### PR DESCRIPTION
This PR takes the logic from https://github.com/rust-lang/triagebot/pull/1854 and updates it to the updated DB schema. It also handles upsert of users into the DB, as we don't know in advance if they will be present there or not.

I renamed the command from `work set` to `work set-pr-limit`, but I don't care much about the naming here. I also added an option to reset the limit to unlimited (`NULL`) using `work set-pr-limit none`.

I don't think that we need a set of testing users here, as the limit is not taken into account when doing reviews yet. But it would be nice to have some data in the DB before we implement that (I plan to refactor PR assignment as a next step).

Best reviewed commit by commit.