### PR TITLE
Do not write `IssueData` to the DB when it is unchanged

### DIFF
--- a/src/handlers/check_commits.rs
+++ b/src/handlers/check_commits.rs
@@ -24,7 +24,7 @@ mod non_default_branch;
 const CHECK_COMMITS_WARNINGS_KEY: &str = "check-commits-warnings";
 
 /// State stored in the database
-#[derive(Debug, Default, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Default, serde::Deserialize, serde::Serialize, Clone, PartialEq)]
 struct CheckCommitsWarningsState {
     /// List of the last warnings in the most recent comment.
     last_warnings: Vec<String>,

--- a/src/handlers/mentions.rs
+++ b/src/handlers/mentions.rs
@@ -20,7 +20,7 @@ pub(super) struct MentionsInput {
     paths: Vec<String>,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
 struct MentionState {
     paths: Vec<String>,
 }

--- a/src/handlers/merge_conflicts.rs
+++ b/src/handlers/merge_conflicts.rs
@@ -45,7 +45,7 @@ const MERGE_CONFLICTS_KEY: &str = "merge-conflicts";
 const UNKNOWN_RESCAN_DELAY: Duration = Duration::from_secs(60);
 
 /// State stored in the database for a PR.
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
 struct MergeConflictState {
     /// The GraphQL ID of the most recent warning comment.
     ///

--- a/src/handlers/relnotes.rs
+++ b/src/handlers/relnotes.rs
@@ -22,7 +22,7 @@ use crate::{
 
 const RELNOTES_KEY: &str = "relnotes";
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
 struct RelnotesState {
     relnotes_issue: Option<u64>,
 }

--- a/src/handlers/shortcut.rs
+++ b/src/handlers/shortcut.rs
@@ -15,7 +15,7 @@ use parser::command::shortcut::ShortcutCommand;
 const AUTHOR_REMINDER_KEY: &str = "author-reminder";
 
 /// State stored in the database for a PR.
-#[derive(Debug, Default, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Default, serde::Deserialize, serde::Serialize, Clone, PartialEq)]
 struct AuthorReminderState {
     /// ID of the reminder comment.
     reminder_comment: Option<String>,


### PR DESCRIPTION
Noticed this while working on https://github.com/rust-lang/triagebot/pull/1968. I don't think that it's really needed for perf., but I suppose that most of the time we just write back the same data, which seems wasteful, and the structs are simple enough that requiring `Clone` + `Eq` shouldn't be that difficult.