### PR TITLE
Do not apply labels in autolabel when opening a draft PR

### DIFF
--- a/src/handlers/autolabel.rs
+++ b/src/handlers/autolabel.rs
@@ -1,3 +1,4 @@
+use crate::db::issue_data::IssueData;
 use crate::{
     config::AutolabelConfig,
     github::{IssuesAction, IssuesEvent, Label},
@@ -5,6 +6,16 @@ use crate::{
 };
 use anyhow::Context as _;
 use tracing as log;
+
+/// Key for the state in the database
+const AUTOLABEL_KEY: &str = "autolabel";
+
+/// State stored in the database
+#[derive(Debug, Default, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+struct AutolabelState {
+    /// If true, then `autolabel.new_pr` labels have already been applied to this PR.
+    new_pr_labels_applied: bool,
+}
 
 pub(super) struct AutolabelInput {
     add: Vec<Label>,
@@ -26,7 +37,16 @@ pub(super) async fn parse_input(
     // FIXME: This will re-apply labels after a push that the user had tried to
     // remove. Not much can be done about that currently; the before/after on
     // synchronize may be straddling a rebase, which will break diff generation.
-    if event.action == IssuesAction::Opened || event.action == IssuesAction::Synchronize {
+    if matches!(
+        event.action,
+        IssuesAction::Opened | IssuesAction::Synchronize | IssuesAction::ReadyForReview
+    ) {
+        let mut db = ctx.db.get().await;
+        let mut state: IssueData<'_, AutolabelState> =
+            IssueData::load(&mut db, &event.issue, AUTOLABEL_KEY)
+                .await
+                .map_err(|e| e.to_string())?;
+
         let files = event
             .issue
             .diff(&ctx.github)
@@ -69,11 +89,19 @@ pub(super) async fn parse_input(
                         name: label.to_owned(),
                     });
                 }
-                if cfg.new_pr && event.action == IssuesAction::Opened {
-                    autolabels.push(Label {
-                        name: label.to_owned(),
-                    });
-                }
+            }
+
+            // Treat the following situations as a "new PR":
+            // 1) New PRs opened as non-draft
+            // 2) PRs opened as draft that are marked as "ready for review" for the first time.
+            let is_new_non_draft_pr = event.action == IssuesAction::Opened && !event.issue.draft;
+            let is_first_time_ready_for_review =
+                event.action == IssuesAction::ReadyForReview && !state.data.new_pr_labels_applied;
+            if cfg.new_pr && (is_new_non_draft_pr || is_first_time_ready_for_review) {
+                autolabels.push(Label {
+                    name: label.to_owned(),
+                });
+                state.data.new_pr_labels_applied = true;
             }
 
             if event.issue.pull_request.is_none()
@@ -85,6 +113,8 @@ pub(super) async fn parse_input(
                 });
             }
         }
+
+        state.save().await.map_err(|e| e.to_string())?;
 
         if !autolabels.is_empty() {
             return Ok(Some(AutolabelInput {


### PR DESCRIPTION
After https://github.com/rust-lang/triagebot/pull/1963, it doesn't make sense to apply `S-waiting-on-review` to PRs opened as a draft. According to https://github.com/search?type=code&q=org%3Arust-lang+%22new_pr+%3D+true%22, this option is only ever used for adding `S-waiting-on-review` in the rust-lang org, so I don't think that we need to complicate the settings by adding some "new_nondraft_pr" setting or something like that.