### PR TITLE
Require `test` job to succeed before starting `deploy` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    needs: [ test ]
     if: github.event_name == 'merge_group'
     steps:
       - name: Checkout the source code


### PR DESCRIPTION
I could sweat that I added the `needs` attribute there before, but it wasn't there.. :laughing: