### PR TITLE
Add possibility to skip workqueue loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ The general overview of what you will need to do:
 6. Add a `triagebot.toml` file to the main branch of your GitHub repo with whichever services you want to try out.
 7. Try interacting with your repo, such as issuing `@rustbot` commands or interacting with PRs and issues (depending on which services you enabled in `triagebot.toml`). Watch the logs from the server to see what's going on.
 
+#### Skipping workqueue loading
+
+When triagebot starts, it eagerly loads the pull request workqueue for the `rust-lang/rust` repository, which can take up ~10-15 seconds. To disable this, for faster local experiments, pass the `SKIP_WORKQUEUE=1` environment variable to triagebot.
+
 ### Configure a database
 
 To use Postgres, you will need to install it and configure it:

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,23 +253,37 @@ async fn run_server(addr: SocketAddr) -> anyhow::Result<()> {
         .build()
         .expect("Failed to build octograb.");
 
+    // Loading the workqueue takes ~10-15s, and it's annoying for local rebuilds.
+    // Allow users to opt out of it.
+    let skip_loading_workqueue = env::var("SKIP_WORKQUEUE")
+        .ok()
+        .map(|v| v == "1")
+        .unwrap_or(false);
+
     // Load the initial workqueue state from GitHub
     // In case this fails, we do not want to block triagebot, instead
     // we use an empty workqueue and let it be updated later through
     // webhooks and the `PullRequestAssignmentUpdate` cron job.
-    tracing::info!("Loading reviewer workqueue for rust-lang/rust");
-    let workqueue = match tokio::time::timeout(Duration::from_secs(60), load_workqueue(&oc)).await {
-        Ok(Ok(workqueue)) => workqueue,
-        Ok(Err(error)) => {
-            tracing::error!("Cannot load initial workqueue: {error:?}");
-            ReviewerWorkqueue::default()
-        }
-        Err(_) => {
-            tracing::error!("Cannot load initial workqueue, timeouted after a minute");
-            ReviewerWorkqueue::default()
-        }
+    let workqueue = if skip_loading_workqueue {
+        tracing::warn!("Skipping workqueue loading");
+        ReviewerWorkqueue::default()
+    } else {
+        tracing::info!("Loading reviewer workqueue for rust-lang/rust");
+        let workqueue =
+            match tokio::time::timeout(Duration::from_secs(60), load_workqueue(&oc)).await {
+                Ok(Ok(workqueue)) => workqueue,
+                Ok(Err(error)) => {
+                    tracing::error!("Cannot load initial workqueue: {error:?}");
+                    ReviewerWorkqueue::default()
+                }
+                Err(_) => {
+                    tracing::error!("Cannot load initial workqueue, timeouted after a minute");
+                    ReviewerWorkqueue::default()
+                }
+            };
+        tracing::info!("Workqueue loaded");
+        workqueue
     };
-    tracing::info!("Workqueue loaded");
 
     // Only run the migrations after the workqueue has been loaded, immediately
     // before starting the HTTP server.


### PR DESCRIPTION
Triagebot always eagerly loads the reviewer workqueue from `rust-lang/rust` on startup, which takes ~10-15s, which is quite annoying for local experiments with triagebot. This PR adds an environment variable that skips this loading.

Longer term, we should probably modify triagebot to avoid the eager load, although that might require some further changes.

CC @apiraino