### PR TITLE
Fix missing repo in CommitBase

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -1219,7 +1219,7 @@ pub struct CommitBase {
     pub sha: String,
     #[serde(rename = "ref")]
     pub git_ref: String,
-    pub repo: Repository,
+    pub repo: Option<Repository>,
 }
 
 pub fn parse_diff(diff: &str) -> Vec<FileDiff> {

--- a/src/handlers/rendered_link.rs
+++ b/src/handlers/rendered_link.rs
@@ -48,9 +48,9 @@ async fn add_rendered_link(
                     .iter()
                     .any(|tf| f.filename.starts_with(tf))
             })
-            .map(|file| {
-                let head = e.issue.head.as_ref().unwrap();
-                let base = e.issue.base.as_ref().unwrap();
+            .and_then(|file| {
+                let head = e.issue.head.as_ref()?;
+                let base = e.issue.base.as_ref()?;
 
                 // This URL should be stable while the PR is open, even if the
                 // user pushes new commits.
@@ -68,12 +68,12 @@ async fn add_rendered_link(
                 //  - if merged: `https://github.com/octocat/REPO/blob/master/FILEPATH`
                 //  - if open: `https://github.com/Bob/REPO/blob/patch-1/FILEPATH`
                 //  - if closed: `https://github.com/octocat/REPO/blob/SHA/FILEPATH`
-                format!(
+                Some(format!(
                     "[Rendered](https://github.com/{}/blob/{}/{})",
                     if e.issue.merged || e.action == IssuesAction::Closed {
                         &e.repository.full_name
                     } else {
-                        &head.repo.full_name
+                        &head.repo.as_ref()?.full_name
                     },
                     if e.issue.merged {
                         &base.git_ref
@@ -83,7 +83,7 @@ async fn add_rendered_link(
                         &head.git_ref
                     },
                     file.filename
-                )
+                ))
             });
 
         let new_body: Cow<'_, str> = if !e.issue.body.contains("[Rendered]") {

--- a/src/handlers/validate_config.rs
+++ b/src/handlers/validate_config.rs
@@ -42,9 +42,13 @@ pub(super) async fn parse_input(
         log::error!("expected head commit in {event:?}");
         return Ok(None);
     };
+    let Some(repo) = &pr_source.repo else {
+        log::warn!("repo is not available in {event:?}");
+        return Ok(None);
+    };
     let triagebot_content = match ctx
         .github
-        .raw_file(&pr_source.repo.full_name, &pr_source.sha, CONFIG_FILE_NAME)
+        .raw_file(&repo.full_name, &pr_source.sha, CONFIG_FILE_NAME)
         .await
     {
         Ok(Some(c)) => c,
@@ -66,7 +70,7 @@ pub(super) async fn parse_input(
                 let (line, col) = translate_position(&triagebot_content, span.start);
                 let url = format!(
                     "https://github.com/{}/blob/{}/{CONFIG_FILE_NAME}#L{line}",
-                    pr_source.repo.full_name, pr_source.sha
+                    repo.full_name, pr_source.sha
                 );
                 format!(" at position [{line}:{col}]({url})",)
             }


### PR DESCRIPTION
The `repo` field is optional. For example, it can be unset if the repository gets deleted.

Fixes https://github.com/rust-lang/triagebot/issues/1954