### PR TITLE
Remove possibly redundant Zulip env var

### DIFF
--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -429,7 +429,7 @@ async fn execute_for_other_user(
         assert_eq!(command.pop(), Some(' ')); // pop trailing space
         command
     };
-    let bot_api_token = env::var("ZULIP_API_TOKEN").expect("ZULIP_API_TOKEN");
+    let bot_api_token = env::var("ZULIP_TOKEN").expect("ZULIP_TOKEN");
 
     let members = ctx
         .github
@@ -592,7 +592,7 @@ impl<'a> MessageApiRequest<'a> {
     }
 
     pub async fn send(&self, client: &reqwest::Client) -> anyhow::Result<reqwest::Response> {
-        let bot_api_token = env::var("ZULIP_API_TOKEN").expect("ZULIP_API_TOKEN");
+        let bot_api_token = env::var("ZULIP_TOKEN").expect("ZULIP_TOKEN");
 
         #[derive(serde::Serialize)]
         struct SerializedApi<'a> {
@@ -643,7 +643,7 @@ pub struct UpdateMessageApiRequest<'a> {
 
 impl<'a> UpdateMessageApiRequest<'a> {
     pub async fn send(&self, client: &reqwest::Client) -> anyhow::Result<reqwest::Response> {
-        let bot_api_token = env::var("ZULIP_API_TOKEN").expect("ZULIP_API_TOKEN");
+        let bot_api_token = env::var("ZULIP_TOKEN").expect("ZULIP_TOKEN");
 
         #[derive(serde::Serialize)]
         struct SerializedApi<'a> {
@@ -846,7 +846,7 @@ struct AddReaction<'a> {
 
 impl<'a> AddReaction<'a> {
     pub async fn send(self, client: &reqwest::Client) -> anyhow::Result<reqwest::Response> {
-        let bot_api_token = env::var("ZULIP_API_TOKEN").expect("ZULIP_API_TOKEN");
+        let bot_api_token = env::var("ZULIP_TOKEN").expect("ZULIP_TOKEN");
 
         Ok(client
             .post(&format!(


### PR DESCRIPTION
I am not sure why we use two env vars to talk to Zulip (`ZULIP_TOKEN` and `ZULIP_API_TOKEN`, see [simpleinfra](https://github.com/rust-lang/simpleinfra/blob/b7ddd5e6bec8a93ec30510cdddec02c5666fefe9/terraform/shared/services/triagebot/main.tf#L95-L101)).
But I think there was a reason why it was added to the infra in commit https://github.com/rust-lang/simpleinfra/commit/d13e1551

I was wondering if one can go, it's slightly confusing.
Anyone in T-infra remembers? cc @Mark-Simulacrum 

If there is a reason for that, then I'll push a small patch to the docs of the triagebot because the latter is not mentioned