### PR TITLE
Store vacation status in the database

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -346,4 +346,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS review_prefs_user_id ON review_prefs(user_id);
     "
 ALTER TABLE review_prefs ADD COLUMN IF NOT EXISTS max_assigned_prs INTEGER DEFAULT NULL;
 ",
+    "
+ALTER TABLE review_prefs ADD COLUMN IF NOT EXISTS rotation_mode TEXT NOT NULL DEFAULT 'on-rotation';
+",
 ];

--- a/src/db/review_prefs.rs
+++ b/src/db/review_prefs.rs
@@ -1,13 +1,65 @@
 use crate::db::users::record_username;
 use crate::github::{User, UserId};
 use anyhow::Context;
+use bytes::BytesMut;
+use postgres_types::{to_sql_checked, FromSql, IsNull, ToSql, Type};
 use std::collections::HashMap;
+use std::error::Error;
+
+#[derive(Debug, Default, Copy, Clone)]
+pub enum RotationMode {
+    /// The reviewer can be automatically assigned by triagebot,
+    /// and they can be assigned through teams and assign groups.
+    #[default]
+    OnRotation,
+    /// The user is off rotation (e.g. on a vacation) and cannot be assigned automatically
+    /// nor through teams and assign groups.
+    OffRotation,
+}
+
+impl<'a> FromSql<'a> for RotationMode {
+    fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
+        let value = <&str as FromSql>::from_sql(ty, raw)?;
+        match value {
+            "on-rotation" => Ok(Self::OnRotation),
+            "off-rotation" => Ok(Self::OffRotation),
+            _ => Err(format!("Unknown value for RotationMode: {value}").into()),
+        }
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <&str as FromSql>::accepts(ty)
+    }
+}
+
+impl ToSql for RotationMode {
+    fn to_sql(&self, ty: &Type, out: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>>
+    where
+        Self: Sized,
+    {
+        let value = match self {
+            RotationMode::OnRotation => "on-rotation",
+            RotationMode::OffRotation => "off-rotation",
+        };
+        <&str as ToSql>::to_sql(&value, ty, out)
+    }
+
+    fn accepts(ty: &Type) -> bool
+    where
+        Self: Sized,
+    {
+        <&str as FromSql>::accepts(ty)
+    }
+
+    to_sql_checked!();
+}
 
 #[derive(Debug)]
 pub struct ReviewPrefs {
     pub id: uuid::Uuid,
     pub user_id: i64,
     pub max_assigned_prs: Option<i32>,
+    pub rotation_mode: RotationMode,
 }
 
 impl From<tokio_postgres::row::Row> for ReviewPrefs {
@@ -16,6 +68,7 @@ impl From<tokio_postgres::row::Row> for ReviewPrefs {
             id: row.get("id"),
             user_id: row.get("user_id"),
             max_assigned_prs: row.get("max_assigned_prs"),
+            rotation_mode: row.get("rotation_mode"),
         }
     }
 }
@@ -27,7 +80,7 @@ pub async fn get_review_prefs(
     user_id: UserId,
 ) -> anyhow::Result<Option<ReviewPrefs>> {
     let query = "
-SELECT id, user_id, max_assigned_prs
+SELECT id, user_id, max_assigned_prs, rotation_mode
 FROM review_prefs
 WHERE review_prefs.user_id = $1;";
     let row = db
@@ -56,10 +109,15 @@ pub async fn get_review_prefs_batch<'a>(
         .collect();
     let lowercase_users: Vec<&str> = lowercase_map.keys().map(|s| s.as_str()).collect();
 
-    // The id/user_id/max_assigned_prs columns have to match the names used in
+    // The id/user_id/max_assigned_prs/rotation_mode columns have to match the names used in
     // `From<tokio_postgres::row::Row> for ReviewPrefs`.
     let query = "
-SELECT lower(u.username) AS username, r.id AS id, r.user_id AS user_id, r.max_assigned_prs AS max_assigned_prs
+SELECT
+    lower(u.username) AS username,
+    r.id AS id,
+    r.user_id AS user_id,
+    r.max_assigned_prs AS max_assigned_prs,
+    r.rotation_mode AS rotation_mode
 FROM review_prefs AS r
 JOIN users AS u ON u.user_id = r.user_id
 WHERE lower(u.username) = ANY($1);";
@@ -87,20 +145,25 @@ pub async fn upsert_review_prefs(
     db: &tokio_postgres::Client,
     user: User,
     max_assigned_prs: Option<u32>,
+    rotation_mode: RotationMode,
 ) -> anyhow::Result<u64, anyhow::Error> {
     // We need to have the user stored in the DB to have a valid FK link in review_prefs
     record_username(db, user.id, &user.login).await?;
 
     let max_assigned_prs = max_assigned_prs.map(|v| v as i32);
     let query = "
-INSERT INTO review_prefs(user_id, max_assigned_prs)
-VALUES ($1, $2)
+INSERT INTO review_prefs(user_id, max_assigned_prs, rotation_mode)
+VALUES ($1, $2, $3)
 ON CONFLICT (user_id)
 DO UPDATE
-SET max_assigned_prs = excluded.max_assigned_prs";
+SET max_assigned_prs = excluded.max_assigned_prs,
+    rotation_mode = excluded.rotation_mode";
 
     let res = db
-        .execute(query, &[&(user.id as i64), &max_assigned_prs])
+        .execute(
+            query,
+            &[&(user.id as i64), &max_assigned_prs, &rotation_mode],
+        )
         .await
         .context("Error upserting review preferences")?;
     Ok(res)
@@ -108,7 +171,7 @@ SET max_assigned_prs = excluded.max_assigned_prs";
 
 #[cfg(test)]
 mod tests {
-    use crate::db::review_prefs::{get_review_prefs, upsert_review_prefs};
+    use crate::db::review_prefs::{get_review_prefs, upsert_review_prefs, RotationMode};
     use crate::db::users::get_user;
     use crate::tests::github::user;
     use crate::tests::run_db_test;
@@ -117,7 +180,13 @@ mod tests {
     async fn insert_prefs_create_user() {
         run_db_test(|ctx| async {
             let user = user("Martin", 1);
-            upsert_review_prefs(&ctx.db_client(), user.clone(), Some(1)).await?;
+            upsert_review_prefs(
+                &ctx.db_client(),
+                user.clone(),
+                Some(1),
+                RotationMode::OnRotation,
+            )
+            .await?;
             assert_eq!(get_user(&ctx.db_client(), user.id).await?.unwrap(), user);
 
             Ok(ctx)
@@ -128,7 +197,13 @@ mod tests {
     #[tokio::test]
     async fn insert_max_assigned_prs() {
         run_db_test(|ctx| async {
-            upsert_review_prefs(&ctx.db_client(), user("Martin", 1), Some(5)).await?;
+            upsert_review_prefs(
+                &ctx.db_client(),
+                user("Martin", 1),
+                Some(5),
+                RotationMode::OnRotation,
+            )
+            .await?;
             assert_eq!(
                 get_review_prefs(&ctx.db_client(), 1)
                     .await?
@@ -147,18 +222,18 @@ mod tests {
         run_db_test(|ctx| async {
             let db = ctx.db_client();
 
-            upsert_review_prefs(&db, user("Martin", 1), Some(5)).await?;
+            upsert_review_prefs(&db, user("Martin", 1), Some(5), RotationMode::OnRotation).await?;
             assert_eq!(
                 get_review_prefs(&db, 1).await?.unwrap().max_assigned_prs,
                 Some(5)
             );
-            upsert_review_prefs(&db, user("Martin", 1), Some(10)).await?;
+            upsert_review_prefs(&db, user("Martin", 1), Some(10), RotationMode::OnRotation).await?;
             assert_eq!(
                 get_review_prefs(&db, 1).await?.unwrap().max_assigned_prs,
                 Some(10)
             );
 
-            upsert_review_prefs(&db, user("Martin", 1), None).await?;
+            upsert_review_prefs(&db, user("Martin", 1), None, RotationMode::OnRotation).await?;
             assert_eq!(
                 get_review_prefs(&db, 1).await?.unwrap().max_assigned_prs,
                 None

--- a/src/db/review_prefs.rs
+++ b/src/db/review_prefs.rs
@@ -1,10 +1,9 @@
 use crate::db::users::record_username;
 use crate::github::{User, UserId};
 use anyhow::Context;
-use serde::Serialize;
 use std::collections::HashMap;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
 pub struct ReviewPrefs {
     pub id: uuid::Uuid,
     pub user_id: i64,

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -281,7 +281,9 @@ async fn workqueue_commands(
         login: gh_username.clone(),
         id: gh_id,
     };
-    let review_prefs = get_review_prefs(&db_client, gh_id).await?;
+    let review_prefs = get_review_prefs(&db_client, gh_id)
+        .await
+        .context("Unable to retrieve your review preferences.")?;
 
     let response = match subcommand {
         "show" => {


### PR DESCRIPTION
This PR adds a notion of being on or off rotation to the DB. This is meant to replace the `on_vacation` array in `triagebot.toml`. The idea is that reviewers will be able to set their vacation/rotation mode through triagebot's DMs (`work set-rotation-mode on/off`), rather than having to modify the `triagebot.toml` file through PRs.

Currently, this PR does not take the DB rotation mode into account when doing reviews, this will be done as a follow-up. Before that, we should resolve if users should be always `r?`-able even if they are on a vacation (https://github.com/rust-lang/triagebot/pull/1920), or if this should be configurable.

I will document this in forge once we get closer to actually using it in practice.

CC @Noratrieb, @apiraino