### PR TITLE
Add a Zulip client API

### DIFF
--- a/src/bin/project_goals.rs
+++ b/src/bin/project_goals.rs
@@ -1,4 +1,5 @@
 use structopt::StructOpt;
+use triagebot::zulip::client::ZulipClient;
 use triagebot::{github::GithubClient, handlers::project_goals};
 
 /// A basic example
@@ -22,8 +23,10 @@ async fn main() -> anyhow::Result<()> {
 
     let opt = Opt::from_args();
     let gh = GithubClient::new_from_env();
+    let zulip = ZulipClient::new_from_env();
     project_goals::ping_project_goals_owners(
         &gh,
+        &zulip,
         opt.dry_run,
         opt.days_threshold,
         &opt.next_meeting_date,

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,6 +1,7 @@
 use crate::config::{self, Config, ConfigurationError};
 use crate::github::{Event, GithubClient, IssueCommentAction, IssuesAction, IssuesEvent};
 use crate::handlers::pr_tracking::ReviewerWorkqueue;
+use crate::zulip::client::ZulipClient;
 use octocrab::Octocrab;
 use parser::command::{assign::AssignCommand, Command, Input};
 use std::fmt;
@@ -372,6 +373,7 @@ command_handlers! {
 
 pub struct Context {
     pub github: GithubClient,
+    pub zulip: ZulipClient,
     pub db: crate::db::ClientPool,
     pub username: String,
     pub octocrab: Octocrab,

--- a/src/handlers/major_change.rs
+++ b/src/handlers/major_change.rs
@@ -148,7 +148,7 @@ pub(super) async fn handle_input(
                 id: config.zulip_stream,
                 topic: &new_topic,
             }
-            .url();
+            .url(&ctx.zulip);
             let breadcrumb_comment = format!(
                 "The associated GitHub issue has been renamed. Please see the [renamed Zulip topic]({}).",
                 new_topic_url
@@ -256,7 +256,7 @@ async fn handle(
     };
 
     if new_proposal {
-        let topic_url = zulip_req.url();
+        let topic_url = zulip_req.url(&ctx.zulip);
         let comment = format!(
             r#"> [!IMPORTANT]
 > This issue is *not meant to be used for technical discussion*. There is a **Zulip [stream]** for that.

--- a/src/handlers/major_change.rs
+++ b/src/handlers/major_change.rs
@@ -138,7 +138,7 @@ pub(super) async fn handle_input(
                 content: None,
             };
             zulip_update_req
-                .send(&ctx.github.raw())
+                .send(&ctx.zulip)
                 .await
                 .context("zulip message update failed")?;
 

--- a/src/handlers/notify_zulip.rs
+++ b/src/handlers/notify_zulip.rs
@@ -1,3 +1,4 @@
+use crate::zulip::api::Recipient;
 use crate::{
     config::{NotifyZulipConfig, NotifyZulipLabelConfig, NotifyZulipTablesConfig},
     github::{Issue, IssuesAction, IssuesEvent, Label},
@@ -208,7 +209,7 @@ pub(super) async fn handle_input<'a>(
                 NotificationType::Reopened => &config.messages_on_reopen,
             };
 
-            let recipient = crate::zulip::Recipient::Stream {
+            let recipient = Recipient::Stream {
                 id: config.zulip_stream,
                 topic: &topic,
             };
@@ -222,7 +223,7 @@ pub(super) async fn handle_input<'a>(
                     recipient,
                     content: &msg,
                 }
-                .send(&ctx.github.raw())
+                .send(&ctx.zulip)
                 .await;
 
                 if let Err(err) = req {

--- a/src/handlers/types_planning_updates.rs
+++ b/src/handlers/types_planning_updates.rs
@@ -1,6 +1,7 @@
 use crate::db::schedule_job;
 use crate::github;
 use crate::jobs::Job;
+use crate::zulip::api::Recipient;
 use anyhow::Context as _;
 use async_trait::async_trait;
 use chrono::{Datelike, Duration, NaiveTime, TimeZone, Utc};
@@ -32,13 +33,13 @@ impl Job for TypesPlanningMeetingThreadOpenJob {
             This is a reminder to update the current [roadmap tracking issues](https://github.com/rust-lang/types-team/issues?q=is%3Aissue+is%3Aopen+label%3Aroadmap-tracking-issue).\n\
             Extra reminders will be sent later this week.");
         let zulip_req = crate::zulip::MessageApiRequest {
-            recipient: crate::zulip::Recipient::Stream {
+            recipient: Recipient::Stream {
                 id: TYPES_MEETINGS_STREAM,
                 topic: &format!("{meeting_date_string} planning meeting"),
             },
             content: &message,
         };
-        zulip_req.send(&ctx.github.raw()).await?;
+        zulip_req.send(&ctx.zulip).await?;
 
         // Then, we want to schedule the next Thursday after this
         let mut thursday = today;
@@ -158,13 +159,13 @@ pub async fn request_updates(
 
     let meeting_date_string = metadata.date_string;
     let zulip_req = crate::zulip::MessageApiRequest {
-        recipient: crate::zulip::Recipient::Stream {
+        recipient: Recipient::Stream {
             id: TYPES_MEETINGS_STREAM,
             topic: &format!("{meeting_date_string} planning meeting"),
         },
         content: &message,
     };
-    zulip_req.send(&ctx.github.raw()).await?;
+    zulip_req.send(&ctx.zulip).await?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use triagebot::handlers::pr_tracking::ReviewerWorkqueue;
 use triagebot::jobs::{
     default_jobs, JOB_PROCESSING_CADENCE_IN_SECS, JOB_SCHEDULING_CADENCE_IN_SECS,
 };
+use triagebot::zulip::client::ZulipClient;
 use triagebot::{db, github, handlers::Context, notification_listing, payload, EventName};
 
 async fn handle_agenda_request(req: String) -> anyhow::Result<String> {
@@ -248,6 +249,7 @@ async fn serve_req(
 
 async fn run_server(addr: SocketAddr) -> anyhow::Result<()> {
     let gh = github::GithubClient::new_from_env();
+    let zulip = ZulipClient::new_from_env();
     let oc = octocrab::OctocrabBuilder::new()
         .personal_token(github::default_token_from_env())
         .build()
@@ -291,6 +293,7 @@ async fn run_server(addr: SocketAddr) -> anyhow::Result<()> {
         github: gh,
         octocrab: oc,
         workqueue: Arc::new(RwLock::new(workqueue)),
+        zulip,
     });
 
     // Run all jobs that have a schedule (recurring jobs)

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -3,6 +3,7 @@ use crate::db::users::record_username;
 use crate::db::{make_client, ClientPool, PooledClient};
 use crate::github::GithubClient;
 use crate::handlers::Context;
+use crate::zulip::client::ZulipClient;
 use octocrab::Octocrab;
 use std::future::Future;
 use std::sync::Arc;
@@ -67,8 +68,13 @@ impl TestContext {
             "https://api.github.com/graphql".to_string(),
             "https://raw.githubusercontent.com".to_string(),
         );
+        let zulip = ZulipClient::new(
+            "https://rust-fake.zulipchat.com".to_string(),
+            "test-bot@zulipchat.com".to_string(),
+        );
         let ctx = Context {
             github,
+            zulip,
             db: pool,
             username: "triagebot-test".to_string(),
             octocrab,

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -1,4 +1,4 @@
-mod api;
+pub mod api;
 pub mod client;
 
 use crate::db::notifications::add_metadata;
@@ -11,6 +11,7 @@ use crate::handlers::project_goals::{self, ping_project_goals_owners};
 use crate::handlers::Context;
 use crate::team_data::{people, teams};
 use crate::utils::pluralize;
+use crate::zulip::api::{MessageApiResponse, Recipient};
 use crate::zulip::client::ZulipClient;
 use anyhow::{format_err, Context as _};
 use rust_team_data::v1::TeamKind;
@@ -265,7 +266,7 @@ fn handle_command<'a>(
                                 };
 
                                 if project_goals::check_project_goal_acl(&ctx.github, gh_id).await? {
-                                    ping_project_goals_owners(&ctx.github, false, threshold, &format!("on {next_update}"))
+                                    ping_project_goals_owners(&ctx.github, &ctx.zulip, false, threshold, &format!("on {next_update}"))
                                         .await
                                         .map_err(|e| format_err!("Failed to await at this time: {e:?}"))?;
                                     return Ok(None);
@@ -275,7 +276,7 @@ fn handle_command<'a>(
                                     ));
                                 }
                             }
-                            Some("docs-update") => return trigger_docs_update(message_data),
+                            Some("docs-update") => return trigger_docs_update(message_data, &ctx.zulip),
                             _ => {}
                         }
                     }
@@ -687,7 +688,7 @@ async fn execute_for_other_user(
         },
         content: &message,
     }
-    .send(ctx.github.raw())
+    .send(&ctx.zulip)
     .await;
 
     if let Err(err) = res {
@@ -697,87 +698,10 @@ async fn execute_for_other_user(
     Ok(Some(output))
 }
 
-#[derive(Copy, Clone, serde::Serialize)]
-#[serde(tag = "type")]
-#[serde(rename_all = "snake_case")]
-pub enum Recipient<'a> {
-    Stream {
-        #[serde(rename = "to")]
-        id: u64,
-        topic: &'a str,
-    },
-    Private {
-        #[serde(skip)]
-        id: u64,
-        #[serde(rename = "to")]
-        email: &'a str,
-    },
-}
-
-impl Recipient<'_> {
-    pub fn narrow(&self) -> String {
-        match self {
-            Recipient::Stream { id, topic } => {
-                // See
-                // https://github.com/zulip/zulip/blob/46247623fc279/zerver/lib/url_encoding.py#L9
-                // ALWAYS_SAFE without `.` from
-                // https://github.com/python/cpython/blob/113e2b0a07c/Lib/urllib/parse.py#L772-L775
-                //
-                // ALWAYS_SAFE doesn't contain `.` because Zulip actually encodes them to be able
-                // to use `.` instead of `%` in the encoded strings
-                const ALWAYS_SAFE: &str =
-                    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-~";
-
-                let mut encoded_topic = String::new();
-                for ch in topic.bytes() {
-                    if !(ALWAYS_SAFE.contains(ch as char)) {
-                        write!(encoded_topic, ".{:02X}", ch).unwrap();
-                    } else {
-                        encoded_topic.push(ch as char);
-                    }
-                }
-                format!("stream/{}-xxx/topic/{}", id, encoded_topic)
-            }
-            Recipient::Private { id, .. } => format!("pm-with/{}-xxx", id),
-        }
-    }
-
-    pub fn url(&self) -> String {
-        format!("{}/#narrow/{}", *ZULIP_URL, self.narrow())
-    }
-}
-
-#[cfg(test)]
-fn check_encode(topic: &str, expected: &str) {
-    const PREFIX: &str = "stream/0-xxx/topic/";
-    let computed = Recipient::Stream { id: 0, topic }.narrow();
-    assert_eq!(&computed[..PREFIX.len()], PREFIX);
-    assert_eq!(&computed[PREFIX.len()..], expected);
-}
-
-#[test]
-fn test_encode() {
-    check_encode("some text with spaces", "some.20text.20with.20spaces");
-    check_encode(
-        " !\"#$%&'()*+,-./",
-        ".20.21.22.23.24.25.26.27.28.29.2A.2B.2C-.2E.2F",
-    );
-    check_encode("0123456789:;<=>?", "0123456789.3A.3B.3C.3D.3E.3F");
-    check_encode(
-        "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_",
-        ".40ABCDEFGHIJKLMNOPQRSTUVWXYZ.5B.5C.5D.5E_",
-    );
-    check_encode(
-        "`abcdefghijklmnopqrstuvwxyz{|}~",
-        ".60abcdefghijklmnopqrstuvwxyz.7B.7C.7D~.7F",
-    );
-    check_encode("áé…", ".C3.A1.C3.A9.E2.80.A6");
-}
-
 #[derive(serde::Serialize)]
-pub struct MessageApiRequest<'a> {
-    pub recipient: Recipient<'a>,
-    pub content: &'a str,
+pub(crate) struct MessageApiRequest<'a> {
+    pub(crate) recipient: Recipient<'a>,
+    pub(crate) content: &'a str,
 }
 
 impl<'a> MessageApiRequest<'a> {
@@ -785,65 +709,9 @@ impl<'a> MessageApiRequest<'a> {
         self.recipient.url()
     }
 
-    pub async fn send(&self, client: &reqwest::Client) -> anyhow::Result<MessageApiResponse> {
-        let bot_api_token = env::var("ZULIP_API_TOKEN").expect("ZULIP_API_TOKEN");
-
-        #[derive(serde::Serialize)]
-        struct SerializedApi<'a> {
-            #[serde(rename = "type")]
-            type_: &'static str,
-            to: String,
-            #[serde(skip_serializing_if = "Option::is_none")]
-            topic: Option<&'a str>,
-            content: &'a str,
-        }
-
-        let resp = client
-            .post(format!("{}/api/v1/messages", *ZULIP_URL))
-            .basic_auth(&*ZULIP_BOT_EMAIL, Some(&bot_api_token))
-            .form(&SerializedApi {
-                type_: match self.recipient {
-                    Recipient::Stream { .. } => "stream",
-                    Recipient::Private { .. } => "private",
-                },
-                to: match self.recipient {
-                    Recipient::Stream { id, .. } => id.to_string(),
-                    Recipient::Private { email, .. } => email.to_string(),
-                },
-                topic: match self.recipient {
-                    Recipient::Stream { topic, .. } => Some(topic),
-                    Recipient::Private { .. } => None,
-                },
-                content: self.content,
-            })
-            .send()
-            .await
-            .context("fail sending Zulip message")?;
-
-        let status = resp.status();
-
-        if !status.is_success() {
-            let body = resp
-                .text()
-                .await
-                .context("fail receiving Zulip API response (when sending a message)")?;
-
-            anyhow::bail!(body)
-        }
-
-        let resp: MessageApiResponse = resp
-            .json()
-            .await
-            .context("fail receiving the JSON Zulip Api reponse (when sending a message)")?;
-
-        Ok(resp)
+    pub(crate) async fn send(&self, client: &ZulipClient) -> anyhow::Result<MessageApiResponse> {
+        client.send_message(self.recipient, self.content).await
     }
-}
-
-#[derive(Debug, serde::Deserialize)]
-pub struct MessageApiResponse {
-    #[serde(rename = "id")]
-    pub message_id: u64,
 }
 
 #[derive(Debug)]
@@ -1144,7 +1012,7 @@ async fn post_waiter(
         },
         content: waiting.primary,
     }
-    .send(ctx.github.raw())
+    .send(&ctx.zulip)
     .await?;
 
     for reaction in waiting.emoji {
@@ -1160,10 +1028,11 @@ async fn post_waiter(
     Ok(None)
 }
 
-fn trigger_docs_update(message: &Message) -> anyhow::Result<Option<String>> {
+fn trigger_docs_update(message: &Message, zulip: &ZulipClient) -> anyhow::Result<Option<String>> {
     let message = message.clone();
     // The default Zulip timeout of 10 seconds can be too short, so process in
     // the background.
+    let zulip = zulip.clone();
     tokio::task::spawn(async move {
         let response = match docs_update().await {
             Ok(None) => "No updates found.".to_string(),
@@ -1179,7 +1048,7 @@ fn trigger_docs_update(message: &Message) -> anyhow::Result<Option<String>> {
             recipient,
             content: &response,
         };
-        if let Err(e) = message.send(&reqwest::Client::new()).await {
+        if let Err(e) = message.send(&zulip).await {
             log::error!("failed to send Zulip response: {e:?}\nresponse was:\n{response}");
         }
     });

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -22,9 +22,6 @@ use std::sync::LazyLock;
 use subtle::ConstantTimeEq;
 use tracing as log;
 
-static ZULIP_URL: LazyLock<String> =
-    LazyLock::new(|| env::var("ZULIP_URL").unwrap_or("https://rust-lang.zulipchat.com".into()));
-
 #[derive(Debug, serde::Deserialize)]
 pub struct Request {
     /// Markdown body of the sent message.
@@ -702,8 +699,8 @@ pub(crate) struct MessageApiRequest<'a> {
 }
 
 impl<'a> MessageApiRequest<'a> {
-    pub fn url(&self) -> String {
-        self.recipient.url()
+    pub fn url(&self, zulip: &ZulipClient) -> String {
+        self.recipient.url(zulip)
     }
 
     pub(crate) async fn send(&self, client: &ZulipClient) -> anyhow::Result<MessageApiResponse> {

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -15,10 +15,8 @@ use crate::zulip::api::{MessageApiResponse, Recipient};
 use crate::zulip::client::ZulipClient;
 use anyhow::{format_err, Context as _};
 use rust_team_data::v1::TeamKind;
-use std::env;
 use std::fmt::Write as _;
 use std::str::FromStr;
-use std::sync::LazyLock;
 use subtle::ConstantTimeEq;
 use tracing as log;
 

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -24,9 +24,6 @@ use tracing as log;
 
 static ZULIP_URL: LazyLock<String> =
     LazyLock::new(|| env::var("ZULIP_URL").unwrap_or("https://rust-lang.zulipchat.com".into()));
-static ZULIP_BOT_EMAIL: LazyLock<String> = LazyLock::new(|| {
-    env::var("ZULIP_BOT_EMAIL").unwrap_or("triage-rust-lang-bot@zulipchat.com".into())
-});
 
 #[derive(Debug, serde::Deserialize)]
 pub struct Request {

--- a/src/zulip/api.rs
+++ b/src/zulip/api.rs
@@ -1,4 +1,4 @@
-use crate::zulip::ZULIP_URL;
+use crate::zulip::client::ZulipClient;
 use std::collections::HashMap;
 
 /// A collection of Zulip users, as returned from '/users'
@@ -85,8 +85,8 @@ impl Recipient<'_> {
         }
     }
 
-    pub fn url(&self) -> String {
-        format!("{}/#narrow/{}", *ZULIP_URL, self.narrow())
+    pub fn url(&self, zulip: &ZulipClient) -> String {
+        format!("{}/#narrow/{}", zulip.instance_url(), self.narrow())
     }
 }
 

--- a/src/zulip/api.rs
+++ b/src/zulip/api.rs
@@ -1,0 +1,32 @@
+use std::collections::HashMap;
+
+/// A collection of Zulip users, as returned from '/users'
+#[derive(serde::Deserialize)]
+pub(crate) struct ZulipUsers {
+    pub(crate) members: Vec<ZulipUser>,
+}
+
+#[derive(Clone, serde::Deserialize, Debug, PartialEq, Eq)]
+pub(crate) struct ProfileValue {
+    pub(crate) value: String,
+}
+
+/// A single Zulip user
+#[derive(Clone, serde::Deserialize, Debug, PartialEq, Eq)]
+pub(crate) struct ZulipUser {
+    pub(crate) user_id: u64,
+    #[serde(rename = "full_name")]
+    pub(crate) name: String,
+    pub(crate) email: String,
+    #[serde(default)]
+    pub(crate) profile_data: HashMap<String, ProfileValue>,
+}
+
+impl ZulipUser {
+    // The custom profile field ID for GitHub profiles on the Rust Zulip
+    // is 3873. This is likely not portable across different Zulip instance,
+    // but we assume that triagebot will only be used on this Zulip instance anyway.
+    pub(crate) fn get_github_username(&self) -> Option<&str> {
+        self.profile_data.get("3873").map(|v| v.value.as_str())
+    }
+}

--- a/src/zulip/api.rs
+++ b/src/zulip/api.rs
@@ -1,3 +1,4 @@
+use crate::zulip::ZULIP_URL;
 use std::collections::HashMap;
 
 /// A collection of Zulip users, as returned from '/users'
@@ -29,4 +30,89 @@ impl ZulipUser {
     pub(crate) fn get_github_username(&self) -> Option<&str> {
         self.profile_data.get("3873").map(|v| v.value.as_str())
     }
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct MessageApiResponse {
+    #[serde(rename = "id")]
+    pub(crate) message_id: u64,
+}
+
+#[derive(Copy, Clone, serde::Serialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Recipient<'a> {
+    Stream {
+        #[serde(rename = "to")]
+        id: u64,
+        topic: &'a str,
+    },
+    Private {
+        #[serde(skip)]
+        id: u64,
+        #[serde(rename = "to")]
+        email: &'a str,
+    },
+}
+
+impl Recipient<'_> {
+    pub fn narrow(&self) -> String {
+        use std::fmt::Write;
+
+        match self {
+            Recipient::Stream { id, topic } => {
+                // See
+                // https://github.com/zulip/zulip/blob/46247623fc279/zerver/lib/url_encoding.py#L9
+                // ALWAYS_SAFE without `.` from
+                // https://github.com/python/cpython/blob/113e2b0a07c/Lib/urllib/parse.py#L772-L775
+                //
+                // ALWAYS_SAFE doesn't contain `.` because Zulip actually encodes them to be able
+                // to use `.` instead of `%` in the encoded strings
+                const ALWAYS_SAFE: &str =
+                    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-~";
+
+                let mut encoded_topic = String::new();
+                for ch in topic.bytes() {
+                    if !(ALWAYS_SAFE.contains(ch as char)) {
+                        write!(encoded_topic, ".{:02X}", ch).unwrap();
+                    } else {
+                        encoded_topic.push(ch as char);
+                    }
+                }
+                format!("stream/{}-xxx/topic/{}", id, encoded_topic)
+            }
+            Recipient::Private { id, .. } => format!("pm-with/{}-xxx", id),
+        }
+    }
+
+    pub fn url(&self) -> String {
+        format!("{}/#narrow/{}", *ZULIP_URL, self.narrow())
+    }
+}
+
+#[cfg(test)]
+fn check_encode(topic: &str, expected: &str) {
+    const PREFIX: &str = "stream/0-xxx/topic/";
+    let computed = Recipient::Stream { id: 0, topic }.narrow();
+    assert_eq!(&computed[..PREFIX.len()], PREFIX);
+    assert_eq!(&computed[PREFIX.len()..], expected);
+}
+
+#[test]
+fn test_encode() {
+    check_encode("some text with spaces", "some.20text.20with.20spaces");
+    check_encode(
+        " !\"#$%&'()*+,-./",
+        ".20.21.22.23.24.25.26.27.28.29.2A.2B.2C-.2E.2F",
+    );
+    check_encode("0123456789:;<=>?", "0123456789.3A.3B.3C.3D.3E.3F");
+    check_encode(
+        "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_",
+        ".40ABCDEFGHIJKLMNOPQRSTUVWXYZ.5B.5C.5D.5E_",
+    );
+    check_encode(
+        "`abcdefghijklmnopqrstuvwxyz{|}~",
+        ".60abcdefghijklmnopqrstuvwxyz.7B.7C.7D~.7F",
+    );
+    check_encode("áé…", ".C3.A1.C3.A9.E2.80.A6");
 }

--- a/src/zulip/client.rs
+++ b/src/zulip/client.rs
@@ -1,0 +1,67 @@
+use crate::zulip::{ZulipUser, ZulipUsers};
+use anyhow::Context;
+use reqwest::{Client, RequestBuilder, Response};
+use serde::de::DeserializeOwned;
+use std::env;
+use std::sync::OnceLock;
+
+pub struct ZulipClient {
+    client: Client,
+    instance_url: String,
+    bot_email: String,
+    // The token is loaded lazily, to avoid requiring the API token if Zulip APIs are not
+    // actually accessed.
+    bot_api_token: OnceLock<String>,
+}
+
+impl ZulipClient {
+    pub fn new_from_env() -> Self {
+        let instance_url =
+            env::var("ZULIP_URL").unwrap_or("https://rust-lang.zulipchat.com".into());
+        let bot_email =
+            env::var("ZULIP_BOT_EMAIL").unwrap_or("triage-rust-lang-bot@zulipchat.com".into());
+        Self::new(instance_url, bot_email)
+    }
+
+    fn new(instance_url: String, bot_email: String) -> Self {
+        let client = Client::new();
+        Self {
+            client,
+            instance_url,
+            bot_email,
+            bot_api_token: OnceLock::new(),
+        }
+    }
+
+    fn make_request(&self, url: &str) -> RequestBuilder {
+        let api_token = self.get_api_token();
+        self.client
+            .get(&format!("{}/{url}", self.instance_url))
+            .basic_auth(&self.bot_email, Some(api_token))
+    }
+
+    fn get_api_token(&self) -> &str {
+        self.bot_api_token
+            .get_or_init(|| env::var("ZULIP_API_TOKEN").expect("ZULIP_API_TOKEN is missing"))
+            .as_ref()
+    }
+}
+
+async fn deserialize_response<T>(response: Response) -> anyhow::Result<T>
+where
+    T: DeserializeOwned,
+{
+    let status = response.status();
+
+    if !status.is_success() {
+        let body = response.text().await.context("Zulip API request failed")?;
+        Err(anyhow::anyhow!(body))
+    } else {
+        Ok(response.json::<T>().await.with_context(|| {
+            anyhow::anyhow!(
+                "Failed to deserialize value of type {}",
+                std::any::type_name::<T>()
+            )
+        })?)
+    }
+}

--- a/src/zulip/client.rs
+++ b/src/zulip/client.rs
@@ -25,7 +25,7 @@ impl ZulipClient {
         Self::new(instance_url, bot_email)
     }
 
-    fn new(instance_url: String, bot_email: String) -> Self {
+    pub fn new(instance_url: String, bot_email: String) -> Self {
         let client = Client::new();
         Self {
             client,

--- a/src/zulip/client.rs
+++ b/src/zulip/client.rs
@@ -35,6 +35,10 @@ impl ZulipClient {
         }
     }
 
+    pub fn instance_url(&self) -> &str {
+        &self.instance_url
+    }
+
     // Taken from https://github.com/kobzol/team/blob/0f68ffc8b0d438d88ef4573deb54446d57e1eae6/src/api/zulip.rs#L45
     pub(crate) async fn get_zulip_users(&self) -> anyhow::Result<Vec<ZulipUser>> {
         let resp = self


### PR DESCRIPTION
First step of cleaning up the `zulip` module. Introduces a separate `ZulipClient` that holds the Zulip instance URL, bot e-mail and also loads the API token.

Best reviewed commit by commit.