### PR TITLE
Unconfuse GitHub with resolved concerns

### DIFF
--- a/src/handlers/concern.rs
+++ b/src/handlers/concern.rs
@@ -195,7 +195,7 @@ fn markdown_content(concerns: &[Concern], bot: &str) -> String {
             } => {
                 writeln!(
                     md,
-                    "> - ~~[{title}]({comment_url})~~ resolved [in this comment]({resolved_comment_url})"
+                    "> - ~~[{title}]({comment_url})~~ resolved in [this comment]({resolved_comment_url})"
                 )
             }
         };
@@ -231,7 +231,7 @@ fn simple_markdown_content() {
 > # Concerns (1 active)
 >
 > - [This is my concern about concern](https://github.com/fake-comment-1234)
-> - ~~[This is a resolved concern](https://github.com/fake-comment-4561)~~ resolved [in this comment](https:://github.com/fake-comment-8888)
+> - ~~[This is a resolved concern](https://github.com/fake-comment-4561)~~ resolved in [this comment](https:://github.com/fake-comment-8888)
 >
 > *Managed by `@rustbot`—see [help](https://forge.rust-lang.org/triagebot/concern.html) for details.*
 "#
@@ -254,7 +254,7 @@ fn resolved_concerns_markdown_content() {
 > [!NOTE]
 > # Concerns (0 active)
 >
-> - ~~[This is a resolved concern](https://github.com/fake-comment-4561)~~ resolved [in this comment](https:://github.com/fake-comment-8888)
+> - ~~[This is a resolved concern](https://github.com/fake-comment-4561)~~ resolved in [this comment](https:://github.com/fake-comment-8888)
 >
 > *Managed by `@rustbot`—see [help](https://forge.rust-lang.org/triagebot/concern.html) for details.*
 "#


### PR DESCRIPTION
You can see in https://github.com/rust-lang/triagebot/pull/2024#issue-3099685606 that GitHub thinks the PR is going to resolve/fix it-self due to the link after the "resolved".

To fix it, we exclude the `in` from the link and only have `this comment` as part of the link.