### PR TITLE
Allow empty `[assign.owners]`

### DIFF
--- a/src/handlers/assign.rs
+++ b/src/handlers/assign.rs
@@ -129,11 +129,7 @@ pub(super) async fn parse_input(
     event: &IssuesEvent,
     config: Option<&AssignConfig>,
 ) -> Result<Option<AssignInput>, String> {
-    let config = match config {
-        Some(config) => config,
-        None => return Ok(None),
-    };
-    if config.owners.is_empty() || !event.issue.is_pr() {
+    if config.is_none() || !event.issue.is_pr() {
         return Ok(None);
     }
 

--- a/src/handlers/assign/tests/tests_from_diff.rs
+++ b/src/handlers/assign/tests/tests_from_diff.rs
@@ -144,3 +144,10 @@ fn basic_gitignore_pattern() {
     let diff = make_fake_diff(&[("src/librustdoc/html/static/js/settings.js", 10, 1)]);
     test_from_diff(&diff, config, &["javascript-reviewers"]);
 }
+
+#[test]
+fn empty_owners_table() {
+    let config = toml::toml!([owners]);
+    let diff = make_fake_diff(&[("src.js", 10, 1)]);
+    test_from_diff(&diff, config, &[]);
+}


### PR DESCRIPTION
This PR relaxes the `[assign]` handler checks to allow empty `[assign.owners]`, otherwise explicit assignments (`r? someone`) in the PR description would be ignored and the welcome message wouldn't be shown (rendering #2037 useless for rustc-dev-guide).

Related to #2035, where rustc-dev-guide wants an "opt-in reviewer".

cc @jieyouxu