### PR TITLE
Allow assigning to users on vacation

### DIFF
--- a/src/handlers/assign.rs
+++ b/src/handlers/assign.rs
@@ -978,9 +978,7 @@ fn candidate_reviewers_from_names<'a>(
         }
 
         // Assume it is a user.
-        if filter(&group_or_user) {
-            candidates.insert(group_or_user);
-        }
+        candidates.insert(group_or_user);
     }
     if candidates.is_empty() {
         let initial = names.iter().cloned().collect();

--- a/src/handlers/assign/tests/tests_candidates.rs
+++ b/src/handlers/assign/tests/tests_candidates.rs
@@ -273,18 +273,14 @@ fn vacation() {
     let config = toml::toml!(users_on_vacation = ["jyn514"]);
     let issue = generic_issue("octocat", "rust-lang/rust");
 
-    // Test that `r? user` falls through to assigning from the team.
-    // See `determine_assignee` - ideally we would test that function directly instead of indirectly through `find_reviewer_from_names`.
-    let err_names = vec!["jyn514".into()];
+    // Test that the user on vacation can still be assigned manually.
     test_from_names(
         Some(teams.clone()),
         config.clone(),
         issue.clone(),
         &["jyn514"],
-        Err(FindReviewerError::AllReviewersFiltered {
-            initial: err_names.clone(),
-            filtered: err_names,
-        }),
+        Ok(&["jyn514"]),
+
     );
 
     // Test that `r? bootstrap` doesn't assign from users on vacation.


### PR DESCRIPTION
People on vacation will usually not (they better >:() respond during their vacation, but they probably will be able to respond after. There is no reason why you wouldn't be able to assign to someone on vacation manually if this person is the best reviewer and you have enough patience for them to return, so don't prevent it. Do print a warning though to set expectations for both the author and triage.

If someone wants to be completely unassignable because they have left, they'll already be unassignable because they have left.

docs: https://github.com/rust-lang/rust-forge/pull/821