### PR TITLE
Silence the `ready` reminder when the author is a member of repository

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use chrono::{DateTime, FixedOffset, Utc};
 use futures::{future::BoxFuture, FutureExt};
 use hyper::header::HeaderValue;
-use octocrab::models::Author;
+use octocrab::models::{Author, AuthorAssociation};
 use regex::Regex;
 use reqwest::header::{AUTHORIZATION, USER_AGENT};
 use reqwest::{Client, Request, RequestBuilder, Response, StatusCode};
@@ -396,6 +396,9 @@ pub struct Issue {
     pub milestone: Option<Milestone>,
     /// Whether a PR has merge conflicts.
     pub mergeable: Option<bool>,
+
+    /// How the author is associated with the repository
+    pub author_association: AuthorAssociation,
 }
 
 #[derive(Debug, serde::Deserialize, Eq, PartialEq)]

--- a/src/handlers/shortcut.rs
+++ b/src/handlers/shortcut.rs
@@ -5,7 +5,7 @@
 use crate::{
     config::ShortcutConfig,
     db::issue_data::IssueData,
-    github::{Event, Label},
+    github::{AuthorAssociation, Event, Label},
     handlers::Context,
     interactions::ErrorComment,
 };

--- a/src/tests/github.rs
+++ b/src/tests/github.rs
@@ -71,6 +71,7 @@ pub fn issue(
         state,
         milestone: None,
         mergeable: None,
+        author_association: octocrab::models::AuthorAssociation::None,
     }
 }
 


### PR DESCRIPTION
After a few times I'm starting to find the `@bot ready` reminder to be a bit spammy.

I proposes that we don't emit it when the author is a member of the repository, as the author should already know about the `ready` command and already have the required permissions to update the labels manually anyway.