### PR TITLE
Suggest update the branch when behind too many commits

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -1458,7 +1458,7 @@ impl Repository {
 
     /// Returns a list of commits between the SHA ranges of start (exclusive)
     /// and end (inclusive).
-    pub async fn commits_in_range(
+    pub async fn github_commits_in_range(
         &self,
         client: &GithubClient,
         start: &str,
@@ -1497,6 +1497,18 @@ impl Repository {
             }
             page += 1;
         }
+    }
+
+    pub async fn github_commit(
+        &self,
+        client: &GithubClient,
+        sha: &str,
+    ) -> anyhow::Result<GithubCommit> {
+        let url = format!("{}/commits/{}", self.url(client), sha);
+        client
+            .json(client.get(&url))
+            .await
+            .with_context(|| format!("{} failed to get github commit {sha}", self.full_name))
     }
 
     /// Retrieves a git commit for the given SHA.

--- a/src/handlers/check_commits/behind_upstream.rs
+++ b/src/handlers/check_commits/behind_upstream.rs
@@ -1,0 +1,102 @@
+use crate::github::{GithubClient, GithubCommit, IssuesEvent, Repository};
+use tracing as log;
+
+/// Default threshold for parent commit age in days to trigger a warning
+pub const DEFAULT_DAYS_THRESHOLD: usize = 7;
+
+/// Check if the PR is based on an old parent commit
+pub async fn behind_upstream(
+    age_threshold: usize,
+    event: &IssuesEvent,
+    client: &GithubClient,
+    commits: &Vec<GithubCommit>,
+) -> Option<String> {
+    log::debug!("Checking if PR #{} is behind upstream", event.issue.number);
+
+    let Some(head_commit) = commits.first() else {
+        return None;
+    };
+
+    // First try the parent commit age check as it's more accurate
+    match is_parent_commit_too_old(head_commit, &event.repository, client, age_threshold).await {
+        Ok(Some(days_old)) => {
+            log::info!(
+                "PR #{} has a parent commit that is {} days old",
+                event.issue.number,
+                days_old
+            );
+
+            return Some(format!(
+                r"This PR is based on an upstream commit that is {} days old.
+
+    *It's recommended to update your branch according to the [rustc_dev_guide](https://rustc-dev-guide.rust-lang.org/contributing.html#keeping-your-branch-up-to-date).*",
+                days_old
+            ));
+        }
+        Ok(None) => {
+            // Parent commit is not too old, log and do nothing
+            log::debug!("PR #{} parent commit is not too old", event.issue.number);
+        }
+        Err(e) => {
+            // Error checking parent commit age, log and do nothing
+            log::error!(
+                "Error checking parent commit age for PR #{}: {}",
+                event.issue.number,
+                e
+            );
+        }
+    }
+
+    None
+}
+
+/// Checks if the PR's parent commit is too old.
+///
+/// This determines if a PR needs updating by examining the first parent of the PR's head commit,
+/// which typically represents the base branch commit that the PR is based on.
+///
+/// If this parent commit is older than the specified threshold, it suggests the PR
+/// should be updated/rebased to a more recent version of the base branch.
+///
+/// Returns:
+/// - Ok(Some(days_old)) - If parent commit is older than the threshold
+/// - Ok(None)
+///     - If there is no parent commit
+///     - If parent is within threshold
+/// - Err(...) - If an error occurred during processing
+pub async fn is_parent_commit_too_old(
+    commit: &GithubCommit,
+    repo: &Repository,
+    client: &GithubClient,
+    max_days_old: usize,
+) -> anyhow::Result<Option<usize>> {
+    // Get the first parent (it should be from the base branch)
+    let Some(parent_sha) = commit.parents.get(0).map(|c| c.sha.clone()) else {
+        return Ok(None);
+    };
+
+    let days_old = commit_days_old(&parent_sha, repo, client).await?;
+
+    if days_old > max_days_old {
+        Ok(Some(days_old))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Returns the number of days old the commit is
+pub async fn commit_days_old(
+    sha: &str,
+    repo: &Repository,
+    client: &GithubClient,
+) -> anyhow::Result<usize> {
+    // Get the commit details to check its date
+    let commit: GithubCommit = repo.github_commit(client, &sha).await?;
+
+    // compute the number of days old the commit is
+    let commit_date = commit.commit.author.date;
+    let now = chrono::Utc::now().with_timezone(&commit_date.timezone());
+    let days_old = (now - commit_date).num_days() as usize;
+
+    Ok(days_old)
+}

--- a/src/handlers/milestone_prs.rs
+++ b/src/handlers/milestone_prs.rs
@@ -134,7 +134,7 @@ async fn milestone_cargo(
     let cargo_repo = gh.repository("rust-lang/cargo").await?;
     log::info!("loading cargo changes {cargo_start_hash}...{cargo_end_hash}");
     let commits = cargo_repo
-        .commits_in_range(gh, cargo_start_hash, cargo_end_hash)
+        .github_commits_in_range(gh, cargo_start_hash, cargo_end_hash)
         .await?;
 
     // For each commit, look for a message from bors that indicates which


### PR DESCRIPTION
As discussion in [#t-compiler/rustc-dev-guide > A reminder in the doc to try to work with &#96;rust-lang/rust&#96;](https://rust-lang.zulipchat.com/#narrow/channel/196385-t-compiler.2Frustc-dev-guide/topic/A.20reminder.20in.20the.20doc.20to.20try.20to.20work.20with.20.60rust-lang.2Frust.60), I add this feature. But I haven't test it (That may takes some time). Do I need to test it locally?

cc @Kobzol 