### PR TITLE
Parse Zulip commands with `clap`

### DIFF
--- a/src/db/notifications.rs
+++ b/src/db/notifications.rs
@@ -27,7 +27,7 @@ pub async fn record_ping(db: &DbClient, notification: &Notification) -> anyhow::
     Ok(())
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum Identifier<'a> {
     Url(&'a str),
     Index(std::num::NonZeroU32),

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -204,6 +204,7 @@ fn handle_command<'a>(
                 ChatCommand::Add { url, description } => {
                     add_notification(&ctx, gh_id, &url, &description.join(" ")).await
                 }
+                ChatCommand::Move { from, to } => move_notification(&ctx, gh_id, from, to).await,
                 ChatCommand::Whoami => whoami_cmd(&ctx, gh_id).await,
                 ChatCommand::Lookup(cmd) => lookup_cmd(&ctx, cmd).await,
                 ChatCommand::Work(cmd) => workqueue_commands(ctx, gh_id, cmd).await,
@@ -796,24 +797,13 @@ async fn add_meta_notification(
 async fn move_notification(
     ctx: &Context,
     gh_id: u64,
-    mut words: impl Iterator<Item = &str>,
+    from: u32,
+    to: u32,
 ) -> anyhow::Result<Option<String>> {
-    let from = match words.next() {
-        Some(idx) => idx,
-        None => anyhow::bail!("from idx not present"),
-    };
-    let to = match words.next() {
-        Some(idx) => idx,
-        None => anyhow::bail!("from idx not present"),
-    };
     let from = from
-        .parse::<u32>()
-        .context("from index")?
         .checked_sub(1)
         .ok_or_else(|| anyhow::anyhow!("1-based indexes"))?;
     let to = to
-        .parse::<u32>()
-        .context("to index")?
         .checked_sub(1)
         .ok_or_else(|| anyhow::anyhow!("1-based indexes"))?;
     match move_indices(&mut *ctx.db.get().await, gh_id, from, to).await {

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -15,7 +15,7 @@ use crate::utils::pluralize;
 use crate::zulip::api::{MessageApiResponse, Recipient};
 use crate::zulip::client::ZulipClient;
 use crate::zulip::commands::{
-    parse_no_color, ChatCommand, LookupCmd, StreamCommand, WorkqueueCmd, WorkqueueLimit,
+    parse_cli, ChatCommand, LookupCmd, StreamCommand, WorkqueueCmd, WorkqueueLimit,
 };
 use anyhow::{format_err, Context as _};
 use rust_team_data::v1::TeamKind;
@@ -193,7 +193,7 @@ fn handle_command<'a>(
 
         // Missing stream means that this is a direct message
         if message_data.stream_id.is_none() {
-            let cmd = parse_no_color::<ChatCommand, _>(words.into_iter())?;
+            let cmd = parse_cli::<ChatCommand, _>(words.into_iter())?;
             match cmd {
                 ChatCommand::Acknowledge { identifier } => {
                     acknowledge(&ctx, gh_id, (&identifier).into()).await
@@ -219,7 +219,7 @@ fn handle_command<'a>(
             if cmd_index >= words.len() {
                 return Ok(Some("Unknown command".to_string()));
             }
-            let cmd = parse_no_color::<StreamCommand, _>(words[cmd_index..].into_iter().copied())?;
+            let cmd = parse_cli::<StreamCommand, _>(words[cmd_index..].into_iter().copied())?;
             match cmd {
                 StreamCommand::EndTopic => {
                     post_waiter(&ctx, message_data, WaitingMessage::end_topic())

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -14,9 +14,10 @@ use crate::team_data::{people, teams};
 use crate::utils::pluralize;
 use crate::zulip::api::{MessageApiResponse, Recipient};
 use crate::zulip::client::ZulipClient;
-use crate::zulip::commands::{ChatCommand, LookupCmd, StreamCommand, WorkqueueCmd, WorkqueueLimit};
+use crate::zulip::commands::{
+    parse_no_color, ChatCommand, LookupCmd, StreamCommand, WorkqueueCmd, WorkqueueLimit,
+};
 use anyhow::{format_err, Context as _};
-use clap::Parser;
 use rust_team_data::v1::TeamKind;
 use std::fmt::Write as _;
 use subtle::ConstantTimeEq;
@@ -192,7 +193,7 @@ fn handle_command<'a>(
 
         // Missing stream means that this is a direct message
         if message_data.stream_id.is_none() {
-            let cmd = ChatCommand::try_parse_from(words)?;
+            let cmd = parse_no_color::<ChatCommand, _>(words.into_iter())?;
             match cmd {
                 ChatCommand::Acknowledge { identifier } => {
                     acknowledge(&ctx, gh_id, (&identifier).into()).await
@@ -218,7 +219,7 @@ fn handle_command<'a>(
             if cmd_index >= words.len() {
                 return Ok(Some("Unknown command".to_string()));
             }
-            let cmd = StreamCommand::try_parse_from(&words[cmd_index..])?;
+            let cmd = parse_no_color::<StreamCommand, _>(words[cmd_index..].into_iter().copied())?;
             match cmd {
                 StreamCommand::EndTopic => {
                     post_waiter(&ctx, message_data, WaitingMessage::end_topic())

--- a/src/zulip/commands.rs
+++ b/src/zulip/commands.rs
@@ -1,11 +1,12 @@
 use crate::db::notifications::Identifier;
 use crate::db::review_prefs::RotationMode;
+use clap::{ColorChoice, Parser};
 use std::num::NonZeroU32;
 use std::str::FromStr;
 
 /// Command sent in a DM with triagebot on Zulip.
 #[derive(clap::Parser, Debug)]
-#[clap(override_usage("<command>"))]
+#[clap(override_usage("<command>"), disable_colored_help(true))]
 pub enum ChatCommand {
     /// Acknowledge a notification
     #[clap(alias = "ack")]
@@ -138,7 +139,7 @@ impl FromStr for IdentifierCli {
 
 /// Command sent in a Zulip stream after `@**triagebot**`.
 #[derive(clap::Parser, Debug)]
-#[clap(override_usage = "`@triagebot <command>`")]
+#[clap(override_usage("`@triagebot <command>`"), disable_colored_help(true))]
 pub enum StreamCommand {
     /// End the current topic.
     #[clap(alias = "await")]
@@ -156,4 +157,13 @@ pub enum StreamCommand {
     },
     /// Update docs
     DocsUpdate,
+}
+
+/// Helper function to parse CLI arguments without any colored help or error output.
+pub fn parse_no_color<'a, T: Parser, I: Iterator<Item = &'a str>>(input: I) -> anyhow::Result<T> {
+    let matches = T::command()
+        .color(ColorChoice::Never)
+        .try_get_matches_from(input)?;
+    let value = T::from_arg_matches(&matches)?;
+    Ok(value)
 }

--- a/src/zulip/commands.rs
+++ b/src/zulip/commands.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 
 /// Command sent in a DM with triagebot on Zulip.
 #[derive(clap::Parser, Debug)]
+#[clap(override_usage("<command>"))]
 pub enum ChatCommand {
     /// Acknowledge a notification
     #[clap(alias = "ack")]
@@ -137,6 +138,7 @@ impl FromStr for IdentifierCli {
 
 /// Command sent in a Zulip stream after `@**triagebot**`.
 #[derive(clap::Parser, Debug)]
+#[clap(override_usage = "`@triagebot <command>`")]
 pub enum StreamCommand {
     /// End the current topic.
     #[clap(alias = "await")]

--- a/src/zulip/commands.rs
+++ b/src/zulip/commands.rs
@@ -1,0 +1,80 @@
+use crate::db::review_prefs::RotationMode;
+use std::str::FromStr;
+
+#[derive(clap::Parser, Debug)]
+pub enum ChatCommand {
+    /// Output your membership in Rust teams.
+    Whoami,
+    /// Perform lookup of GitHub or Zulip username.
+    #[clap(subcommand)]
+    Lookup(LookupCmd),
+    /// Inspect or modify your reviewer workqueue.
+    #[clap(subcommand)]
+    Work(WorkqueueCmd),
+}
+
+#[derive(clap::Parser, Debug)]
+pub enum LookupCmd {
+    /// Try to find the Zulip name of a user with the provided GitHub username.
+    Zulip {
+        /// GitHub username to lookup the Zulip user from.
+        github_username: String,
+    },
+    ///  Try to find the GitHub username of a user with the provided Zulip name.
+    GitHub {
+        /// Zulip name to lookup the GitHub username from.
+        // Zulip usernames could contain spaces, so take everything to the end of the input
+        #[clap(trailing_var_arg(true))]
+        zulip_username: Vec<String>,
+    },
+}
+
+#[derive(clap::Parser, Debug)]
+pub enum WorkqueueCmd {
+    /// Show the current state of your workqueue
+    Show,
+    /// Set the maximum capacity limit of your workqueue.
+    SetPrLimit {
+        /// Workqueue capacity
+        limit: WorkqueueLimit,
+    },
+    /// Set your rotation mode (`on` rotation or `off` rotation).
+    SetRotationMode {
+        /// Rotation mode
+        rotation_mode: RotationModeCli,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub enum WorkqueueLimit {
+    Unlimited,
+    Limit(u32),
+}
+
+impl FromStr for WorkqueueLimit {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "unlimited" => Ok(Self::Unlimited),
+            v => v.parse::<u32>().map_err(|_|
+                                              "Wrong parameter format. Must be a positive integer or `unlimited` to unset the limit.".to_string(),
+            ).map(WorkqueueLimit::Limit)
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RotationModeCli(pub RotationMode);
+
+impl FromStr for RotationModeCli {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "on" => Ok(Self(RotationMode::OnRotation)),
+            "off" => Ok(Self(RotationMode::OffRotation)),
+            _ => Err("Invalid value for rotation mode. Must be `on` or `off`.".to_string()),
+        }
+    }
+}

--- a/src/zulip/commands.rs
+++ b/src/zulip/commands.rs
@@ -17,6 +17,8 @@ pub enum ChatCommand {
         #[clap(trailing_var_args(true))]
         description: Vec<String>,
     },
+    /// Move a notification
+    Move { from: u32, to: u32 },
     /// Output your membership in Rust teams.
     Whoami,
     /// Perform lookup of GitHub or Zulip username.

--- a/src/zulip/commands.rs
+++ b/src/zulip/commands.rs
@@ -11,6 +11,12 @@ pub enum ChatCommand {
         /// Notification identifier. `*`, `all`, non-zero index or a URL.
         identifier: IdentifierCli,
     },
+    /// Add a notification
+    Add {
+        url: String,
+        #[clap(trailing_var_args(true))]
+        description: Vec<String>,
+    },
     /// Output your membership in Rust teams.
     Whoami,
     /// Perform lookup of GitHub or Zulip username.

--- a/src/zulip/commands.rs
+++ b/src/zulip/commands.rs
@@ -3,6 +3,7 @@ use crate::db::review_prefs::RotationMode;
 use std::num::NonZeroU32;
 use std::str::FromStr;
 
+/// Command sent in a DM with triagebot on Zulip.
 #[derive(clap::Parser, Debug)]
 pub enum ChatCommand {
     /// Acknowledge a notification
@@ -132,4 +133,25 @@ impl FromStr for IdentifierCli {
             },
         }
     }
+}
+
+/// Command sent in a Zulip stream after `@**triagebot**`.
+#[derive(clap::Parser, Debug)]
+pub enum StreamCommand {
+    /// End the current topic.
+    #[clap(alias = "await")]
+    EndTopic,
+    /// End the current meeting.
+    EndMeeting,
+    /// Read a document.
+    Read,
+    /// Ping project goal owners.
+    PingGoals {
+        /// Number of days before an update is considered stale
+        threshold: u64,
+        /// Date of next update
+        next_update: String,
+    },
+    /// Update docs
+    DocsUpdate,
 }

--- a/src/zulip/commands.rs
+++ b/src/zulip/commands.rs
@@ -14,11 +14,17 @@ pub enum ChatCommand {
     /// Add a notification
     Add {
         url: String,
-        #[clap(trailing_var_args(true))]
+        #[clap(trailing_var_arg(true))]
         description: Vec<String>,
     },
     /// Move a notification
     Move { from: u32, to: u32 },
+    /// Add meta notification
+    Meta {
+        index: u32,
+        #[clap(trailing_var_arg(true))]
+        description: Vec<String>,
+    },
     /// Output your membership in Rust teams.
     Whoami,
     /// Perform lookup of GitHub or Zulip username.
@@ -120,7 +126,7 @@ impl FromStr for IdentifierCli {
             "all" | "*" => Ok(Self::All),
             v => match v.parse::<u32>() {
                 Ok(v) => NonZeroU32::new(v)
-                    .ok_or_else(|e| "index must be at least 1".to_string())
+                    .ok_or_else(|| "index must be at least 1".to_string())
                     .map(Self::Index),
                 Err(_) => Ok(Self::Url(v.to_string())),
             },


### PR DESCRIPTION
This removes the annoying manual parsing routines and makes the whole command surface easier to understand and discover. It also automatically generates help.

I didn't actually know what are the meta/notification commands for, so I inferred their behavior from code to generate the doc comments.