### PR TITLE
Put review capacity into backticks

### DIFF
--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -318,7 +318,7 @@ async fn workqueue_commands(
                 assigned_prs.len(),
                 pluralize("PR", assigned_prs.len())
             );
-            writeln!(response, "Review capacity: {capacity}\n")?;
+            writeln!(response, "Review capacity: `{capacity}`\n")?;
             writeln!(response, "Rotation mode: *{rotation_mode}*\n")?;
             writeln!(response, "*Note that only certain PRs that are assigned to you are included in your review queue.*")?;
             response


### PR DESCRIPTION
To avoid this: [#t-compiler > Review queue tracking in triagebot @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Review.20queue.20tracking.20in.20triagebot/near/522646142) :facepalm: :laughing: