### PR TITLE
Add a handler to post a summary comment of Clippy lintcheck runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +86,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,7 +144,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.4.4",
  "object",
  "rustc-demangle",
 ]
@@ -147,6 +162,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,9 +181,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bitvec"
@@ -242,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.9.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byte-tools"
@@ -282,9 +303,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "caseless"
@@ -297,9 +318,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.96"
+version = "1.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
+checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -381,10 +405,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.3"
+name = "core-foundation"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "counter"
@@ -405,6 +439,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cron"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,13 +460,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
-dependencies = [
- "cfg-if",
- "lazy_static",
-]
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -582,6 +621,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "deunicode"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,12 +656,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dotenvy"
@@ -674,6 +718,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a7e408202050813e6f1d9addadcaafef3dca7530c7ddfb005d4081cce6779"
 
 [[package]]
+name = "flate2"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide 0.8.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -736,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
@@ -753,38 +807,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.21"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.91",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -828,13 +882,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -903,7 +959,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.9",
  "indexmap 1.8.1",
  "slab",
  "tokio",
@@ -983,27 +1039,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.9",
  "pin-project-lite",
 ]
 
 [[package]]
-name = "http-range-header"
-version = "0.3.1"
+name = "http-body"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.3.1",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -1022,13 +1106,13 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.9",
+ "http-body 0.4.5",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -1036,31 +1120,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.24.1"
+name = "hyper"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 1.3.1",
+ "hyper 1.6.0",
+ "hyper-util",
  "log",
  "rustls",
  "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
  "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
 name = "hyper-timeout"
-version = "0.4.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.6.0",
+ "hyper-util",
  "pin-project-lite",
  "tokio",
- "tokio-io-timeout",
+ "tower-service",
 ]
 
 [[package]]
@@ -1070,10 +1177,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.27",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.6.0",
+ "libc",
+ "pin-project-lite",
+ "socket2 0.5.9",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1170,6 +1297,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35e70ee094dc02fd9c13fdad4940090f22dbd6ac7c9e7094a46cf0232a50bc7c"
 
 [[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,11 +1332,12 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "8.3.0"
+version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.22.1",
+ "js-sys",
  "pem",
  "ring",
  "serde",
@@ -1231,9 +1369,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "maplit"
@@ -1282,15 +1420,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.8.11"
+name = "miniz_oxide"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
+ "wasi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1306,7 +1452,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.6.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -1348,16 +1494,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "object"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1368,13 +1504,13 @@ dependencies = [
 
 [[package]]
 name = "octocrab"
-version = "0.30.1"
+version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbed1b1298bc70dd4ae89fd44dd7c13f0a1c80a506d731eb1b939f14f5e367de"
+checksum = "86996964f8b721067b6ed238aa0ccee56ecad6ee5e714468aa567992d05d2b91"
 dependencies = [
  "arc-swap",
  "async-trait",
- "base64 0.21.4",
+ "base64 0.22.1",
  "bytes",
  "cfg-if",
  "chrono",
@@ -1382,11 +1518,13 @@ dependencies = [
  "futures",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
  "hyper-rustls",
  "hyper-timeout",
+ "hyper-util",
  "jsonwebtoken",
  "once_cell",
  "percent-encoding",
@@ -1398,10 +1536,11 @@ dependencies = [
  "serde_urlencoded",
  "snafu",
  "tokio",
- "tower",
+ "tower 0.5.2",
  "tower-http",
  "tracing",
  "url",
+ "web-time",
 ]
 
 [[package]]
@@ -1508,11 +1647,12 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "1.1.1"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.22.1",
+ "serde",
 ]
 
 [[package]]
@@ -1768,7 +1908,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.9.0",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -1911,9 +2051,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.9",
+ "http-body 0.4.5",
+ "hyper 0.14.27",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -1938,17 +2078,16 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
+ "cfg-if",
+ "getrandom",
  "libc",
- "once_cell",
- "spin",
  "untrusted",
- "web-sys",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2002,44 +2141,48 @@ checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustls"
-version = "0.21.7"
+version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "log",
+ "once_cell",
  "ring",
+ "rustls-pki-types",
  "rustls-webpki",
- "sct",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.6.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.3"
+name = "rustls-pki-types"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
- "base64 0.21.4",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.6"
+version = "0.103.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
+checksum = "7149975849f1abb3832b246010ef62ccc80d3a76169517ada7188252b9cfb437"
 dependencies = [
  "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -2080,16 +2223,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "sct"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2097,9 +2230,9 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "secrecy"
-version = "0.8.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "zeroize",
 ]
@@ -2111,7 +2244,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.3",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags 2.9.0",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2119,9 +2265,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.6.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2221,6 +2367,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
 name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2262,31 +2420,29 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "snafu"
-version = "0.7.5"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4de37ad025c587a29e8f3f5605c00f70b98715ef90b9061a815b9e59e9042d6"
+checksum = "223891c85e2a29c3fe8fb900c1fae5e69c2e42415e3177752e8718475efa5019"
 dependencies = [
- "backtrace",
- "doc-comment",
  "snafu-derive",
 ]
 
 [[package]]
 name = "snafu-derive"
-version = "0.7.5"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
+checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 1.0.91",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2300,10 +2456,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.5.2"
+name = "socket2"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "spki"
@@ -2400,6 +2560,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "tap"
@@ -2544,40 +2710,29 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.17.0"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
+ "backtrace",
  "bytes",
  "libc",
- "memchr",
  "mio",
- "num_cpus",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.9",
  "tokio-macros",
- "winapi",
-]
-
-[[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.7.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.91",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2608,16 +2763,16 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tokio-util 0.6.9",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls",
  "tokio",
@@ -2703,19 +2858,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-http"
-version = "0.4.4"
+name = "tower"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
- "bitflags 2.4.0",
- "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
- "http-range-header",
  "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util 0.7.1",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
+dependencies = [
+ "bitflags 2.9.0",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "iri-string",
+ "pin-project-lite",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2723,15 +2895,15 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -2814,7 +2986,7 @@ dependencies = [
  "glob",
  "hex",
  "hmac",
- "hyper",
+ "hyper 0.14.27",
  "ignore",
  "itertools",
  "native-tls",
@@ -2837,12 +3009,13 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "toml",
- "tower",
+ "tower 0.4.13",
  "tracing",
  "tracing-subscriber",
  "url",
  "uuid 0.8.2",
  "x509-cert",
+ "zip",
 ]
 
 [[package]]
@@ -2984,9 +3157,9 @@ dependencies = [
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -3066,12 +3239,6 @@ dependencies = [
  "log",
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -3156,6 +3323,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3202,6 +3380,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3401,4 +3588,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "zip"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dcb24d0152526ae49b9b96c1dcf71850ca1e0b882e4e28ed898a93c41334744"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "indexmap 2.9.0",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ postgres-native-tls = "0.5.0"
 native-tls = "0.2"
 x509-cert = { version = "0.2.5", features = ["pem"] }
 serde_path_to_error = "0.1.2"
-octocrab = { version = "0.30.1", features = ["stream"] }
+octocrab = { version = "0.44.1", features = ["stream"] }
 comrak = { version = "0.38", default-features = false }
 route-recognizer = "0.3.0"
 cynic = "3.2.2"
@@ -48,6 +48,7 @@ structopt = "0.3.26"
 hmac = "0.12.1"
 subtle = "2.6.1"
 sha2 = "0.10.9"
+zip = { version = "2.6.1", default-features = false, features = ["deflate"] }
 
 [dependencies.serde]
 version = "1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,6 +50,7 @@ pub(crate) struct Config {
     pub(crate) issue_links: Option<IssueLinksConfig>,
     pub(crate) no_mentions: Option<NoMentionsConfig>,
     pub(crate) behind_upstream: Option<BehindUpstreamConfig>,
+    pub(crate) lintcheck_summary: Option<LintcheckSummaryConfig>,
 }
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]
@@ -492,6 +493,13 @@ pub(crate) struct BehindUpstreamConfig {
     pub(crate) days_threshold: Option<usize>,
 }
 
+#[derive(PartialEq, Eq, Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct LintcheckSummaryConfig {
+    pub(crate) workflow: String,
+    pub(crate) artifact: String,
+}
+
 #[inline]
 fn default_true() -> bool {
     true
@@ -697,6 +705,7 @@ mod tests {
                 behind_upstream: Some(BehindUpstreamConfig {
                     days_threshold: Some(14),
                 }),
+                lintcheck_summary: None,
             }
         );
     }
@@ -774,6 +783,7 @@ mod tests {
                 behind_upstream: Some(BehindUpstreamConfig {
                     days_threshold: Some(7),
                 }),
+                lintcheck_summary: None,
             }
         );
     }

--- a/src/db/issue_data.rs
+++ b/src/db/issue_data.rs
@@ -30,13 +30,22 @@ impl<'db, T> IssueData<'db, T>
 where
     T: for<'a> Deserialize<'a> + Serialize + Default + std::fmt::Debug + Sync + PartialEq + Clone,
 {
-    pub async fn load(
+    pub async fn load_issue(
         db: &'db mut DbClient,
         issue: &Issue,
         key: &str,
     ) -> Result<IssueData<'db, T>> {
         let repo = issue.repository().to_string();
         let issue_number = issue.number as i32;
+        Self::load(db, repo, issue_number, key).await
+    }
+
+    pub async fn load(
+        db: &'db mut DbClient,
+        repo: String,
+        issue_number: i32,
+        key: &str,
+    ) -> Result<IssueData<'db, T>> {
         let transaction = db.transaction().await?;
         transaction
             .execute("LOCK TABLE issue_data", &[])

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -33,6 +33,7 @@ pub mod docs_update;
 mod github_releases;
 mod glacier;
 mod issue_links;
+mod lintcheck_summary;
 mod major_change;
 mod mentions;
 mod merge_conflicts;
@@ -185,6 +186,20 @@ pub async fn handle(ctx: &Context, event: &Event) -> Vec<HandlerError> {
         }
     }
 
+    if let Some(lintcheck_summary_config) = config
+        .as_ref()
+        .ok()
+        .and_then(|c| c.lintcheck_summary.as_ref())
+    {
+        if let Err(e) = lintcheck_summary::handle(ctx, event, lintcheck_summary_config).await {
+            log::error!(
+                "failed to process event {:?} with workflow_run_comment handler: {:?}",
+                event,
+                e
+            );
+        }
+    }
+
     errors
 }
 
@@ -278,7 +293,7 @@ macro_rules! command_handlers {
                         }
                     }
                 }
-                Event::Push(_) | Event::Create(_) => {
+                Event::Push(_) | Event::Create(_) | Event::WorkflowRun(_) => {
                     log::debug!("skipping unsupported event");
                     return;
                 }

--- a/src/handlers/autolabel.rs
+++ b/src/handlers/autolabel.rs
@@ -43,7 +43,7 @@ pub(super) async fn parse_input(
     ) {
         let mut db = ctx.db.get().await;
         let mut state: IssueData<'_, AutolabelState> =
-            IssueData::load(&mut db, &event.issue, AUTOLABEL_KEY)
+            IssueData::load_issue(&mut db, &event.issue, AUTOLABEL_KEY)
                 .await
                 .map_err(|e| e.to_string())?;
 

--- a/src/handlers/check_commits.rs
+++ b/src/handlers/check_commits.rs
@@ -120,7 +120,7 @@ async fn handle_warnings_and_labels(
     // Get the state of the warnings for this PR in the database.
     let mut db = ctx.db.get().await;
     let mut state: IssueData<'_, CheckCommitsWarningsState> =
-        IssueData::load(&mut db, &event.issue, CHECK_COMMITS_WARNINGS_KEY).await?;
+        IssueData::load_issue(&mut db, &event.issue, CHECK_COMMITS_WARNINGS_KEY).await?;
 
     // We only post a new comment when we haven't posted one with the same warnings before.
     if !warnings.is_empty() && state.data.last_warnings != warnings {
@@ -128,10 +128,8 @@ async fn handle_warnings_and_labels(
 
         // Hide a previous warnings comment if there was one before printing the new ones.
         if let Some(last_warned_comment_id) = state.data.last_warned_comment {
-            event
-                .issue
+            ctx.github
                 .hide_comment(
-                    &ctx.github,
                     &last_warned_comment_id,
                     ReportedContentClassifiers::Resolved,
                 )
@@ -146,10 +144,8 @@ async fn handle_warnings_and_labels(
     } else if warnings.is_empty() {
         // No warnings to be shown, let's resolve a previous warnings comment, if there was one.
         if let Some(last_warned_comment_id) = state.data.last_warned_comment {
-            event
-                .issue
+            ctx.github
                 .hide_comment(
-                    &ctx.github,
                     &last_warned_comment_id,
                     ReportedContentClassifiers::Resolved,
                 )

--- a/src/handlers/lintcheck_summary.rs
+++ b/src/handlers/lintcheck_summary.rs
@@ -1,0 +1,235 @@
+//! Clippy has a tool called [lintcheck] that's used in CI to show how a PR
+//! would change the output of Clippy when ran on a large corpus of crates
+//!
+//! The workflow run uploads a JSON summary as a GitHub artifact which this
+//! handler uses to post a summary of the changes as a comment in the pull
+//! request
+//!
+//! [lintcheck]: https://github.com/rust-lang/rust-clippy/tree/master/lintcheck
+
+use std::fmt::Write;
+use std::io::{self, Cursor};
+
+use anyhow::Context as _;
+use octocrab::models::{CommentId, RunId};
+use serde::{Deserialize, Serialize};
+use zip::ZipArchive;
+
+use crate::config::LintcheckSummaryConfig;
+use crate::db::issue_data::IssueData;
+use crate::github::{
+    Event, ReportedContentClassifiers, Repository, WorkflowRunAction, WorkflowRunConclusion,
+};
+use crate::handlers::Context;
+
+/// An arbitrary limit of 32KiB, avoids downloading large files and/or
+/// decompressing a ZIP bomb
+const MAX_SIZE: u64 = 32768;
+
+const LINTCHECK_SUMMARY_KEY: &str = "lintcheck-summary";
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+struct CommentIds {
+    comment_id: CommentId,
+    /// The GraphQL id used for [un]hiding the comment
+    node_id: String,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+struct LintcheckSummaryState {
+    /// The IDs of the comment if we've already commented on a particular PR
+    comment_ids: Option<CommentIds>,
+}
+
+/// The summary JSON can come from PRs from forks and so may contain arbitrary
+/// content. Before using their contents in a comment we must validate that they
+/// contain only the expected characters
+///
+/// This is to avoid e.g. @user mass ping spams or triggering any other bots
+/// that may be a privileged operation
+#[derive(Debug, Deserialize)]
+struct UntrustedString(String);
+
+impl UntrustedString {
+    fn validate(&self, f: impl Fn(char) -> bool) -> anyhow::Result<&str> {
+        for ch in self.0.chars() {
+            anyhow::ensure!(f(ch), "string contains invalid character: {ch:?}");
+        }
+        Ok(&self.0)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SummaryRow {
+    name: UntrustedString,
+    url: UntrustedString,
+    added: u64,
+    removed: u64,
+    changed: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct Summary {
+    commit: UntrustedString,
+    rows: Vec<SummaryRow>,
+}
+
+pub(super) async fn handle(
+    ctx: &Context,
+    event: &Event,
+    config: &LintcheckSummaryConfig,
+) -> anyhow::Result<()> {
+    let Event::WorkflowRun(event) = event else {
+        return Ok(());
+    };
+
+    if event.action != WorkflowRunAction::Completed
+        || event.workflow_run.name != config.workflow
+        || event.workflow_run.conclusion != Some(WorkflowRunConclusion::Success)
+    {
+        return Ok(());
+    }
+
+    let [pr] = event.workflow_run.pull_requests.as_slice() else {
+        return Ok(());
+    };
+
+    let summary = download_summary(
+        ctx,
+        &event.repository,
+        event.workflow_run.id,
+        &config.artifact,
+    )
+    .await?;
+
+    let mut db = ctx.db.get().await;
+    let mut state: IssueData<'_, LintcheckSummaryState> = IssueData::load(
+        &mut db,
+        event.repository.full_name.clone(),
+        pr.number as i32,
+        LINTCHECK_SUMMARY_KEY,
+    )
+    .await?;
+
+    if state.data.comment_ids.is_none() && summary.is_none() {
+        return Ok(());
+    }
+
+    if let Some(ids) = &state.data.comment_ids {
+        // There is a previous comment, if there's a summary unhide it, hide it
+        // if not
+        //
+        // It's not an error to [un]hide an already [un]hidden comment
+        if summary.is_some() {
+            ctx.github.unhide_comment(&ids.node_id).await?;
+        } else {
+            ctx.github
+                .hide_comment(&ids.node_id, ReportedContentClassifiers::Outdated)
+                .await?;
+        }
+    }
+
+    let Some(summary) = summary else {
+        return Ok(());
+    };
+
+    let markdown = summary_to_markdown(&summary)?;
+
+    // Post the comment, or update the previous one if it already exists
+    if let Some(ids) = &state.data.comment_ids {
+        ctx.octocrab
+            .issues(event.repository.owner(), event.repository.name())
+            .update_comment(ids.comment_id, markdown)
+            .await?;
+    } else {
+        let comment = ctx
+            .octocrab
+            .issues(event.repository.owner(), event.repository.name())
+            .create_comment(pr.number, markdown)
+            .await?;
+        state.data.comment_ids = Some(CommentIds {
+            comment_id: comment.id,
+            node_id: comment.node_id,
+        });
+        state.save().await?;
+    }
+
+    Ok(())
+}
+
+async fn download_summary(
+    ctx: &Context,
+    repo: &Repository,
+    run_id: RunId,
+    artifact_name: &str,
+) -> anyhow::Result<Option<Summary>> {
+    let artifacts = ctx
+        .octocrab
+        .actions()
+        .list_workflow_run_artifacts(repo.owner(), repo.name(), run_id)
+        .send()
+        .await?
+        .value
+        .context("missing value")?
+        .items;
+
+    let Some(artifact) = artifacts
+        .into_iter()
+        .find(|artifact| artifact.name == artifact_name)
+    else {
+        return Ok(None);
+    };
+
+    anyhow::ensure!(
+        artifact.size_in_bytes < MAX_SIZE as usize,
+        "artifact archive is too large"
+    );
+
+    let bytes = ctx
+        .octocrab
+        // This is a ZIP file but the API wants `application/json`
+        .download(artifact.archive_download_url.as_str(), "application/json")
+        .await?;
+    let mut zip = ZipArchive::new(Cursor::new(bytes))?;
+    let file = zip.by_index(0)?;
+    anyhow::ensure!(file.size() < MAX_SIZE, "artifact file is too large");
+
+    let file_contents = io::read_to_string(file)?;
+    let summary: Summary = serde_json::from_str(&file_contents)?;
+
+    Ok(Some(summary))
+}
+
+fn summary_to_markdown(summary: &Summary) -> anyhow::Result<String> {
+    let commit = summary.commit.validate(|ch| ch.is_ascii_alphanumeric())?;
+
+    let mut md = format!(
+        "Lintcheck changes for {commit}
+
+| Lint | Added | Removed | Changed |
+| ---- | ----: | ------: | ------: |
+"
+    );
+
+    for SummaryRow {
+        name,
+        url,
+        added,
+        removed,
+        changed,
+    } in &summary.rows
+    {
+        let name = name.validate(|ch| matches!(ch, 'a'..='z' | ':' | '_' | '-'))?;
+        let url = url.validate(|ch| {
+            ch.is_ascii_alphanumeric() || matches!(ch, ':' | '/' | '.' | '#' | '-')
+        })?;
+        writeln!(
+            &mut md,
+            "| [`{name}`]({url}) | {added} | {removed} | {changed} |"
+        )?;
+    }
+
+    md.push_str("\nThis comment will be updated if you push new changes");
+
+    Ok(md)
+}

--- a/src/handlers/mentions.rs
+++ b/src/handlers/mentions.rs
@@ -91,7 +91,7 @@ pub(super) async fn handle_input(
 ) -> anyhow::Result<()> {
     let mut client = ctx.db.get().await;
     let mut state: IssueData<'_, MentionState> =
-        IssueData::load(&mut client, &event.issue, MENTIONS_KEY).await?;
+        IssueData::load_issue(&mut client, &event.issue, MENTIONS_KEY).await?;
     // Build the message to post to the issue.
     let mut result = String::new();
     for to_mention in &input.paths {

--- a/src/handlers/merge_conflicts.rs
+++ b/src/handlers/merge_conflicts.rs
@@ -262,7 +262,7 @@ async fn maybe_add_comment(
     possibly: Option<&str>,
 ) -> anyhow::Result<()> {
     let mut state: IssueData<'_, MergeConflictState> =
-        IssueData::load(db, issue, MERGE_CONFLICTS_KEY).await?;
+        IssueData::load_issue(db, issue, MERGE_CONFLICTS_KEY).await?;
     if state.data.last_warned_comment.is_some() {
         // There was already an unresolved notification, don't warn again.
         return Ok(());
@@ -308,13 +308,12 @@ async fn maybe_hide_comment(
     issue: &Issue,
 ) -> anyhow::Result<()> {
     let mut state: IssueData<'_, MergeConflictState> =
-        IssueData::load(db, issue, MERGE_CONFLICTS_KEY).await?;
+        IssueData::load_issue(db, issue, MERGE_CONFLICTS_KEY).await?;
     let Some(comment_id) = &state.data.last_warned_comment else {
         return Ok(());
     };
 
-    issue
-        .hide_comment(gh, comment_id, ReportedContentClassifiers::Resolved)
+    gh.hide_comment(comment_id, ReportedContentClassifiers::Resolved)
         .await?;
 
     state.data.last_warned_comment = None;

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -34,7 +34,7 @@ pub(super) async fn handle(ctx: &Context, event: &Event) -> anyhow::Result<()> {
     let short_description = match event {
         Event::Issue(e) => e.issue.title.clone(),
         Event::IssueComment(e) => format!("Comment on {}", e.issue.title),
-        Event::Push(_) | Event::Create(_) => return Ok(()),
+        Event::Push(_) | Event::Create(_) | Event::WorkflowRun(_) => return Ok(()),
     };
 
     let mut caps = parser::get_mentions(body)

--- a/src/handlers/relnotes.rs
+++ b/src/handlers/relnotes.rs
@@ -46,7 +46,7 @@ pub(super) async fn handle(ctx: &Context, event: &Event) -> anyhow::Result<()> {
 
     let mut client = ctx.db.get().await;
     let mut state: IssueData<'_, RelnotesState> =
-        IssueData::load(&mut client, &e.issue, RELNOTES_KEY).await?;
+        IssueData::load_issue(&mut client, &e.issue, RELNOTES_KEY).await?;
 
     if let Some(paired) = state.data.relnotes_issue {
         // Already has a paired release notes issue.

--- a/src/handlers/shortcut.rs
+++ b/src/handlers/shortcut.rs
@@ -79,7 +79,7 @@ pub(super) async fn handle_command(
         // Get the state of the author reminder for this PR
         let mut db = ctx.db.get().await;
         let mut state: IssueData<'_, AuthorReminderState> =
-            IssueData::load(&mut db, &issue, AUTHOR_REMINDER_KEY).await?;
+            IssueData::load_issue(&mut db, &issue, AUTHOR_REMINDER_KEY).await?;
 
         if state.data.reminder_comment.is_none() {
             let comment_body = format!(


### PR DESCRIPTION
In Clippy we have a tool called lintcheck that we use in CI as a sort of mini crater run, this handler would post a summary of the run as a comment in the PR thread

It works by having the workflow upload a JSON artifact that the handler downloads, in Clippy we would add

```toml
[lintcheck-summary]
workflow = "Lintcheck"
artifact = "summary"
```

JSON is used instead of uploading a markdown file so that PRs from forks can't have triagebot post arbitrary comments

For https://github.com/rust-lang/rust-clippy/actions/runs/14763277413#summary-41449477485 the following comment would be posted:

---

Lintcheck changes for f980edd0da51eb4da9c15eb423a7829f2c5657fc

| Lint | Added | Removed | Changed |
| ---- | ----: | ------: | ------: |
| [`clippy::collapsible_if`](https://github.com/rust-lang/rust-clippy/actions/runs/14763277413#user-content-collapsible-if) | 0 | 0 | 1 |
| [`clippy::elidable_lifetime_names`](https://github.com/rust-lang/rust-clippy/actions/runs/14763277413#user-content-elidable-lifetime-names) | 30 | 0 | 1125 |
| [`clippy::extra_unused_lifetimes`](https://github.com/rust-lang/rust-clippy/actions/runs/14763277413#user-content-extra-unused-lifetimes) | 1 | 3 | 4 |
| [`clippy::needless_lifetimes`](https://github.com/rust-lang/rust-clippy/actions/runs/14763277413#user-content-needless-lifetimes) | 23 | 0 | 214 |

This comment will be updated if you push new changes
