### PR TITLE
Revert "Use GitHub Actions cache to make deploys faster"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,15 +39,8 @@ jobs:
       - name: Checkout the source code
         uses: actions/checkout@v4
 
-      - uses: docker/setup-buildx-action@v3
-      - name: Test and build the Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          tags: triagebot
-          load: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Test and build
+        run: docker build -t triagebot .
 
       - name: Deploy to production
         uses: rust-lang/simpleinfra/github-actions/upload-docker-image@master


### PR DESCRIPTION
Reverts rust-lang/triagebot#1925

I forgot that on triagebot (unlike bors), we deploy directly from the merge queue, and sadly there the cache doesn't work (https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Help.20with.20rust-analyzer's.20CI/with/510973141) :( So this only made things slower, because we were uploading the cache, but never consuming it.