### PR TITLE
Fix label used to detect 10-days final comment period in major change

### DIFF
--- a/src/handlers/major_change.rs
+++ b/src/handlers/major_change.rs
@@ -200,7 +200,7 @@ pub(super) async fn handle_input(
         ),
         Invocation::ConcernsResolved => (
             if event.issue.labels().contains(&Label {
-                name: config.enabling_label.to_string(),
+                name: config.second_label.to_string(),
             }) {
                 format!("All concerns on the [associated GitHub issue]({}) have been resolved, this proposal is no longer blocked, and will be approved in 10 days if no (new) objections are raised.", event.issue.html_url)
             } else {


### PR DESCRIPTION
I was wrong again in https://github.com/rust-lang/triagebot/pull/2051#discussion_r2127162020, `enabling_label` is the label that enables (duh) the major change, the one we want is the one that is for the 10-days final comment period, which is the `second_label`.