### PR TITLE
Add missing issue type actions

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -1223,6 +1223,8 @@ pub enum IssuesAction {
     AutoMergeDisabled,
     Enqueued,
     Dequeued,
+    Typed,
+    Untyped,
 }
 
 #[derive(Debug, serde::Deserialize)]


### PR DESCRIPTION
The "typed" and "untyped" issue actions were added a while ago for when issue types are added/removed from an issue. These were causing errors in triagebot's logs when it failed to deserialize these.

Reference: https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=typed#issues