### PR TITLE
Migrate `EditIssueBody` to database state storage

### DIFF
--- a/src/interactions.rs
+++ b/src/interactions.rs
@@ -1,4 +1,11 @@
-use crate::github::{GithubClient, Issue};
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use tokio_postgres::Client as DbClient;
+
+use crate::{
+    db::issue_data::IssueData,
+    github::{GithubClient, Issue},
+};
 use std::fmt::Write;
 
 pub struct ErrorComment<'a> {
@@ -51,7 +58,11 @@ impl<'a> PingComment<'a> {
     }
 }
 
-pub struct EditIssueBody<'a> {
+pub struct EditIssueBody<'a, T>
+where
+    T: for<'t> Deserialize<'t> + Serialize + Default + std::fmt::Debug + Sync + PartialEq + Clone,
+{
+    issue_data: IssueData<'a, T>,
     issue: &'a Issue,
     id: &'static str,
 }
@@ -63,88 +74,47 @@ fn normalize_body(body: &str) -> String {
     str::replace(body, "\r\n", "\n")
 }
 
-impl<'a> EditIssueBody<'a> {
-    pub fn new(issue: &'a Issue, id: &'static str) -> EditIssueBody<'a> {
-        EditIssueBody { issue, id }
-    }
+impl<'a, T> EditIssueBody<'a, T>
+where
+    T: for<'t> Deserialize<'t> + Serialize + Default + std::fmt::Debug + Sync + PartialEq + Clone,
+{
+    pub async fn load(
+        db: &'a mut DbClient,
+        issue: &'a Issue,
+        id: &'static str,
+    ) -> Result<EditIssueBody<'a, T>> {
+        let issue_data = IssueData::load(db, issue, id).await?;
 
-    fn get_current(&self) -> Option<String> {
-        let self_issue_body = normalize_body(&self.issue.body);
-        let start_section = self.start_section();
-        let end_section = self.end_section();
-        if self_issue_body.contains(START_BOT) {
-            if self_issue_body.contains(&start_section) {
-                let start_idx = self_issue_body.find(&start_section).unwrap();
-                let end_idx = self_issue_body.find(&end_section).unwrap();
-                let current =
-                    String::from(&self_issue_body[start_idx..(end_idx + end_section.len())]);
-                Some(current)
-            } else {
-                None
-            }
-        } else {
-            None
+        let mut edit = EditIssueBody {
+            issue_data,
+            issue,
+            id,
+        };
+
+        // Legacy, if we find data inside the issue body for the current
+        // id, use that instead of the (hopefully) default value given
+        // by IssueData.
+        if let Some(d) = edit.current_data_markdown() {
+            edit.issue_data.data = d;
         }
+
+        Ok(edit)
     }
 
-    pub fn current_data<T: serde::de::DeserializeOwned>(&self) -> Option<T> {
-        let all = self.get_current()?;
-        let start = self.data_section_start();
-        let end = self.data_section_end();
-        let start_idx = all.find(&start).unwrap();
-        let end_idx = all.find(&end).unwrap();
-        let text = &all[(start_idx + start.len())..end_idx];
-        Some(serde_json::from_str(text).unwrap_or_else(|e| {
-            panic!("deserializing data {:?} failed: {:?}", text, e);
-        }))
+    pub fn data_mut(&mut self) -> &mut T {
+        &mut self.issue_data.data
     }
 
-    fn start_section(&self) -> String {
-        format!("<!-- TRIAGEBOT_{}_START -->\n", self.id)
-    }
-
-    fn end_section(&self) -> String {
-        format!("\n<!-- TRIAGEBOT_{}_END -->\n", self.id)
-    }
-
-    fn data_section_start(&self) -> String {
-        format!("\n<!-- TRIAGEBOT_{}_DATA_START$$", self.id)
-    }
-
-    fn data_section_end(&self) -> String {
-        format!("$$TRIAGEBOT_{}_DATA_END -->\n", self.id)
-    }
-
-    fn data_section<T>(&self, data: T) -> String
-    where
-        T: serde::Serialize,
-    {
-        format!(
-            "{}{}{}",
-            self.data_section_start(),
-            serde_json::to_string(&data).unwrap(),
-            self.data_section_end()
-        )
-    }
-
-    pub async fn apply<T>(&self, client: &GithubClient, text: String, data: T) -> anyhow::Result<()>
-    where
-        T: serde::Serialize,
-    {
+    pub async fn apply(self, client: &GithubClient, text: String) -> anyhow::Result<()> {
         let mut current_body = normalize_body(&self.issue.body.clone());
         let start_section = self.start_section();
         let end_section = self.end_section();
 
-        let bot_section = format!(
-            "{}{}{}{}",
-            start_section,
-            text,
-            self.data_section(data),
-            end_section
-        );
+        let bot_section = format!("{}{}{}", start_section, text, end_section);
         let empty_bot_section = format!("{}{}", start_section, end_section);
-
         let all_new = format!("\n\n{}{}{}", START_BOT, bot_section, END_BOT);
+
+        // Edit or add the new text the current triagebot section
         if current_body.contains(START_BOT) {
             if current_body.contains(&start_section) {
                 let start_idx = current_body.find(&start_section).unwrap();
@@ -166,6 +136,59 @@ impl<'a> EditIssueBody<'a> {
 
             self.issue.edit_body(&client, &new_body).await?;
         }
+
+        // Save the state in the database
+        self.issue_data.save().await?;
+
         Ok(())
+    }
+
+    fn start_section(&self) -> String {
+        format!("<!-- TRIAGEBOT_{}_START -->\n", self.id)
+    }
+
+    fn end_section(&self) -> String {
+        format!("\n<!-- TRIAGEBOT_{}_END -->\n", self.id)
+    }
+
+    // Legacy, only used for handling data inside the issue body it-self
+
+    fn current_data_markdown(&self) -> Option<T> {
+        let all = self.get_current_markdown()?;
+        let start = self.data_section_start();
+        let end = self.data_section_end();
+        let start_idx = all.find(&start).unwrap();
+        let end_idx = all.find(&end).unwrap();
+        let text = &all[(start_idx + start.len())..end_idx];
+        Some(serde_json::from_str(text).unwrap_or_else(|e| {
+            panic!("deserializing data {:?} failed: {:?}", text, e);
+        }))
+    }
+
+    fn get_current_markdown(&self) -> Option<String> {
+        let self_issue_body = normalize_body(&self.issue.body);
+        let start_section = self.start_section();
+        let end_section = self.end_section();
+        if self_issue_body.contains(START_BOT) {
+            if self_issue_body.contains(&start_section) {
+                let start_idx = self_issue_body.find(&start_section).unwrap();
+                let end_idx = self_issue_body.find(&end_section).unwrap();
+                let current =
+                    String::from(&self_issue_body[start_idx..(end_idx + end_section.len())]);
+                Some(current)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+
+    fn data_section_start(&self) -> String {
+        format!("\n<!-- TRIAGEBOT_{}_DATA_START$$", self.id)
+    }
+
+    fn data_section_end(&self) -> String {
+        format!("$$TRIAGEBOT_{}_DATA_END -->\n", self.id)
     }
 }


### PR DESCRIPTION
This PR migrate our `EditIssueBody` from storing the state inside the issue body it-self to using the database storage.

This includes a migration code, if we find an old data in the issue body we prefer that one over the default one, but of-course we no longer save it

This should avoid issues when multiple commands using `EditIssueBody` are used in the same comment, as they would overlap each other due to `EditIssueBody` [re-using the same issue body](https://github.com/rust-lang/triagebot/blob/7044e5449aaf29eea939bc7db81c63b7c872b9b8/src/interactions.rs#L72) instead of fetching the new one.

What this PR does is pretty straight forward (doesn't use anything new), but I haven't tested it.

Given the small amount of users of `EditIssueBody`, I migrated everything in this PR.