### PR TITLE
Post comment when failing to add team label in `ping` command

### DIFF
--- a/src/handlers/ping.rs
+++ b/src/handlers/ping.rs
@@ -65,12 +65,24 @@ pub(super) async fn handle_command(
         }
     };
 
-    if let Some(label) = config.label.clone() {
-        event
+    if let Some(label) = &config.label {
+        if let Err(err) = event
             .issue()
             .unwrap()
-            .add_labels(&ctx.github, vec![github::Label { name: label }])
-            .await?;
+            .add_labels(
+                &ctx.github,
+                vec![github::Label {
+                    name: label.clone(),
+                }],
+            )
+            .await
+        {
+            let cmnt = ErrorComment::new(
+                &event.issue().unwrap(),
+                format!("Error adding team label (`{}`): {:?}.", label, err),
+            );
+            cmnt.post(&ctx.github).await?;
+        }
     }
 
     let mut users = Vec::new();


### PR DESCRIPTION
> It also seems reasonable to me to have the ping handler just log errors about missing labels, but otherwise continue to process the ping (instead of just stopping).

From https://github.com/rust-lang/triagebot/issues/1992#issuecomment-2888608180