### PR TITLE
Take review preferences into account when determining reviewers

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -94,6 +94,10 @@ pub(crate) struct PingTeamConfig {
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
+pub(crate) struct AssignReviewPrefsConfig {}
+
+#[derive(PartialEq, Eq, Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct AssignConfig {
     /// If enabled, then posts a warning comment if the PR is opened against a
     /// different branch than the default (usually master or main).
@@ -111,6 +115,9 @@ pub(crate) struct AssignConfig {
     pub(crate) owners: HashMap<String, Vec<String>>,
     #[serde(default)]
     pub(crate) users_on_vacation: HashSet<String>,
+    /// Should review preferences be taken into account when deciding who to assign to a PR?
+    #[serde(default)]
+    pub(crate) review_prefs: Option<AssignReviewPrefsConfig>,
 }
 
 impl AssignConfig {
@@ -656,6 +663,7 @@ mod tests {
                     adhoc_groups: HashMap::new(),
                     owners: HashMap::new(),
                     users_on_vacation: HashSet::from(["jyn514".into()]),
+                    review_prefs: None,
                 }),
                 note: Some(NoteConfig { _empty: () }),
                 ping: Some(PingConfig { teams: ping_teams }),
@@ -736,6 +744,7 @@ mod tests {
                     adhoc_groups: HashMap::new(),
                     owners: HashMap::new(),
                     users_on_vacation: HashSet::new(),
+                    review_prefs: None,
                 }),
                 note: None,
                 ping: None,

--- a/src/db/review_prefs.rs
+++ b/src/db/review_prefs.rs
@@ -117,12 +117,9 @@ mod tests {
     #[tokio::test]
     async fn insert_prefs_create_user() {
         run_db_test(|ctx| async {
-            let db = ctx.db_client().await;
-
             let user = user("Martin", 1);
-            upsert_review_prefs(&db, user.clone(), Some(1)).await?;
-
-            assert_eq!(get_user(&db, user.id).await?.unwrap(), user);
+            upsert_review_prefs(&ctx.db_client(), user.clone(), Some(1)).await?;
+            assert_eq!(get_user(&ctx.db_client(), user.id).await?.unwrap(), user);
 
             Ok(ctx)
         })
@@ -132,11 +129,12 @@ mod tests {
     #[tokio::test]
     async fn insert_max_assigned_prs() {
         run_db_test(|ctx| async {
-            let db = ctx.db_client().await;
-
-            upsert_review_prefs(&db, user("Martin", 1), Some(5)).await?;
+            upsert_review_prefs(&ctx.db_client(), user("Martin", 1), Some(5)).await?;
             assert_eq!(
-                get_review_prefs(&db, 1).await?.unwrap().max_assigned_prs,
+                get_review_prefs(&ctx.db_client(), 1)
+                    .await?
+                    .unwrap()
+                    .max_assigned_prs,
                 Some(5)
             );
 
@@ -148,7 +146,7 @@ mod tests {
     #[tokio::test]
     async fn update_max_assigned_prs() {
         run_db_test(|ctx| async {
-            let db = ctx.db_client().await;
+            let db = ctx.db_client();
 
             upsert_review_prefs(&db, user("Martin", 1), Some(5)).await?;
             assert_eq!(

--- a/src/db/review_prefs.rs
+++ b/src/db/review_prefs.rs
@@ -112,11 +112,11 @@ mod tests {
     use crate::db::review_prefs::{get_review_prefs, upsert_review_prefs};
     use crate::db::users::get_user;
     use crate::tests::github::user;
-    use crate::tests::run_test;
+    use crate::tests::run_db_test;
 
     #[tokio::test]
     async fn insert_prefs_create_user() {
-        run_test(|ctx| async {
+        run_db_test(|ctx| async {
             let db = ctx.db_client().await;
 
             let user = user("Martin", 1);
@@ -131,7 +131,7 @@ mod tests {
 
     #[tokio::test]
     async fn insert_max_assigned_prs() {
-        run_test(|ctx| async {
+        run_db_test(|ctx| async {
             let db = ctx.db_client().await;
 
             upsert_review_prefs(&db, user("Martin", 1), Some(5)).await?;
@@ -147,7 +147,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_max_assigned_prs() {
-        run_test(|ctx| async {
+        run_db_test(|ctx| async {
             let db = ctx.db_client().await;
 
             upsert_review_prefs(&db, user("Martin", 1), Some(5)).await?;

--- a/src/db/review_prefs.rs
+++ b/src/db/review_prefs.rs
@@ -2,6 +2,7 @@ use crate::db::users::record_username;
 use crate::github::{User, UserId};
 use anyhow::Context;
 use serde::Serialize;
+use std::collections::HashMap;
 
 #[derive(Debug, Serialize)]
 pub struct ReviewPrefs {
@@ -35,6 +36,50 @@ WHERE review_prefs.user_id = $1;";
         .await
         .context("Error retrieving review preferences")?;
     Ok(row.map(|r| r.into()))
+}
+
+/// Returns a set of review preferences for all passed usernames.
+/// Usernames are matched regardless of case.
+///
+/// Usernames that are not present in the resulting map have no review preferences configured
+/// in the database.
+pub async fn get_review_prefs_batch<'a>(
+    db: &tokio_postgres::Client,
+    users: &[&'a str],
+) -> anyhow::Result<HashMap<&'a str, ReviewPrefs>> {
+    // We need to make sure that we match users regardless of case, but at the
+    // same time we need to return the originally-cased usernames in the final hashmap.
+    // At the same time, we can't depend on the order of results returned by the DB.
+    // So we need to do some additional bookkeeping here.
+    let lowercase_map: HashMap<String, &str> = users
+        .iter()
+        .map(|name| (name.to_lowercase(), *name))
+        .collect();
+    let lowercase_users: Vec<&str> = lowercase_map.keys().map(|s| s.as_str()).collect();
+
+    // The id/user_id/max_assigned_prs columns have to match the names used in
+    // `From<tokio_postgres::row::Row> for ReviewPrefs`.
+    let query = "
+SELECT lower(u.username) AS username, r.id AS id, r.user_id AS user_id, r.max_assigned_prs AS max_assigned_prs
+FROM review_prefs AS r
+JOIN users AS u ON u.user_id = r.user_id
+WHERE lower(u.username) = ANY($1);";
+
+    Ok(db
+        .query(query, &[&lowercase_users])
+        .await
+        .context("Error retrieving review preferences from usernames")?
+        .into_iter()
+        .map(|row| {
+            // Map back from the lowercase username to the original username.
+            let username_lower: &str = row.get("username");
+            let username = lowercase_map
+                .get(username_lower)
+                .expect("Lowercase username not found");
+            let prefs: ReviewPrefs = row.into();
+            (*username, prefs)
+        })
+        .collect())
 }
 
 /// Updates review preferences of the specified user, or creates them

--- a/src/db/users.rs
+++ b/src/db/users.rs
@@ -41,11 +41,11 @@ WHERE user_id = $1;",
 #[cfg(test)]
 mod tests {
     use crate::db::users::{get_user, record_username};
-    use crate::tests::run_test;
+    use crate::tests::run_db_test;
 
     #[tokio::test]
     async fn update_username_on_conflict() {
-        run_test(|ctx| async {
+        run_db_test(|ctx| async {
             let db = ctx.db_client().await;
 
             record_username(&db, 1, "Foo").await?;

--- a/src/db/users.rs
+++ b/src/db/users.rs
@@ -46,7 +46,7 @@ mod tests {
     #[tokio::test]
     async fn update_username_on_conflict() {
         run_db_test(|ctx| async {
-            let db = ctx.db_client().await;
+            let db = ctx.db_client();
 
             record_username(&db, 1, "Foo").await?;
             record_username(&db, 1, "Bar").await?;

--- a/src/handlers/assign.rs
+++ b/src/handlers/assign.rs
@@ -20,6 +20,8 @@
 //! `assign.owners` config, it will auto-select an assignee based on the files
 //! the PR modifies.
 
+use crate::db::review_prefs::get_review_prefs_batch;
+use crate::github::UserId;
 use crate::handlers::pr_tracking::ReviewerWorkqueue;
 use crate::{
     config::AssignConfig,
@@ -345,7 +347,9 @@ async fn determine_assignee(
                     e @ FindReviewerError::NoReviewer { .. }
                     | e @ FindReviewerError::ReviewerIsPrAuthor { .. }
                     | e @ FindReviewerError::ReviewerAlreadyAssigned { .. }
-                    | e @ FindReviewerError::ReviewerOnVacation { .. },
+                    | e @ FindReviewerError::ReviewerOnVacation { .. }
+                    | e @ FindReviewerError::DatabaseError(_)
+                    | e @ FindReviewerError::ReviewerAtMaxCapacity { .. },
                 ) => log::trace!(
                     "no reviewer could be determined for PR {}: {e}",
                     event.issue.global_id()
@@ -675,6 +679,10 @@ enum FindReviewerError {
     ReviewerIsPrAuthor { username: String },
     /// Requested reviewer is already assigned to that PR
     ReviewerAlreadyAssigned { username: String },
+    /// Data required for assignment could not be loaded from the DB.
+    DatabaseError(String),
+    /// The reviewer has too many PRs alreayd assigned.
+    ReviewerAtMaxCapacity { username: String },
 }
 
 impl std::error::Error for FindReviewerError {}
@@ -717,6 +725,17 @@ impl fmt::Display for FindReviewerError {
                     REVIEWER_ALREADY_ASSIGNED.replace("{username}", username)
                 )
             }
+            FindReviewerError::DatabaseError(error) => {
+                write!(f, "Database error: {error}")
+            }
+            FindReviewerError::ReviewerAtMaxCapacity { username } => {
+                write!(
+                    f,
+                    r"`{username}` has too many PRs assigned to them.
+
+Please select a different reviewer.",
+                )
+            }
         }
     }
 }
@@ -728,7 +747,7 @@ impl fmt::Display for FindReviewerError {
 /// auto-assign groups, or rust-lang team names. It must have at least one
 /// entry.
 async fn find_reviewer_from_names(
-    _db: &DbClient,
+    db: &DbClient,
     workqueue: Arc<RwLock<ReviewerWorkqueue>>,
     teams: &Teams,
     config: &AssignConfig,
@@ -742,7 +761,10 @@ async fn find_reviewer_from_names(
         }
     }
 
-    let candidates = candidate_reviewers_from_names(workqueue, teams, config, issue, names)?;
+    let candidates =
+        candidate_reviewers_from_names(db, workqueue, teams, config, issue, names).await?;
+    assert!(!candidates.is_empty());
+
     // This uses a relatively primitive random choice algorithm.
     // GitHub's CODEOWNERS supports much more sophisticated options, such as:
     //
@@ -846,13 +868,15 @@ fn expand_teams_and_groups(
 
 /// Returns a list of candidate usernames (from relevant teams) to choose as a reviewer.
 /// If not reviewer is available, returns an error.
-fn candidate_reviewers_from_names<'a>(
+async fn candidate_reviewers_from_names<'a>(
+    db: &DbClient,
     workqueue: Arc<RwLock<ReviewerWorkqueue>>,
     teams: &'a Teams,
     config: &'a AssignConfig,
     issue: &Issue,
     names: &'a [String],
 ) -> Result<HashSet<String>, FindReviewerError> {
+    // Step 1: expand teams and groups into candidate names
     let (expanded, expansion_happened) = expand_teams_and_groups(teams, issue, config, names)?;
     let expanded_count = expanded.len();
 
@@ -860,6 +884,7 @@ fn candidate_reviewers_from_names<'a>(
     // We go through each expanded candidate and store either success or an error for them.
     let mut candidates: Vec<Result<String, FindReviewerError>> = Vec::new();
 
+    // Step 2: pre-filter candidates based on checks that we can perform quickly
     for candidate in expanded {
         let name_lower = candidate.to_lowercase();
         let is_pr_author = name_lower == issue.user.login.to_lowercase();
@@ -896,9 +921,50 @@ fn candidate_reviewers_from_names<'a>(
     }
     assert_eq!(candidates.len(), expanded_count);
 
-    let valid_candidates: HashSet<String> = candidates
+    if config.review_prefs.is_some() {
+        // Step 3: gather potential usernames to form a DB query for review preferences
+        let usernames: Vec<String> = candidates
+            .iter()
+            .filter_map(|res| res.as_deref().ok().map(|s| s.to_string()))
+            .collect();
+        let usernames: Vec<&str> = usernames.iter().map(|s| s.as_str()).collect();
+        let review_prefs = get_review_prefs_batch(db, &usernames)
+            .await
+            .context("cannot fetch review preferences")
+            .map_err(|e| FindReviewerError::DatabaseError(e.to_string()))?;
+
+        let workqueue = workqueue.read().await;
+
+        // Step 4: check review preferences
+        candidates = candidates
+            .into_iter()
+            .map(|username| {
+                // Only consider candidates that did not have an earlier error
+                let username = username?;
+
+                // If no review prefs were found, we assume the default unlimited
+                // review capacity.
+                let Some(review_prefs) = review_prefs.get(username.as_str()) else {
+                    return Ok(username);
+                };
+                let Some(capacity) = review_prefs.max_assigned_prs else {
+                    return Ok(username);
+                };
+                let assigned_prs = workqueue.assigned_pr_count(review_prefs.user_id as UserId);
+                // Can we assign one more PR?
+                if (assigned_prs as i32) < capacity {
+                    Ok(username)
+                } else {
+                    Err(FindReviewerError::ReviewerAtMaxCapacity { username })
+                }
+            })
+            .collect();
+    }
+    assert_eq!(candidates.len(), expanded_count);
+
+    let valid_candidates: HashSet<&str> = candidates
         .iter()
-        .filter_map(|res| res.as_ref().ok().cloned())
+        .filter_map(|res| res.as_deref().ok())
         .collect();
 
     if valid_candidates.is_empty() {
@@ -925,6 +991,9 @@ fn candidate_reviewers_from_names<'a>(
             })
         }
     } else {
-        Ok(valid_candidates)
+        Ok(valid_candidates
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect())
     }
 }

--- a/src/handlers/pr_tracking.rs
+++ b/src/handlers/pr_tracking.rs
@@ -281,11 +281,11 @@ mod tests {
     use crate::github::{Label, PullRequestNumber};
     use crate::handlers::pr_tracking::{handle_input, parse_input, upsert_pr_into_user_queue};
     use crate::tests::github::{default_test_user, issue, pull_request, user};
-    use crate::tests::{run_test, TestContext};
+    use crate::tests::{run_db_test, TestContext};
 
     #[tokio::test]
     async fn add_pr_to_workqueue_on_assign() {
-        run_test(|ctx| async move {
+        run_db_test(|ctx| async move {
             let user = user("Martin", 2);
 
             run_handler(
@@ -332,7 +332,7 @@ mod tests {
 
     #[tokio::test]
     async fn remove_pr_from_workqueue_on_unassign() {
-        run_test(|ctx| async move {
+        run_db_test(|ctx| async move {
             let user = user("Martin", 2);
             set_assigned_prs(&ctx, &user, &[10]).await;
 
@@ -394,7 +394,7 @@ mod tests {
 
     #[tokio::test]
     async fn remove_pr_from_workqueue_on_pr_closed() {
-        run_test(|ctx| async move {
+        run_db_test(|ctx| async move {
             let user = user("Martin", 2);
             set_assigned_prs(&ctx, &user, &[10]).await;
 
@@ -417,7 +417,7 @@ mod tests {
 
     #[tokio::test]
     async fn add_pr_to_workqueue_on_pr_reopen() {
-        run_test(|ctx| async move {
+        run_db_test(|ctx| async move {
             let user = user("Martin", 2);
             set_assigned_prs(&ctx, &user, &[42]).await;
 
@@ -442,7 +442,7 @@ mod tests {
     // Make sure that we only consider pull requests, not issues.
     #[tokio::test]
     async fn ignore_issue_assignments() {
-        run_test(|ctx| async move {
+        run_db_test(|ctx| async move {
             let user = user("Martin", 2);
 
             run_handler(

--- a/src/handlers/pr_tracking.rs
+++ b/src/handlers/pr_tracking.rs
@@ -314,7 +314,7 @@ mod tests {
 
     #[tokio::test]
     async fn ignore_blocked_pr() {
-        run_test(|ctx| async move {
+        run_db_test(|ctx| async move {
             let user = user("Martin", 2);
 
             run_handler(
@@ -362,7 +362,7 @@ mod tests {
 
     #[tokio::test]
     async fn add_pr_to_workqueue_on_label() {
-        run_test(|ctx| async move {
+        run_db_test(|ctx| async move {
             let user = user("Martin", 2);
 
             run_handler(

--- a/src/handlers/pr_tracking.rs
+++ b/src/handlers/pr_tracking.rs
@@ -43,6 +43,11 @@ impl ReviewerWorkqueue {
             .map(|prs| prs.len() as u64)
             .unwrap_or(0)
     }
+
+    #[cfg(test)]
+    pub fn set_user_prs(&mut self, user_id: UserId, prs: HashSet<PullRequestNumber>) {
+        self.reviewers.insert(user_id, prs);
+    }
 }
 
 pub(super) enum ReviewPrefsInput {

--- a/src/handlers/pr_tracking.rs
+++ b/src/handlers/pr_tracking.rs
@@ -36,6 +36,13 @@ impl ReviewerWorkqueue {
     pub fn new(reviewers: HashMap<UserId, HashSet<PullRequestNumber>>) -> Self {
         Self { reviewers }
     }
+
+    pub fn assigned_pr_count(&self, user_id: UserId) -> u64 {
+        self.reviewers
+            .get(&user_id)
+            .map(|prs| prs.len() as u64)
+            .unwrap_or(0)
+    }
 }
 
 pub(super) enum ReviewPrefsInput {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -114,7 +114,7 @@ impl TestContext {
     }
 }
 
-pub(crate) async fn run_test<F, Fut>(f: F)
+pub(crate) async fn run_db_test<F, Fut>(f: F)
 where
     F: FnOnce(TestContext) -> Fut,
     Fut: Future<Output = anyhow::Result<TestContext>>,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -8,7 +8,7 @@ use std::future::Future;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio_postgres::config::Host;
-use tokio_postgres::{Config, GenericClient};
+use tokio_postgres::Config;
 
 pub(crate) mod github;
 
@@ -16,10 +16,11 @@ pub(crate) mod github;
 /// used in integration tests to test logic that interacts with
 /// a database.
 pub(crate) struct TestContext {
-    pool: ClientPool,
     ctx: Context,
     db_name: String,
     original_db_url: String,
+    // Pre-cached client to avoid creating unnecessary connections in tests
+    client: PooledClient,
 }
 
 impl TestContext {
@@ -53,7 +54,8 @@ impl TestContext {
             db_name
         );
         let pool = ClientPool::new(test_db_url.clone());
-        db::run_migrations(&mut *pool.get().await)
+        let mut client = pool.get().await;
+        db::run_migrations(&mut client)
             .await
             .expect("Cannot run database migrations");
 
@@ -66,17 +68,17 @@ impl TestContext {
         );
         let ctx = Context {
             github,
-            db: ClientPool::new(test_db_url),
+            db: pool,
             username: "triagebot-test".to_string(),
             octocrab,
             workqueue: Arc::new(RwLock::new(Default::default())),
         };
 
         Self {
-            pool,
             db_name,
             original_db_url: db_url.to_string(),
             ctx,
+            client,
         }
     }
 
@@ -87,13 +89,12 @@ impl TestContext {
         &self.ctx
     }
 
-    pub(crate) async fn db_client(&self) -> PooledClient {
-        self.pool.get().await
+    pub(crate) fn db_client(&self) -> &PooledClient {
+        &self.client
     }
 
-    #[allow(dead_code)]
     pub(crate) async fn add_user(&self, name: &str, id: u64) {
-        record_username(self.db_client().await.client(), id, name)
+        record_username(self.db_client(), id, name)
             .await
             .expect("Cannot create user");
     }
@@ -101,7 +102,8 @@ impl TestContext {
     async fn finish(self) {
         // Cleanup the test database
         // First, we need to stop using the database
-        drop(self.pool);
+        drop(self.client);
+        drop(self.ctx);
 
         // Then we need to connect to the default database and drop our test DB
         let client = make_client(&self.original_db_url)


### PR DESCRIPTION
This PR implements step 6 of https://github.com/rust-lang/triagebot/issues/1753. When `[assign.review_prefs]` is configured in `triagebot.toml`, triagebot will now take into account the number of PRs already assigned to a reviewer, and their reviewer preferences.

Users can set their review preferences by sending a DM to triagebot on Zulip, and sending `work set-pr-limit <max-prs>` (this was implemented in https://github.com/rust-lang/triagebot/pull/1919). When a reviewer already has `N` PRs assigned where `N >= max-prs`, they will not be considered for assignment.

Note that the way this is currently implemented, the assigned PR tracking only works for `rust-lang/rust`, so it should not be enabled on any other repo.

There are a couple of questions in the design that we should consider (they do not necessarily block this PR though):
- Should the assigned PR tracking be within a repository or across repositories? In other words, do reviewers want to configure a "max assigned PR limit" across the whole of rust-lang, or do they want to have a limit per repository?  
- Should we only consider open PRs or open + draft PRs to be assigned to a given reviewer?
- Should we ignore this limit in certain situations, e.g. when you request a reviewer explicitly (`r? reviewer`) or when we use the adhoc group fallback assigment logic?

CC @apiraino

Requesting a review regarding the implementation details, but I still want to discuss the design on Zulip first and update Forge, so marking as a draft for now. Best reviewer commit-by-commit. I should probably add more logging before we merge this.