### PR TITLE
Only consider PRs with certain labels to be in the reviewer workqueue

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -2,11 +2,8 @@ use anyhow::{anyhow, Context};
 use async_trait::async_trait;
 use bytes::Bytes;
 use chrono::{DateTime, FixedOffset, Utc};
-use futures::{future::BoxFuture, FutureExt, TryStreamExt};
+use futures::{future::BoxFuture, FutureExt};
 use hyper::header::HeaderValue;
-use octocrab::params::pulls::Sort;
-use octocrab::params::{Direction, State};
-use octocrab::Octocrab;
 use regex::Regex;
 use reqwest::header::{AUTHORIZATION, USER_AGENT};
 use reqwest::{Client, Request, RequestBuilder, Response, StatusCode};
@@ -3051,57 +3048,6 @@ async fn project_items_by_status(
 
     all_items.sort_by_key(|item| item.date());
     Ok(all_items)
-}
-
-/// Retrieve tuples of (user, PR number) where
-/// the given user is assigned as a reviewer for that PR.
-/// Only non-draft, non-rollup and open PRs are taken into account.
-pub async fn retrieve_pull_request_assignments(
-    owner: &str,
-    repository: &str,
-    client: &Octocrab,
-) -> anyhow::Result<Vec<(User, PullRequestNumber)>> {
-    let mut assignments = vec![];
-
-    // We use the REST API to fetch open pull requests, as it is much (~5-10x)
-    // faster than using GraphQL here.
-    let stream = client
-        .pulls(owner, repository)
-        .list()
-        .state(State::Open)
-        .direction(Direction::Ascending)
-        .sort(Sort::Created)
-        .per_page(100)
-        .send()
-        .await?
-        .into_stream(client);
-    let mut stream = std::pin::pin!(stream);
-    while let Some(pr) = stream.try_next().await? {
-        if pr.draft == Some(true) {
-            continue;
-        }
-        // exclude rollup PRs
-        if pr
-            .labels
-            .unwrap_or_default()
-            .iter()
-            .any(|label| label.name == "rollup")
-        {
-            continue;
-        }
-        for user in pr.assignees.unwrap_or_default() {
-            assignments.push((
-                User {
-                    login: user.login,
-                    id: (*user.id).into(),
-                },
-                pr.number,
-            ));
-        }
-    }
-    assignments.sort_by(|a, b| a.0.id.cmp(&b.0.id));
-
-    Ok(assignments)
 }
 
 pub enum DesignMeetingStatus {

--- a/src/handlers/pr_tracking.rs
+++ b/src/handlers/pr_tracking.rs
@@ -130,6 +130,22 @@ pub(super) async fn handle_input<'a>(
     Ok(())
 }
 
+/// Loads the workqueue (mapping of open PRs assigned to users) from GitHub
+pub async fn load_workqueue(client: &Octocrab) -> anyhow::Result<ReviewerWorkqueue> {
+    tracing::debug!("Loading workqueue for rust-lang/rust");
+    let prs = retrieve_pull_request_assignments("rust-lang", "rust", &client).await?;
+
+    // Aggregate PRs by user
+    let aggregated: HashMap<UserId, HashSet<PullRequestNumber>> =
+        prs.into_iter().fold(HashMap::new(), |mut acc, (user, pr)| {
+            let prs = acc.entry(user.id).or_default();
+            prs.insert(pr);
+            acc
+        });
+    tracing::debug!("PR assignments\n{aggregated:?}");
+    Ok(ReviewerWorkqueue::new(aggregated))
+}
+
 /// Retrieve tuples of (user, PR number) where
 /// the given user is assigned as a reviewer for that PR.
 /// Only non-draft, non-rollup and open PRs are taken into account.

--- a/src/handlers/pull_requests_assignment_update.rs
+++ b/src/handlers/pull_requests_assignment_update.rs
@@ -1,6 +1,6 @@
 use crate::github::PullRequestNumber;
-use crate::github::{retrieve_pull_request_assignments, UserId};
-use crate::handlers::pr_tracking::ReviewerWorkqueue;
+use crate::github::UserId;
+use crate::handlers::pr_tracking::{retrieve_pull_request_assignments, ReviewerWorkqueue};
 use crate::jobs::Job;
 use async_trait::async_trait;
 use octocrab::Octocrab;

--- a/src/handlers/pull_requests_assignment_update.rs
+++ b/src/handlers/pull_requests_assignment_update.rs
@@ -1,10 +1,6 @@
-use crate::github::PullRequestNumber;
-use crate::github::UserId;
-use crate::handlers::pr_tracking::{retrieve_pull_request_assignments, ReviewerWorkqueue};
+use crate::handlers::pr_tracking::load_workqueue;
 use crate::jobs::Job;
 use async_trait::async_trait;
-use octocrab::Octocrab;
-use std::collections::{HashMap, HashSet};
 
 pub struct PullRequestAssignmentUpdate;
 
@@ -22,20 +18,4 @@ impl Job for PullRequestAssignmentUpdate {
 
         Ok(())
     }
-}
-
-/// Loads the workqueue (mapping of open PRs assigned to users) from GitHub
-pub async fn load_workqueue(client: &Octocrab) -> anyhow::Result<ReviewerWorkqueue> {
-    tracing::debug!("Loading workqueue for rust-lang/rust");
-    let prs = retrieve_pull_request_assignments("rust-lang", "rust", &client).await?;
-
-    // Aggregate PRs by user
-    let aggregated: HashMap<UserId, HashSet<PullRequestNumber>> =
-        prs.into_iter().fold(HashMap::new(), |mut acc, (user, pr)| {
-            let prs = acc.entry(user.id).or_default();
-            prs.insert(pr);
-            acc
-        });
-    tracing::debug!("PR assignments\n{aggregated:?}");
-    Ok(ReviewerWorkqueue::new(aggregated))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod rfcbot;
 pub mod team;
 mod team_data;
 pub mod triage;
+mod utils;
 pub mod zulip;
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,8 +12,8 @@ use tokio::{task, time};
 use tower::{Service, ServiceExt};
 use tracing as log;
 use tracing::Instrument;
+use triagebot::handlers::pr_tracking::load_workqueue;
 use triagebot::handlers::pr_tracking::ReviewerWorkqueue;
-use triagebot::handlers::pull_requests_assignment_update::load_workqueue;
 use triagebot::jobs::{
     default_jobs, JOB_PROCESSING_CADENCE_IN_SECS, JOB_SCHEDULING_CADENCE_IN_SECS,
 };

--- a/src/tests/github.rs
+++ b/src/tests/github.rs
@@ -1,4 +1,4 @@
-use crate::github::{Issue, IssueState, PullRequestDetails, User};
+use crate::github::{Issue, IssueState, Label, PullRequestDetails, User};
 use bon::builder;
 use chrono::Utc;
 
@@ -26,6 +26,7 @@ pub fn issue(
     pr: Option<bool>,
     org: Option<&str>,
     repo: Option<&str>,
+    labels: Option<Vec<&str>>,
 ) -> Issue {
     let number = number.unwrap_or(1);
     let state = state.unwrap_or(IssueState::Open);
@@ -39,6 +40,13 @@ pub fn issue(
     };
     let org = org.unwrap_or("rust-lang");
     let repo = repo.unwrap_or("rust");
+    let labels = labels
+        .unwrap_or_default()
+        .into_iter()
+        .map(|l| Label {
+            name: l.to_string(),
+        })
+        .collect();
 
     Issue {
         number,
@@ -49,7 +57,7 @@ pub fn issue(
         title: format!("Issue #{number}"),
         html_url: format!("https://github.com/{org}/{repo}/pull/{number}"),
         user: author,
-        labels: vec![],
+        labels,
         assignees,
         pull_request,
         merged: false,
@@ -73,12 +81,14 @@ pub fn pull_request(
     author: Option<User>,
     body: Option<&str>,
     assignees: Option<Vec<User>>,
+    labels: Option<Vec<&str>>,
 ) -> Issue {
     issue()
         .maybe_state(state)
         .maybe_number(number)
         .maybe_author(author)
         .maybe_body(body)
+        .maybe_labels(labels)
         .maybe_assignees(assignees)
         .pr(true)
         .call()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,10 @@
+use std::borrow::Cow;
+
+/// Pluralize (add an 's' sufix) to `text` based on `count`.
+pub fn pluralize(text: &str, count: usize) -> Cow<str> {
+    if count == 1 {
+        text.into()
+    } else {
+        format!("{}s", text).into()
+    }
+}

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -291,8 +291,9 @@ async fn workqueue_commands(
                 None => String::from("Not set (i.e. unlimited)"),
             };
 
-            let mut response = format!("Assigned rust-lang/rust PRs: {prs}\n");
-            writeln!(response, "Review capacity: {capacity}")?;
+            let mut response = format!("`rust-lang/rust` PRs in your review queue: {prs}\n");
+            writeln!(response, "Review capacity: {capacity}\n")?;
+            writeln!(response, "*Note that only selected PRs that are assigned to you are considered as being in the review queue.*")?;
             response
         }
         "set-pr-limit" => {

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -6,6 +6,7 @@ use crate::handlers::docs_update::docs_update;
 use crate::handlers::pr_tracking::get_assigned_prs;
 use crate::handlers::project_goals::{self, ping_project_goals_owners};
 use crate::handlers::Context;
+use crate::utils::pluralize;
 use anyhow::{format_err, Context as _};
 use std::env;
 use std::fmt::Write as _;
@@ -291,7 +292,11 @@ async fn workqueue_commands(
                 None => String::from("Not set (i.e. unlimited)"),
             };
 
-            let mut response = format!("`rust-lang/rust` PRs in your review queue: {prs}\n");
+            let mut response = format!(
+                "`rust-lang/rust` PRs in your review queue: {prs} ({} {})\n",
+                prs.len(),
+                pluralize("PR", prs.len())
+            );
             writeln!(response, "Review capacity: {capacity}\n")?;
             writeln!(response, "*Note that only selected PRs that are assigned to you are considered as being in the review queue.*")?;
             response


### PR DESCRIPTION
This PR adds logic for determining if a PR should be considered to be in the reviewer workqueue. The implemented rules are:

- The PR has to be assigned to the given user (duh).
- The PR has to be open.
- The PR has to be non-draft. 
- The PR **must not** contain `S-blocked`, `S-inactive` or `rollup` labels.
- The PR **must** contain the `S-waiting-on-review` label.
- The PR **must not** be assigned to the PR author.

This implementation is based on discussion in https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/New.20triagebot.20assignment.20logic.20respecting.20PR.20limits/with/513565237.

Prerequisite for https://github.com/rust-lang/triagebot/pull/1947.