### PR TITLE
Use GitHub Actions cache to make deploys faster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,15 @@ jobs:
       - name: Checkout the source code
         uses: actions/checkout@v4
 
-      - name: Test and build
-        run: docker build -t triagebot .
+      - uses: docker/setup-buildx-action@v3
+      - name: Test and build the Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          tags: triagebot
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Deploy to production
         uses: rust-lang/simpleinfra/github-actions/upload-docker-image@master


### PR DESCRIPTION
Building the Docker image took 5+ minutes, which is quite slow for deploying. This commit adds a GHA cache, using the same approach we use for bors.