### PR TITLE
Switch CI to use a merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 on:
   push: {}
   pull_request: {}
-  schedule:
-    - cron: "0 12 * * 1" # Every Monday at 12:00 UTC
 
 env:
   AWS_ACCESS_KEY_ID: AKIA46X5W6CZEAQSMRH7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
+        uses: actions/checkout@v4
 
       - name: Test and build
         run: docker build -t triagebot .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
-  push: {}
-  pull_request: {}
+  pull_request:
+  merge_group:
 
 env:
   AWS_ACCESS_KEY_ID: AKIA46X5W6CZEAQSMRH7
@@ -30,9 +30,10 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all --check
 
-  ci:
-    name: CI
+  deploy:
+    name: Deploy
     runs-on: ubuntu-latest
+    if: github.event_name == 'merge_group'
     steps:
       - name: Checkout the source code
         uses: actions/checkout@v4
@@ -50,4 +51,22 @@ jobs:
           redeploy_ecs_service: triagebot
           aws_access_key_id: "${{ env.AWS_ACCESS_KEY_ID }}"
           aws_secret_access_key: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
-        if: github.ref == 'refs/heads/master'
+
+  # Summary job for the merge queue.
+  # ALL THE PREVIOUS JOBS NEED TO BE ADDED TO THE `needs` SECTION OF THIS JOB!
+  ci:
+    needs: [ test, deploy ]
+    # We need to ensure this job does *not* get skipped if its dependencies fail,
+    # because a skipped job is considered a success by GitHub. So we have to
+    # overwrite `if:`. We use `!cancelled()` to ensure the job does still not get run
+    # when the workflow is canceled manually.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      # Manually check the status of all dependencies. `if: failure()` does not work.
+      - name: Conclusion
+        run: |
+          # Print the dependent jobs to see them in the CI log
+          jq -C <<< '${{ toJson(needs) }}'
+          # Check if all jobs that we depend on (in the needs array) were successful.
+          jq --exit-status 'all(.result == "success" or .result == "skipped")' <<< '${{ toJson(needs) }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,6 @@ env:
   AWS_ACCESS_KEY_ID: AKIA46X5W6CZEAQSMRH7
 
 jobs:
-  rustfmt:
-    name: Rustfmt
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - name: Install Rust
-      run: rustup update stable && rustup default stable && rustup component add rustfmt
-    - run: cargo fmt --all --check
-
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -38,6 +29,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
         run: cargo test --workspace --all-targets
+      - name: Check formatting
+        run: cargo fmt --all --check
 
   ci:
     name: CI


### PR DESCRIPTION
To make it easier to make changes to triagebot, we should first gain more confidence in the fact that merged changes will actually work. One way of doing that is implementing more end-to-end tests, and also making sure that tests are always green before deploying. This PR switches this repository to a merge queue, to ensure the second part.

Before merging, a merge queue has to be configured on this repository.

I checked with @Mark-Simulacrum that the cron job wasn't used for anything.

CC @marcoieni