### PR TITLE
Handle drafts better in PR tracking and do not consider self-assigned PRs for the workqueue

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -4,6 +4,7 @@ use bytes::Bytes;
 use chrono::{DateTime, FixedOffset, Utc};
 use futures::{future::BoxFuture, FutureExt};
 use hyper::header::HeaderValue;
+use octocrab::models::Author;
 use regex::Regex;
 use reqwest::header::{AUTHORIZATION, USER_AGENT};
 use reqwest::{Client, Request, RequestBuilder, Response, StatusCode};
@@ -22,6 +23,15 @@ pub type PullRequestNumber = u64;
 pub struct User {
     pub login: String,
     pub id: UserId,
+}
+
+impl From<&Author> for User {
+    fn from(author: &Author) -> Self {
+        Self {
+            id: author.id.0,
+            login: author.login.clone(),
+        }
+    }
 }
 
 impl GithubClient {

--- a/src/handlers/pr_tracking.rs
+++ b/src/handlers/pr_tracking.rs
@@ -82,6 +82,8 @@ pub(super) async fn parse_input(
         })),
         // We don't need to handle Opened explicitly, because that will trigger the Assigned event
         IssuesAction::Reopened
+        | IssuesAction::ReadyForReview
+        | IssuesAction::ConvertedToDraft
         | IssuesAction::Closed
         | IssuesAction::Deleted
         | IssuesAction::Transferred

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -298,7 +298,7 @@ async fn workqueue_commands(
                 pluralize("PR", assigned_prs.len())
             );
             writeln!(response, "Review capacity: {capacity}\n")?;
-            writeln!(response, "*Note that only selected PRs that are assigned to you are considered as being in the review queue.*")?;
+            writeln!(response, "*Note that only certain PRs that are assigned to you are included in your review queue.*")?;
             response
         }
         "set-pr-limit" => {


### PR DESCRIPTION
A few improvements I found after testing the effects of https://github.com/rust-lang/triagebot/pull/1947 in production.