### PR TITLE
Add option to disable checking issue links in commits

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -465,7 +465,10 @@ pub(crate) struct RenderedLinkConfig {
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
-pub(crate) struct IssueLinksConfig {}
+pub(crate) struct IssueLinksConfig {
+    #[serde(default = "default_true")]
+    pub(crate) check_commits: bool,
+}
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -480,6 +483,11 @@ pub(crate) struct BehindUpstreamConfig {
     /// The threshold of days for parent commit age to trigger a warning.
     /// Default is 7 days if not specified.
     pub(crate) days_threshold: Option<usize>,
+}
+
+#[inline]
+fn default_true() -> bool {
+    true
 }
 
 fn get_cached_config(repo: &str) -> Option<Result<Arc<Config>, ConfigurationError>> {
@@ -603,7 +611,7 @@ mod tests {
 
             [shortcut]
 
-            [canonicalize-issue-links]
+            [issue-links]
 
             [rendered-link]
             trigger-files = ["posts/"]
@@ -674,7 +682,9 @@ mod tests {
                 rendered_link: Some(RenderedLinkConfig {
                     trigger_files: vec!["posts/".to_string()]
                 }),
-                issue_links: Some(IssueLinksConfig {}),
+                issue_links: Some(IssueLinksConfig {
+                    check_commits: true,
+                }),
                 no_mentions: Some(NoMentionsConfig {}),
                 behind_upstream: Some(BehindUpstreamConfig {
                     days_threshold: Some(14),
@@ -697,7 +707,8 @@ mod tests {
             title = "[stable"
             branch = "stable"
 
-            [canonicalize-issue-links]
+            [issue-links]
+            check-commits = false
 
             [behind-upstream]
             days-threshold = 7
@@ -747,7 +758,9 @@ mod tests {
                 merge_conflicts: None,
                 bot_pull_requests: None,
                 rendered_link: None,
-                issue_links: Some(IssueLinksConfig {}),
+                issue_links: Some(IssueLinksConfig {
+                    check_commits: false,
+                }),
                 no_mentions: None,
                 behind_upstream: Some(BehindUpstreamConfig {
                     days_threshold: Some(7),

--- a/src/handlers/check_commits/issue_links.rs
+++ b/src/handlers/check_commits/issue_links.rs
@@ -10,9 +10,13 @@ static LINKED_RE: LazyLock<Regex> =
 const MERGE_IGNORE_LIST: [&str; 3] = ["Rollup merge of ", "Auto merge of ", "Merge pull request "];
 
 pub(super) fn issue_links_in_commits(
-    _conf: &IssueLinksConfig,
+    conf: &IssueLinksConfig,
     commits: &[GithubCommit],
 ) -> Option<String> {
+    if !conf.check_commits {
+        return None;
+    }
+
     let issue_links_commits = commits
         .into_iter()
         .filter(|c| {
@@ -39,7 +43,9 @@ pub(super) fn issue_links_in_commits(
 fn test_mentions_in_commits() {
     use super::dummy_commit_from_body;
 
-    let config = IssueLinksConfig {};
+    let config = IssueLinksConfig {
+        check_commits: true,
+    };
 
     let mut commits = vec![dummy_commit_from_body(
         "d1992a392617dfb10518c3e56446b6c9efae38b0",
@@ -76,6 +82,16 @@ fn test_mentions_in_commits() {
     - d7daa17bc97df9377640b0d33cbd0bbeed703c3a
 ".to_string()
         )
+    );
+
+    assert_eq!(
+        issue_links_in_commits(
+            &IssueLinksConfig {
+                check_commits: false,
+            },
+            &commits
+        ),
+        None
     );
 
     commits.push(dummy_commit_from_body(


### PR DESCRIPTION
This PR adds an option (~~`allowed-in-commits`~~) to disable checking issue links in commits, this was requested in rust-lang/triagebot#1965 by @tgross35.

More context in https://github.com/rust-lang/triagebot/issues/1965#issuecomment-2849106561, but summary: repository that aren't subtrees in r-l/r don't necessarily need to prevent issue links in commits.

```toml
[issue-links]
check-commits = false # defaults to true
```

Fixes rust-lang/triagebot#1965