### PR TITLE
Store PR title in the workqueue and output it in `work show`

### DIFF
--- a/src/handlers/assign/tests/tests_candidates.rs
+++ b/src/handlers/assign/tests/tests_candidates.rs
@@ -3,7 +3,7 @@
 use super::super::*;
 use crate::db::review_prefs::{upsert_review_prefs, RotationMode};
 use crate::github::{PullRequestNumber, User};
-use crate::handlers::pr_tracking::ReviewerWorkqueue;
+use crate::handlers::pr_tracking::{AssignedPullRequest, ReviewerWorkqueue};
 use crate::tests::github::{issue, user};
 use crate::tests::{run_db_test, TestContext};
 
@@ -13,7 +13,7 @@ struct AssignCtx {
     teams: Teams,
     config: AssignConfig,
     issue: Issue,
-    reviewer_workqueue: HashMap<UserId, HashSet<PullRequestNumber>>,
+    reviewer_workqueue: HashMap<UserId, HashMap<PullRequestNumber, AssignedPullRequest>>,
 }
 
 impl AssignCtx {
@@ -50,7 +50,16 @@ impl AssignCtx {
     }
 
     fn assign_prs(mut self, user_id: UserId, count: u64) -> Self {
-        let prs: HashSet<PullRequestNumber> = (0..count).collect();
+        let prs = (0..count)
+            .map(|pr_number| {
+                (
+                    pr_number,
+                    AssignedPullRequest {
+                        title: format!("PR {pr_number}"),
+                    },
+                )
+            })
+            .collect();
         self.reviewer_workqueue.insert(user_id, prs);
         self
     }

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -289,7 +289,7 @@ async fn workqueue_commands(
                 .await
                 .into_iter()
                 .collect::<Vec<_>>();
-            assigned_prs.sort();
+            assigned_prs.sort_by_key(|(pr_number, _)| *pr_number);
 
             let review_prefs = get_review_prefs(&db_client, gh_id)
                 .await
@@ -309,9 +309,14 @@ async fn workqueue_commands(
 
             let prs = assigned_prs
                 .iter()
-                .map(|pr| format!("- [#{pr}](https://github.com/rust-lang/rust/pull/{pr})"))
+                .map(|(pr_number, pr)| {
+                    format!(
+                        "- [#{pr_number}](https://github.com/rust-lang/rust/pull/{pr_number}) {}",
+                        pr.title
+                    )
+                })
                 .collect::<Vec<String>>()
-                .join(", ");
+                .join("\n");
             let mut response = format!(
                 "`rust-lang/rust` PRs in your review queue ({} {}):\n{prs}\n",
                 assigned_prs.len(),

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -291,12 +291,6 @@ async fn workqueue_commands(
                 .collect::<Vec<_>>();
             assigned_prs.sort();
 
-            let prs = assigned_prs
-                .iter()
-                .map(|pr| format!("#{pr}"))
-                .collect::<Vec<String>>()
-                .join(", ");
-
             let review_prefs = get_review_prefs(&db_client, gh_id)
                 .await
                 .context("cannot get review preferences")?;
@@ -313,8 +307,13 @@ async fn workqueue_commands(
                 RotationMode::OffRotation => "off rotation",
             };
 
+            let prs = assigned_prs
+                .iter()
+                .map(|pr| format!("- [#{pr}](https://github.com/rust-lang/rust/pull/{pr})"))
+                .collect::<Vec<String>>()
+                .join(", ");
             let mut response = format!(
-                "`rust-lang/rust` PRs in your review queue: {prs} ({} {})\n",
+                "`rust-lang/rust` PRs in your review queue ({} {}):\n{prs}\n",
                 assigned_prs.len(),
                 pluralize("PR", assigned_prs.len())
             );


### PR DESCRIPTION
Requested by @BoxyUwU. I think it makes a lot of sense, in order to provide more useful `work show` output and let people see their queue on Zulip only, without going to GitHub.