### PR TITLE
Make label removal check case insensitive

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -705,7 +705,11 @@ impl Issue {
             name = label,
         );
 
-        if !self.labels().iter().any(|l| l.name == label) {
+        if !self
+            .labels()
+            .iter()
+            .any(|l| l.name.to_lowercase() == label.to_lowercase())
+        {
             log::info!(
                 "remove_label from {}: {:?} already not present, skipping",
                 self.global_id(),


### PR DESCRIPTION
When removing a label we check if the label exists. This check is case sensitive and therefore fails if the user isn't writing the label correctly.

This patch makes it so, that removing a label is now case insensitive.

Thanks for checking this out!

Ref: https://github.com/rust-lang/triagebot/issues/1915#issuecomment-2701704816
Closes #1915

r? @ehuss 