### PR TITLE
Fix failure to deserialize `FileDiff` with missing `patch` field

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -330,6 +330,10 @@ pub struct FileDiff {
     /// The fullname path of the file.
     pub filename: String,
     /// The patch/diff for the file.
+    ///
+    /// Can be empty when there isn't any changes to the content of the file
+    /// (like when a file is renamed without it's content being modified).
+    #[serde(default)]
     pub patch: String,
 }
 


### PR DESCRIPTION
This PR fixes the failure to deserialize `FileDiff` when the missing `patch` field, which seems to be omitted by GitHub when there isn't any changes to the content of the file (like when a file is renamed without it's content being modified).

I choose to do the simplest thing for know and simply use a default value, we can in the future think about making the `patch` field properly optional (`Option<String>`).

Fixes https://rust-lang.zulipchat.com/#narrow/channel/224082-triagebot/topic/Missing.20labels.20due.20to.20missing.20.60patch.60.20field/with/520515295