### PR TITLE
Improve formatting of `work show`

### DIFF
--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -366,21 +366,26 @@ async fn workqueue_commands(
                 RotationMode::OffRotation => "off rotation",
             };
 
-            let prs = assigned_prs
-                .iter()
-                .map(|(pr_number, pr)| {
-                    format!(
-                        "- [#{pr_number}](https://github.com/rust-lang/rust/pull/{pr_number}) {}",
-                        pr.title
-                    )
-                })
-                .collect::<Vec<String>>()
-                .join("\n");
-            let mut response = format!(
-                "`rust-lang/rust` PRs in your review queue ({} {}):\n{prs}\n",
-                assigned_prs.len(),
-                pluralize("PR", assigned_prs.len())
-            );
+            let mut response = if assigned_prs.is_empty() {
+                "There are no PRs in your `rust-lang/rust` review queue\n".to_string()
+            } else {
+                let prs = assigned_prs
+                    .iter()
+                    .map(|(pr_number, pr)| {
+                        format!(
+                            "- [#{pr_number}](https://github.com/rust-lang/rust/pull/{pr_number}) {}",
+                            pr.title
+                        )
+                    })
+                    .collect::<Vec<String>>()
+                    .join("\n");
+                format!(
+                    "`rust-lang/rust` PRs in your review queue ({} {}):\n{prs}\n\n",
+                    assigned_prs.len(),
+                    pluralize("PR", assigned_prs.len())
+                )
+            };
+
             writeln!(response, "Review capacity: `{capacity}`\n")?;
             writeln!(response, "Rotation mode: *{rotation_mode}*\n")?;
             writeln!(response, "*Note that only certain PRs that are assigned to you are included in your review queue.*")?;


### PR DESCRIPTION
Seems like we need one more newline to avoid weird formatting with the review capacity:
![image](https://github.com/user-attachments/assets/2e004548-6f56-4512-afa3-3bf5c34b62c3)

While we're at it, improve formatting for zero PRs in the workqueue.