### PR TITLE
Add `lookup [github|zulip] <username>` command for determining the GitHub/Zulip username mapping

### DIFF
--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -617,7 +617,9 @@ pub(crate) struct ZulipUser {
 }
 
 impl ZulipUser {
-    // The GitHub profile data key is 3873
+    // The custom profile field ID for GitHub profiles on the Rust Zulip
+    // is 3873. This is likely not portable across different Zulip instance,
+    // but we assume that triagebot will only be used on this Zulip instance anyway.
     pub(crate) fn get_github_username(&self) -> Option<&str> {
         self.profile_data.get("3873").map(|v| v.value.as_str())
     }


### PR DESCRIPTION
This should make it much easier to figure out a GitHub username from Zulip name, and Zulip name from a GitHub username.

Suggested here: [#t-compiler/contrib-private > Nominating mati865 and madsmtm @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/244344-t-compiler.2Fcontrib-private/topic/Nominating.20mati865.20and.20madsmtm/near/520956178).

I know that the code of the Zulip integration is... not great. I just copy-pasted stuff around for this, but after this PR (and after https://github.com/rust-lang/rust-forge/pull/853, which shuffles some Zulip docs and mentions Zulip DM commands), I want to do the following:
- Split the `zulip.rs` file into multiple modules
- Rewrite the command handling using e.g. `clap` (or something similar), to both remove the manual parsing and provide automatically generated error messages for users
- Use an actual Zulip API client struct, rather than copy pasting loading of the Zulip API token from the environment and Zulip API error handling all over the place.
- Document this (and the previous `whoami` command in the Forge)