### PR TITLE
Fix errors due to github team name mismatch

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -290,6 +290,25 @@ pub async fn get_team(
     Ok(map.swap_remove(team))
 }
 
+/// Fetches a Rust team via its GitHub team name.
+pub async fn get_team_by_github_name(
+    client: &GithubClient,
+    org: &str,
+    team: &str,
+) -> anyhow::Result<Option<rust_team_data::v1::Team>> {
+    let teams = crate::team_data::teams(client).await?;
+    for rust_team in teams.teams.into_values() {
+        if let Some(github) = &rust_team.github {
+            for gh_team in &github.teams {
+                if gh_team.org == org && gh_team.name == team {
+                    return Ok(Some(rust_team));
+                }
+            }
+        }
+    }
+    Ok(None)
+}
+
 #[derive(PartialEq, Eq, Debug, Clone, serde::Deserialize)]
 pub struct Label {
     pub name: String,

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -125,7 +125,7 @@ async fn id_from_user(
     ctx: &Context,
     login: &str,
 ) -> anyhow::Result<Option<(Vec<github::User>, Option<String>)>> {
-    if login.contains('/') {
+    if let Some((org, team)) = login.split_once('/') {
         // This is a team ping. For now, just add it to everyone's agenda on
         // that team, but also mark it as such (i.e., a team ping) for
         // potentially different prioritization and so forth.
@@ -136,11 +136,7 @@ async fn id_from_user(
         //
         // We may also want to be able to categorize into these buckets
         // *after* the ping occurs and is initially processed.
-
-        let mut iter = login.split('/');
-        let _rust_lang = iter.next().unwrap();
-        let team = iter.next().unwrap();
-        let team = match github::get_team(&ctx.github, team).await {
+        let team = match github::get_team_by_github_name(&ctx.github, org, team).await {
             Ok(Some(team)) => team,
             Ok(None) => {
                 // If the team is in rust-lang*, then this is probably an error (potentially user


### PR DESCRIPTION
This fixes a problem where the notification handler was generating errors when a GitHub team name does not match its Rust team name. The solution here is to actually iterate over the GitHub team names instead of assuming the GitHub team name matches the Rust team name.

CC https://github.com/rust-lang/triagebot/issues/1889 (This does not fix assignment.)