### PR TITLE
Remove label grammar docs

### DIFF
--- a/parser/src/command/relabel.rs
+++ b/parser/src/command/relabel.rs
@@ -1,33 +1,7 @@
 //! The labels command parser.
 //!
-//! This can parse arbitrary input, giving the list of labels added/removed.
-//!
-//! The grammar is as follows:
-//!
-//! ```text
-//! Command: `@bot modify? <label-w> to? :? <label-list>.`
-//!
-//! <label-w>:
-//!  - label
-//!  - labels
-//!
-//! <label-list>:
-//!  - <label-delta>
-//!  - <label-delta> and <label-list>
-//!  - <label-delta>, <label-list>
-//!  - <label-delta>, and <label-list>
-//!
-//! <label-delta>:
-//!  - +<label>
-//!  - -<label>
-//!  this can start with a + or -, but then the only supported way of adding it
-//!  is with the previous two variants of this (i.e., ++label and -+label).
-//!  - <label>
-//!
-//! <label>:
-//!  - \S+
-//!  - ".+"
-//! ```
+//! See https://forge.rust-lang.org/triagebot/labeling.html#usage for the
+//! grammar this parser accepts.
 
 use crate::error::Error;
 use crate::token::{Token, Tokenizer};

--- a/parser/src/command/relabel.rs
+++ b/parser/src/command/relabel.rs
@@ -1,6 +1,6 @@
 //! The labels command parser.
 //!
-//! See https://forge.rust-lang.org/triagebot/labeling.html#usage for the
+//! See <https://forge.rust-lang.org/triagebot/labeling.html#usage> for the
 //! grammar this parser accepts.
 
 use crate::error::Error;


### PR DESCRIPTION
These docs are slightly wrong in various ways (like it doesn't handle space-separated labels, and `\S` isn't correct since it doesn't allow certain punctuation).

Instead of trying to keep both this and the user documentation up-to-date and correct, I'd like to just drop this and lean on the user documentation.