### PR TITLE
Fix panic when not finding the data inside the markdown

### DIFF
--- a/src/interactions.rs
+++ b/src/interactions.rs
@@ -157,8 +157,8 @@ where
         let all = self.get_current_markdown()?;
         let start = self.data_section_start();
         let end = self.data_section_end();
-        let start_idx = all.find(&start).unwrap();
-        let end_idx = all.find(&end).unwrap();
+        let start_idx = all.find(&start)?;
+        let end_idx = all.find(&end)?;
         let text = &all[(start_idx + start.len())..end_idx];
         Some(serde_json::from_str(text).unwrap_or_else(|e| {
             panic!("deserializing data {:?} failed: {:?}", text, e);


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/triagebot/pull/2032, where after migrating to the database and removing the data from the issue it-self we are crashing when not finding the data the next time, instead of returning a `None`.

```
thread 'main' panicked at /src/interactions.rs:160:42::
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

You can test the crash and fix on the playground: https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=25c1249cdda417c7948f80e815e648e5 