### PR TITLE
Post a comment when label does not exist

### DIFF
--- a/src/handlers/relabel.rs
+++ b/src/handlers/relabel.rs
@@ -10,6 +10,7 @@
 
 use crate::{
     config::RelabelConfig,
+    github::UnknownLabels,
     github::{self, Event, GithubClient},
     handlers::Context,
     interactions::ErrorComment,
@@ -71,6 +72,14 @@ pub(super) async fn handle_command(
             event.issue().unwrap().global_id(),
             e
         );
+        if let Some(err @ UnknownLabels { .. }) = e.downcast_ref() {
+            event
+                .issue()
+                .unwrap()
+                .post_comment(&ctx.github, &err.to_string())
+                .await?;
+        }
+
         return Err(e);
     }
 


### PR DESCRIPTION
This fixes the case when a user posts a comment editing an issue/pr labels and mistakenly mispells a label. The triagebot silently fails leaving the user wondering why the label wasn't applied. This patch makes it so, that a comment is posted, warning the user if non-existing label(s) were tried.

Patch discussed on [Zulip](https://rust-lang.zulipchat.com/#narrow/channel/224082-triagebot/topic/triagebot.20does.20not.20parse.20labels.20with.20dots/near/500692007), original context was [triagebot#1903](https://togithub.com/rust-lang/triagebot/issues/1903)

Thanks for checking this out!

r? @rust-lang/triagebot