### PR TITLE
Take rotation mode into account when performing assignments

### DIFF
--- a/src/handlers/assign.rs
+++ b/src/handlers/assign.rs
@@ -1024,6 +1024,13 @@ async fn candidate_reviewers_from_names<'a>(
         .filter_map(|res| res.as_deref().ok())
         .collect();
 
+    log::debug!(
+        "Candidate reviewer results for review request `{}` on `{}`: {:?}",
+        names.join(", "),
+        issue.global_id(),
+        candidates
+    );
+
     if valid_candidates.is_empty() {
         // If we requested a single user for a review, we return a concrete error message
         // describing why they couldn't be assigned.

--- a/src/handlers/assign/tests/tests_candidates.rs
+++ b/src/handlers/assign/tests/tests_candidates.rs
@@ -462,7 +462,7 @@ async fn vacation() {
             .teams(&teams)
             .check(
                 &["jyn514"],
-                Err(FindReviewerError::ReviewerOnVacation {
+                Err(FindReviewerError::ReviewerOffRotation {
                     username: "jyn514".to_string(),
                 }),
             )


### PR DESCRIPTION
This PR takes the new rotation mode, which can be configured through Zulip, and is stored in the triagebot DM, into account when doing assignments using the `[review_prefs]` mode.

Couple of notes:
- The new assignment logic is still not enabled anywhere, we need to enable `[assign.review_prefs]` on `rust-lang/rust` for that to work. I will document the new logic in Rust Forge before doing that. So this PR shouldn't cause any assignment changes at the moment.
- The old `assign.users_on_vacation` array is still taken into account and has precedence over the configured rotation mode. We need to support it because it is used right now in [Clippy](https://github.com/search?type=code&q=org%3Arust-lang+users_on_vacation), for which we do not yet have PR tracking enabled (since it only works for `rust-lang/rust` now).
- This PR does not enable directly requesting users (`r? <username>`) that are off rotation/on a vacation. This is consistent with the previous vacation behavior. We can change this in the future, but it is a separate change from this.