### PR TITLE
Refactor assignment logic slightly

### DIFF
--- a/parser/src/command.rs
+++ b/parser/src/command.rs
@@ -322,7 +322,7 @@ fn review_commands() {
         let mut input = Input::new(input, vec!["bot"]);
         assert_eq!(
             input.next(),
-            Some(Command::Assign(Ok(assign::AssignCommand::ReviewName {
+            Some(Command::Assign(Ok(assign::AssignCommand::RequestReview {
                 name: name.to_string()
             })))
         );

--- a/parser/src/command/assign.rs
+++ b/parser/src/command/assign.rs
@@ -15,13 +15,13 @@ use std::fmt;
 #[derive(PartialEq, Eq, Debug)]
 pub enum AssignCommand {
     /// Corresponds to `@bot claim`.
-    Own,
+    Claim,
     /// Corresponds to `@bot release-assignment`.
-    Release,
+    ReleaseAssignment,
     /// Corresponds to `@bot assign @user`.
-    User { username: String },
+    AssignUser { username: String },
     /// Corresponds to `r? [@]user`.
-    ReviewName { name: String },
+    RequestReview { name: String },
 }
 
 #[derive(PartialEq, Eq, Debug)]
@@ -51,7 +51,7 @@ impl AssignCommand {
             if let Some(Token::Dot) | Some(Token::EndOfLine) = toks.peek_token()? {
                 toks.next_token()?;
                 *input = toks;
-                return Ok(Some(AssignCommand::Own));
+                return Ok(Some(AssignCommand::Claim));
             } else {
                 return Err(toks.error(ParseError::ExpectedEnd));
             }
@@ -59,7 +59,7 @@ impl AssignCommand {
             toks.next_token()?;
             if let Some(Token::Word(user)) = toks.next_token()? {
                 if user.starts_with('@') && user.len() != 1 {
-                    Ok(Some(AssignCommand::User {
+                    Ok(Some(AssignCommand::AssignUser {
                         username: user[1..].to_owned(),
                     }))
                 } else {
@@ -73,7 +73,7 @@ impl AssignCommand {
             if let Some(Token::Dot) | Some(Token::EndOfLine) = toks.peek_token()? {
                 toks.next_token()?;
                 *input = toks;
-                return Ok(Some(AssignCommand::Release));
+                return Ok(Some(AssignCommand::ReleaseAssignment));
             } else {
                 return Err(toks.error(ParseError::ExpectedEnd));
             }
@@ -90,7 +90,7 @@ impl AssignCommand {
                 if name.is_empty() {
                     return Err(input.error(ParseError::NoUser));
                 }
-                Ok(Some(AssignCommand::ReviewName { name }))
+                Ok(Some(AssignCommand::RequestReview { name }))
             }
             _ => Err(input.error(ParseError::NoUser)),
         }
@@ -108,19 +108,19 @@ mod tests {
 
     #[test]
     fn test_1() {
-        assert_eq!(parse("claim."), Ok(Some(AssignCommand::Own)),);
+        assert_eq!(parse("claim."), Ok(Some(AssignCommand::Claim)),);
     }
 
     #[test]
     fn test_2() {
-        assert_eq!(parse("claim"), Ok(Some(AssignCommand::Own)),);
+        assert_eq!(parse("claim"), Ok(Some(AssignCommand::Claim)),);
     }
 
     #[test]
     fn test_3() {
         assert_eq!(
             parse("assign @user"),
-            Ok(Some(AssignCommand::User {
+            Ok(Some(AssignCommand::AssignUser {
                 username: "user".to_owned()
             })),
         );
@@ -158,7 +158,7 @@ mod tests {
         ] {
             assert_eq!(
                 parse_review(input),
-                Ok(Some(AssignCommand::ReviewName {
+                Ok(Some(AssignCommand::RequestReview {
                     name: name.to_string()
                 })),
                 "failed on {input}"

--- a/parser/src/command/assign.rs
+++ b/parser/src/command/assign.rs
@@ -14,9 +14,13 @@ use std::fmt;
 
 #[derive(PartialEq, Eq, Debug)]
 pub enum AssignCommand {
+    /// Corresponds to `@bot claim`.
     Own,
+    /// Corresponds to `@bot release-assignment`.
     Release,
+    /// Corresponds to `@bot assign @user`.
     User { username: String },
+    /// Corresponds to `r? [@]user`.
     ReviewName { name: String },
 }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -308,7 +308,7 @@ macro_rules! command_handlers {
                     // case, just ignore it.
                     if commands
                         .iter()
-                        .all(|cmd| matches!(cmd, Command::Assign(Ok(AssignCommand::ReviewName { .. }))))
+                        .all(|cmd| matches!(cmd, Command::Assign(Ok(AssignCommand::RequestReview { .. }))))
                     {
                         return;
                     }

--- a/src/handlers/assign.rs
+++ b/src/handlers/assign.rs
@@ -70,9 +70,13 @@ Use `r?` to explicitly pick a reviewer";
 const RETURNING_USER_WELCOME_MESSAGE_NO_REVIEWER: &str =
     "@{author}: no appropriate reviewer found, use `r?` to override";
 
-const ON_VACATION_WARNING: &str = "{username} is on vacation.
+fn on_vacation_warning(username: &str) -> String {
+    format!(
+        r"{username} is on vacation.
 
-Please choose another assignee.";
+Please choose another assignee."
+    )
+}
 
 pub const SELF_ASSIGN_HAS_NO_CAPACITY: &str = "
 You have insufficient capacity to be assigned the pull request at this time. PR assignment has been reverted.
@@ -467,10 +471,7 @@ pub(super) async fn handle_command(
                 {
                     // This is a comment, so there must already be a reviewer assigned. No need to assign anyone else.
                     issue
-                        .post_comment(
-                            &ctx.github,
-                            &ON_VACATION_WARNING.replace("{username}", &username),
-                        )
+                        .post_comment(&ctx.github, &on_vacation_warning(&username))
                         .await?;
                     return Ok(());
                 }
@@ -700,7 +701,7 @@ impl fmt::Display for FindReviewerError {
                 write!(f, "{}", NO_REVIEWER_HAS_CAPACITY)
             }
             FindReviewerError::ReviewerOnVacation { username } => {
-                write!(f, "{}", ON_VACATION_WARNING.replace("{username}", username))
+                write!(f, "{}", on_vacation_warning(username))
             }
             FindReviewerError::ReviewerIsPrAuthor { username } => {
                 write!(

--- a/src/handlers/assign.rs
+++ b/src/handlers/assign.rs
@@ -503,23 +503,6 @@ pub(super) async fn handle_command(
                 }
                 let db_client = ctx.db.get().await;
                 if is_self_assign(&name, &event.user().login) {
-                    // let work_queue = has_user_capacity(&db_client, &name).await;
-                    // if work_queue.is_err() {
-                    //     // NOTE: disabled for now, just log
-                    //     log::warn!(
-                    //         "[#{}] PR self-assign failed, DB reported that user {} has no review capacity. Ignoring.",
-                    //         issue.number,
-                    //         name
-                    //     );
-                    //     // issue
-                    //     //     .post_comment(
-                    //     //         &ctx.github,
-                    //     //         &REVIEWER_HAS_NO_CAPACITY.replace("{username}", &name),
-                    //     //     )
-                    //     //     .await?;
-                    //     // return Ok(());
-                    // }
-
                     name.to_string()
                 } else {
                     let teams = crate::team_data::teams(&ctx.github).await?;
@@ -620,7 +603,6 @@ pub(super) async fn handle_command(
 
     e.apply(&ctx.github, String::new(), &data).await?;
 
-    // Assign the PR: user's work queue has been checked and can accept this PR
     match issue.set_assignee(&ctx.github, &to_assign).await {
         Ok(()) => return Ok(()), // we are done
         Err(github::AssignmentError::InvalidAssignee) => {


### PR DESCRIPTION
Before moving forward with using the PR workqueue for determining who to assign, I want to first refactor the assignment logic to make it easier to follow and understand, and also write more tests for it.

This PR just slightly refactors a few things and removes/adds comments.