### PR TITLE
Improve canonicalize issue links handler

### DIFF
--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -4,4 +4,5 @@ mod ignore_block;
 mod mentions;
 mod token;
 
+pub use ignore_block::replace_all_outside_ignore_blocks;
 pub use mentions::get_mentions;


### PR DESCRIPTION
This PR improves the canonicalize issue links handler by:
1. Taking into account ignore blocks (eg. `<!-- Fixes #1 -->`, shouldn't be canonicalized)
2. Taking every issue links into account, not just the action ones (not limited anymore to `Fixes` and the others)

To do the first I had to implement our own ~~custom~~ `Regex::replace_all` function which takes into account the ignore blocks from our parser.