### PR TITLE
Ignore elements in markdown links

### DIFF
--- a/parser/src/ignore_block.rs
+++ b/parser/src/ignore_block.rs
@@ -27,6 +27,12 @@ impl IgnoreBlocks {
                 Event::Start(Tag::CodeBlock(_)) => {
                     ignore_till_end!(TagEnd::CodeBlock);
                 }
+                Event::Start(Tag::Link { .. }) => {
+                    ignore_till_end!(TagEnd::Link { .. });
+                }
+                Event::Start(Tag::Image { .. }) => {
+                    ignore_till_end!(TagEnd::Image { .. });
+                }
                 Event::Start(Tag::BlockQuote(_)) => {
                     let start = range.start;
                     let mut count = 1;
@@ -324,11 +330,22 @@ fn cbs_13() {
 
 #[test]
 fn ignore_link() {
-    assert_eq!(bodies("[This is a link](https://example.com)"), []);
-    assert_eq!(bodies("![This is an image](foo.png)"), []);
+    assert_eq!(
+        bodies("[This is a link](https://example.com)"),
+        [Ignore::Yes("[This is a link](https://example.com)")]
+    );
+    assert_eq!(
+        bodies("![This is an image](foo.png)"),
+        [Ignore::Yes("![This is an image](foo.png)")]
+    );
 
+    // Unfortunately pulldown_cmark does not give ranges for the link
+    // definition.
     assert_eq!(
         bodies("[Link from def]\n\n[Link from def]: https://example.com"),
-        []
+        [
+            Ignore::Yes("[Link from def]"),
+            Ignore::No("\n\n[Link from def]: https://example.com")
+        ]
     );
 }

--- a/parser/src/ignore_block.rs
+++ b/parser/src/ignore_block.rs
@@ -321,3 +321,14 @@ fn cbs_13() {
         ],
     );
 }
+
+#[test]
+fn ignore_link() {
+    assert_eq!(bodies("[This is a link](https://example.com)"), []);
+    assert_eq!(bodies("![This is an image](foo.png)"), []);
+
+    assert_eq!(
+        bodies("[Link from def]\n\n[Link from def]: https://example.com"),
+        []
+    );
+}


### PR DESCRIPTION
We do not want to process things inside links, as this is causing some false positives. GitHub seems to also ignore these.