### PR TITLE
Add test for parsing `assign.review_prefs`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -777,4 +777,16 @@ mod tests {
             }
         );
     }
+
+    #[test]
+    fn assign_review_prefs() {
+        let config = r#"
+            [assign.review_prefs]
+        "#;
+        let config = toml::from_str::<Config>(&config).unwrap();
+        assert!(matches!(
+            config.assign.and_then(|c| c.review_prefs),
+            Some(AssignReviewPrefsConfig {})
+        ));
+    }
 }


### PR DESCRIPTION
It is an empty table without any fields at the moment, so let's make sure that it can be parsed like this.