### PR TITLE
Add `team-stats` Zulip command

### DIFF
--- a/src/bin/project_goals.rs
+++ b/src/bin/project_goals.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use triagebot::team_data::TeamApiClient;
 use triagebot::zulip::client::ZulipClient;
 use triagebot::{github::GithubClient, handlers::project_goals};
 
@@ -24,9 +25,11 @@ async fn main() -> anyhow::Result<()> {
     let opt = Opt::parse();
     let gh = GithubClient::new_from_env();
     let zulip = ZulipClient::new_from_env();
+    let team_api = TeamApiClient::new_from_env();
     project_goals::ping_project_goals_owners(
         &gh,
         &zulip,
+        &team_api,
         opt.dry_run,
         opt.days_threshold,
         &opt.next_meeting_date,

--- a/src/github.rs
+++ b/src/github.rs
@@ -267,49 +267,6 @@ impl User {
     }
 }
 
-// Returns the ID of the given user, if the user is in the `all` team.
-pub async fn get_id_for_username(
-    client: &TeamApiClient,
-    login: &str,
-) -> anyhow::Result<Option<u64>> {
-    let permission = client.teams().await?;
-    let map = permission.teams;
-    let login = login.to_lowercase();
-    Ok(map["all"]
-        .members
-        .iter()
-        .find(|g| g.github.to_lowercase() == login)
-        .map(|u| u.github_id))
-}
-
-pub async fn get_team(
-    client: &TeamApiClient,
-    team: &str,
-) -> anyhow::Result<Option<rust_team_data::v1::Team>> {
-    let permission = client.teams().await?;
-    let mut map = permission.teams;
-    Ok(map.swap_remove(team))
-}
-
-/// Fetches a Rust team via its GitHub team name.
-pub async fn get_team_by_github_name(
-    client: &TeamApiClient,
-    org: &str,
-    team: &str,
-) -> anyhow::Result<Option<rust_team_data::v1::Team>> {
-    let teams = client.teams().await?;
-    for rust_team in teams.teams.into_values() {
-        if let Some(github) = &rust_team.github {
-            for gh_team in &github.teams {
-                if gh_team.org == org && gh_team.name == team {
-                    return Ok(Some(rust_team));
-                }
-            }
-        }
-    }
-    Ok(None)
-}
-
 #[derive(PartialEq, Eq, Debug, Clone, serde::Deserialize)]
 pub struct Label {
     pub name: String,

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,3 +1,4 @@
+use crate::team_data::TeamApiClient;
 use anyhow::{anyhow, Context};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -240,9 +241,9 @@ impl User {
             .await
     }
 
-    pub async fn is_team_member<'a>(&'a self, client: &'a GithubClient) -> anyhow::Result<bool> {
+    pub async fn is_team_member<'a>(&'a self, client: &'a TeamApiClient) -> anyhow::Result<bool> {
         log::trace!("Getting team membership for {:?}", self.login);
-        let permission = crate::team_data::teams(client).await?;
+        let permission = client.teams().await?;
         let map = permission.teams;
         let is_triager = map
             .get("wg-triage")
@@ -268,10 +269,10 @@ impl User {
 
 // Returns the ID of the given user, if the user is in the `all` team.
 pub async fn get_id_for_username(
-    client: &GithubClient,
+    client: &TeamApiClient,
     login: &str,
 ) -> anyhow::Result<Option<u64>> {
-    let permission = crate::team_data::teams(client).await?;
+    let permission = client.teams().await?;
     let map = permission.teams;
     let login = login.to_lowercase();
     Ok(map["all"]
@@ -282,21 +283,21 @@ pub async fn get_id_for_username(
 }
 
 pub async fn get_team(
-    client: &GithubClient,
+    client: &TeamApiClient,
     team: &str,
 ) -> anyhow::Result<Option<rust_team_data::v1::Team>> {
-    let permission = crate::team_data::teams(client).await?;
+    let permission = client.teams().await?;
     let mut map = permission.teams;
     Ok(map.swap_remove(team))
 }
 
 /// Fetches a Rust team via its GitHub team name.
 pub async fn get_team_by_github_name(
-    client: &GithubClient,
+    client: &TeamApiClient,
     org: &str,
     team: &str,
 ) -> anyhow::Result<Option<rust_team_data::v1::Team>> {
-    let teams = crate::team_data::teams(client).await?;
+    let teams = client.teams().await?;
     for rust_team in teams.teams.into_values() {
         if let Some(github) = &rust_team.github {
             for gh_team in &github.teams {
@@ -2059,10 +2060,11 @@ impl<'q> IssuesQuery for Query<'q> {
         repo: &'a Repository,
         include_fcp_details: bool,
         include_mcp_details: bool,
-        client: &'a GithubClient,
+        gh_client: &'a GithubClient,
+        team_api_client: &'a TeamApiClient,
     ) -> anyhow::Result<Vec<crate::actions::IssueDecorator>> {
         let issues = repo
-            .get_issues(&client, self)
+            .get_issues(&gh_client, self)
             .await
             .with_context(|| "Unable to get issues.")?;
 
@@ -2075,7 +2077,7 @@ impl<'q> IssuesQuery for Query<'q> {
         };
 
         let zulip_map = if include_fcp_details {
-            Some(crate::team_data::zulip_map(client).await?)
+            Some(team_api_client.zulip_map().await?)
         } else {
             None
         };
@@ -2111,7 +2113,7 @@ impl<'q> IssuesQuery for Query<'q> {
                             ("".to_string(), "".to_string())
                         } else {
                             let comment = issue
-                                .get_comment(&client, fk_initiating_comment.try_into()?)
+                                .get_comment(&gh_client, fk_initiating_comment.try_into()?)
                                 .await
                                 .with_context(|| {
                                     format!(
@@ -2176,7 +2178,7 @@ impl<'q> IssuesQuery for Query<'q> {
             };
 
             let mcp_details = if include_mcp_details {
-                let first100_comments = issue.get_first100_comments(&client).await?;
+                let first100_comments = issue.get_first100_comments(&gh_client).await?;
                 let (zulip_link, concerns) = if !first100_comments.is_empty() {
                     let split = re_zulip_link
                         .split(&first100_comments[0].body)
@@ -2891,7 +2893,8 @@ pub trait IssuesQuery {
         repo: &'a Repository,
         include_fcp_details: bool,
         include_mcp_details: bool,
-        client: &'a GithubClient,
+        gh_client: &'a GithubClient,
+        team_api_client: &'a TeamApiClient,
     ) -> anyhow::Result<Vec<crate::actions::IssueDecorator>>;
 }
 
@@ -2904,6 +2907,7 @@ impl IssuesQuery for LeastRecentlyReviewedPullRequests {
         _include_fcp_details: bool,
         _include_mcp_details: bool,
         client: &'a GithubClient,
+        _team_api_client: &'a TeamApiClient,
     ) -> anyhow::Result<Vec<crate::actions::IssueDecorator>> {
         use cynic::QueryBuilder;
         use github_graphql::queries;
@@ -3122,6 +3126,7 @@ impl IssuesQuery for DesignMeetings {
         _include_fcp_details: bool,
         _include_mcp_details: bool,
         client: &'a GithubClient,
+        _team_api_client: &'a TeamApiClient,
     ) -> anyhow::Result<Vec<crate::actions::IssueDecorator>> {
         use github_graphql::project_items::ProjectV2ItemContent;
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,6 +1,7 @@
 use crate::config::{self, Config, ConfigurationError};
 use crate::github::{Event, GithubClient, IssueCommentAction, IssuesAction, IssuesEvent};
 use crate::handlers::pr_tracking::ReviewerWorkqueue;
+use crate::team_data::TeamApiClient;
 use crate::zulip::client::ZulipClient;
 use octocrab::Octocrab;
 use parser::command::{assign::AssignCommand, Command, Input};
@@ -374,6 +375,7 @@ command_handlers! {
 pub struct Context {
     pub github: GithubClient,
     pub zulip: ZulipClient,
+    pub team_api: TeamApiClient,
     pub db: crate::db::ClientPool,
     pub username: String,
     pub octocrab: Octocrab,

--- a/src/handlers/assign.rs
+++ b/src/handlers/assign.rs
@@ -388,7 +388,7 @@ async fn determine_assignee(
     diff: &[FileDiff],
 ) -> anyhow::Result<(Option<ReviewerSelection>, bool)> {
     let mut db_client = ctx.db.get().await;
-    let teams = crate::team_data::teams(&ctx.github).await?;
+    let teams = &ctx.team_api.teams().await?;
     if let Some(name) = assign_command {
         // User included `r?` in the opening PR body.
         match find_reviewer_from_names(
@@ -564,12 +564,12 @@ pub(super) async fn handle_command(
     event: &Event,
     cmd: AssignCommand,
 ) -> anyhow::Result<()> {
-    let is_team_member = if let Err(_) | Ok(false) = event.user().is_team_member(&ctx.github).await
-    {
-        false
-    } else {
-        true
-    };
+    let is_team_member =
+        if let Err(_) | Ok(false) = event.user().is_team_member(&ctx.team_api).await {
+            false
+        } else {
+            true
+        };
 
     // Don't handle commands in comments from the bot. Some of the comments it
     // posts contain commands to instruct the user, not things that the bot
@@ -599,7 +599,7 @@ pub(super) async fn handle_command(
             return Ok(());
         }
 
-        let teams = crate::team_data::teams(&ctx.github).await?;
+        let teams = ctx.team_api.teams().await?;
 
         let assignee = match cmd {
             AssignCommand::Claim => event.user().login.clone(),

--- a/src/handlers/close.rs
+++ b/src/handlers/close.rs
@@ -12,7 +12,7 @@ pub(super) async fn handle_command(
     let issue = event.issue().unwrap();
     let is_team_member = event
         .user()
-        .is_team_member(&ctx.github)
+        .is_team_member(&ctx.team_api)
         .await
         .unwrap_or(false);
     if !is_team_member {

--- a/src/handlers/major_change.rs
+++ b/src/handlers/major_change.rs
@@ -247,7 +247,7 @@ pub(super) async fn handle_command(
 
     let is_team_member = event
         .user()
-        .is_team_member(&ctx.github)
+        .is_team_member(&ctx.team_api)
         .await
         .ok()
         .unwrap_or(false);

--- a/src/handlers/nominate.rs
+++ b/src/handlers/nominate.rs
@@ -14,12 +14,12 @@ pub(super) async fn handle_command(
     event: &Event,
     cmd: NominateCommand,
 ) -> anyhow::Result<()> {
-    let is_team_member = if let Err(_) | Ok(false) = event.user().is_team_member(&ctx.github).await
-    {
-        false
-    } else {
-        true
-    };
+    let is_team_member =
+        if let Err(_) | Ok(false) = event.user().is_team_member(&ctx.team_api).await {
+            false
+        } else {
+            true
+        };
 
     if !is_team_member {
         let cmnt = ErrorComment::new(

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -69,7 +69,7 @@ pub(super) async fn handle(ctx: &Context, event: &Event) -> anyhow::Result<()> {
     //
     // If the user intended to ping themselves, they can add the GitHub comment
     // via the Zulip interface.
-    match get_id_for_username(&ctx.github, &event.user().login).await {
+    match get_id_for_username(&ctx.team_api, &event.user().login).await {
         Ok(Some(id)) => {
             users_notified.insert(id.try_into().unwrap());
         }
@@ -136,7 +136,7 @@ async fn id_from_user(
         //
         // We may also want to be able to categorize into these buckets
         // *after* the ping occurs and is initially processed.
-        let team = match github::get_team_by_github_name(&ctx.github, org, team).await {
+        let team = match github::get_team_by_github_name(&ctx.team_api, org, team).await {
             Ok(Some(team)) => team,
             Ok(None) => {
                 // If the team is in rust-lang*, then this is probably an error (potentially user
@@ -170,7 +170,7 @@ async fn id_from_user(
             Some(team.name),
         )))
     } else {
-        let id = get_id_for_username(&ctx.github, login)
+        let id = get_id_for_username(&ctx.team_api, login)
             .await
             .with_context(|| format!("failed to get user {} ID", login))?;
         let Some(id) = id else {

--- a/src/handlers/ping.rs
+++ b/src/handlers/ping.rs
@@ -49,7 +49,7 @@ pub(super) async fn handle_command(
             return Ok(());
         }
     };
-    let team = github::get_team(&ctx.team_api, &gh_team).await?;
+    let team = ctx.team_api.get_team(&gh_team).await?;
     let team = match team {
         Some(team) => team,
         None => {

--- a/src/handlers/ping.rs
+++ b/src/handlers/ping.rs
@@ -18,12 +18,12 @@ pub(super) async fn handle_command(
     event: &Event,
     team_name: PingCommand,
 ) -> anyhow::Result<()> {
-    let is_team_member = if let Err(_) | Ok(false) = event.user().is_team_member(&ctx.github).await
-    {
-        false
-    } else {
-        true
-    };
+    let is_team_member =
+        if let Err(_) | Ok(false) = event.user().is_team_member(&ctx.team_api).await {
+            false
+        } else {
+            true
+        };
 
     if !is_team_member {
         let cmnt = ErrorComment::new(
@@ -49,7 +49,7 @@ pub(super) async fn handle_command(
             return Ok(());
         }
     };
-    let team = github::get_team(&ctx.github, &gh_team).await?;
+    let team = github::get_team(&ctx.team_api, &gh_team).await?;
     let team = match team {
         Some(team) => team,
         None => {

--- a/src/handlers/project_goals.rs
+++ b/src/handlers/project_goals.rs
@@ -4,6 +4,7 @@ use crate::github::{
 };
 use crate::github::{Event, Issue};
 use crate::jobs::Job;
+use crate::team_data::TeamApiClient;
 use crate::zulip::api::Recipient;
 use crate::zulip::client::ZulipClient;
 use crate::zulip::to_zulip_id;
@@ -40,16 +41,19 @@ impl Job for ProjectGoalsUpdateJob {
     }
 
     async fn run(&self, ctx: &super::Context, _metadata: &serde_json::Value) -> anyhow::Result<()> {
-        ping_project_goals_owners_automatically(&ctx.github, &ctx.zulip).await
+        ping_project_goals_owners_automatically(&ctx.github, &ctx.zulip, &ctx.team_api).await
     }
 }
 
 /// Returns true if the user with the given github id is allowed to ping all group people
 /// and do other "project group adminstrative" tasks.
-pub async fn check_project_goal_acl(gh: &GithubClient, gh_id: u64) -> anyhow::Result<bool> {
+pub async fn check_project_goal_acl(
+    team_api_client: &TeamApiClient,
+    gh_id: u64,
+) -> anyhow::Result<bool> {
     const GOALS_TEAM: &str = "goals";
 
-    let team = match github::get_team(gh, GOALS_TEAM).await {
+    let team = match github::get_team(team_api_client, GOALS_TEAM).await {
         Ok(Some(team)) => team,
         Ok(None) => {
             log::info!("team ({}) failed to resolve to a known team", GOALS_TEAM);
@@ -75,6 +79,7 @@ pub async fn check_project_goal_acl(gh: &GithubClient, gh_id: u64) -> anyhow::Re
 async fn ping_project_goals_owners_automatically(
     gh: &GithubClient,
     zulip: &ZulipClient,
+    team_api: &TeamApiClient,
 ) -> anyhow::Result<()> {
     // Predicted schedule is to author a blog post on the 3rd week of the month.
     // We start pinging when the month starts until we see an update in this month
@@ -95,7 +100,15 @@ async fn ping_project_goals_owners_automatically(
             .format("on %b-%d")
             .to_string();
 
-    ping_project_goals_owners(gh, zulip, false, days_threshold as i64, &third_monday).await
+    ping_project_goals_owners(
+        gh,
+        zulip,
+        team_api,
+        false,
+        days_threshold as i64,
+        &third_monday,
+    )
+    .await
 }
 
 /// Sends a ping message to all project goal owners if
@@ -106,6 +119,7 @@ async fn ping_project_goals_owners_automatically(
 pub async fn ping_project_goals_owners(
     gh: &GithubClient,
     zulip: &ZulipClient,
+    team_api_client: &TeamApiClient,
     dry_run: bool,
     days_threshold: i64,
     next_update: &str,
@@ -141,7 +155,7 @@ pub async fn ping_project_goals_owners(
         }
 
         let zulip_topic_name = zulip_topic_name(&issue);
-        let Some(zulip_owners) = zulip_owners(gh, &issue).await? else {
+        let Some(zulip_owners) = zulip_owners(team_api_client, &issue).await? else {
             log::debug!("no owners assigned");
             continue;
         };
@@ -198,30 +212,33 @@ fn zulip_topic_name(issue: &Issue) -> String {
     title
 }
 
-async fn zulip_owners(gh: &GithubClient, issue: &Issue) -> anyhow::Result<Option<String>> {
+async fn zulip_owners(
+    team_api_client: &TeamApiClient,
+    issue: &Issue,
+) -> anyhow::Result<Option<String>> {
     use std::fmt::Write;
 
     Ok(match &issue.assignees[..] {
         [] => None,
-        [string0] => Some(owner_string(gh, string0).await?),
+        [string0] => Some(owner_string(team_api_client, string0).await?),
         [string0, string1] => Some(format!(
             "{} and {}",
-            owner_string(gh, string0).await?,
-            owner_string(gh, string1).await?
+            owner_string(team_api_client, string0).await?,
+            owner_string(team_api_client, string1).await?
         )),
         [string0 @ .., string1] => {
             let mut out = String::new();
             for s in string0 {
-                write!(out, "{}, ", owner_string(gh, s).await?).unwrap();
+                write!(out, "{}, ", owner_string(team_api_client, s).await?).unwrap();
             }
-            write!(out, "{}, ", owner_string(gh, string1).await?).unwrap();
+            write!(out, "{}, ", owner_string(team_api_client, string1).await?).unwrap();
             Some(out)
         }
     })
 }
 
-async fn owner_string(gh: &GithubClient, assignee: &User) -> anyhow::Result<String> {
-    if let Some(zulip_id) = to_zulip_id(gh, assignee.id).await? {
+async fn owner_string(team_api_client: &TeamApiClient, assignee: &User) -> anyhow::Result<String> {
+    if let Some(zulip_id) = to_zulip_id(team_api_client, assignee.id).await? {
         Ok(format!("@**|{zulip_id}**"))
     } else {
         // No zulip-id? Fallback to github user name.
@@ -233,8 +250,6 @@ async fn owner_string(gh: &GithubClient, assignee: &User) -> anyhow::Result<Stri
 }
 
 pub async fn handle(ctx: &Context, event: &Event) -> anyhow::Result<()> {
-    let gh = &ctx.github;
-
     if event.repo().full_name != RUST_PROJECT_GOALS_REPO {
         return Ok(());
     }
@@ -251,7 +266,7 @@ pub async fn handle(ctx: &Context, event: &Event) -> anyhow::Result<()> {
                 return Ok(());
             }
             let zulip_topic_name = zulip_topic_name(issue);
-            let zulip_owners = match zulip_owners(gh, issue).await? {
+            let zulip_owners = match zulip_owners(&ctx.team_api, issue).await? {
                 Some(names) => names,
                 None => format!("(no owners assigned)"),
             };
@@ -292,7 +307,7 @@ pub async fn handle(ctx: &Context, event: &Event) -> anyhow::Result<()> {
             let zulip_topic_name = zulip_topic_name(issue);
             let url = &comment.html_url;
             let text = &comment.body;
-            let zulip_author = owner_string(gh, &comment.user).await?;
+            let zulip_author = owner_string(&ctx.team_api, &comment.user).await?;
 
             let mut ticks = "````".to_string();
             while text.contains(&ticks) {

--- a/src/handlers/project_goals.rs
+++ b/src/handlers/project_goals.rs
@@ -7,7 +7,6 @@ use crate::jobs::Job;
 use crate::team_data::TeamApiClient;
 use crate::zulip::api::Recipient;
 use crate::zulip::client::ZulipClient;
-use crate::zulip::to_zulip_id;
 use anyhow::Context as _;
 use async_trait::async_trait;
 use chrono::{Datelike, NaiveDate, Utc};
@@ -53,7 +52,7 @@ pub async fn check_project_goal_acl(
 ) -> anyhow::Result<bool> {
     const GOALS_TEAM: &str = "goals";
 
-    let team = match github::get_team(team_api_client, GOALS_TEAM).await {
+    let team = match team_api_client.get_team(GOALS_TEAM).await {
         Ok(Some(team)) => team,
         Ok(None) => {
             log::info!("team ({}) failed to resolve to a known team", GOALS_TEAM);
@@ -237,8 +236,8 @@ async fn zulip_owners(
     })
 }
 
-async fn owner_string(team_api_client: &TeamApiClient, assignee: &User) -> anyhow::Result<String> {
-    if let Some(zulip_id) = to_zulip_id(team_api_client, assignee.id).await? {
+async fn owner_string(team_api: &TeamApiClient, assignee: &User) -> anyhow::Result<String> {
+    if let Some(zulip_id) = team_api.github_to_zulip_id(assignee.id).await? {
         Ok(format!("@**|{zulip_id}**"))
     } else {
         // No zulip-id? Fallback to github user name.

--- a/src/handlers/transfer.rs
+++ b/src/handlers/transfer.rs
@@ -19,7 +19,7 @@ pub(super) async fn handle_command(
     }
     if !event
         .user()
-        .is_team_member(&ctx.github)
+        .is_team_member(&ctx.team_api)
         .await
         .ok()
         .unwrap_or(false)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub mod jobs;
 pub mod notification_listing;
 pub mod payload;
 mod rfcbot;
-mod team_data;
+pub mod team_data;
 pub mod triage;
 mod utils;
 pub mod zulip;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use triagebot::handlers::pr_tracking::ReviewerWorkqueue;
 use triagebot::jobs::{
     default_jobs, JOB_PROCESSING_CADENCE_IN_SECS, JOB_SCHEDULING_CADENCE_IN_SECS,
 };
+use triagebot::team_data::TeamApiClient;
 use triagebot::zulip::client::ZulipClient;
 use triagebot::{db, github, handlers::Context, notification_listing, payload, EventName};
 
@@ -250,10 +251,11 @@ async fn serve_req(
 async fn run_server(addr: SocketAddr) -> anyhow::Result<()> {
     let gh = github::GithubClient::new_from_env();
     let zulip = ZulipClient::new_from_env();
+    let team_api = TeamApiClient::new_from_env();
     let oc = octocrab::OctocrabBuilder::new()
         .personal_token(github::default_token_from_env())
         .build()
-        .expect("Failed to build octograb.");
+        .expect("Failed to build octocrab.");
 
     // Load the initial workqueue state from GitHub
     // In case this fails, we do not want to block triagebot, instead
@@ -291,6 +293,7 @@ async fn run_server(addr: SocketAddr) -> anyhow::Result<()> {
         })?,
         db: pool,
         github: gh,
+        team_api,
         octocrab: oc,
         workqueue: Arc::new(RwLock::new(workqueue)),
         zulip,

--- a/src/team_data.rs
+++ b/src/team_data.rs
@@ -1,44 +1,67 @@
-use crate::github::GithubClient;
 use anyhow::Context as _;
+use reqwest::Client;
 use rust_team_data::v1::{People, Teams, ZulipMapping, BASE_URL};
 use serde::de::DeserializeOwned;
 
-async fn by_url<T: DeserializeOwned>(client: &GithubClient, path: &str) -> anyhow::Result<T> {
-    let base = std::env::var("TEAMS_API_URL").unwrap_or(BASE_URL.to_string());
-    let url = format!("{}{}", base, path);
+#[derive(Clone)]
+pub struct TeamApiClient {
+    base_url: String,
+    client: Client,
+}
+
+impl TeamApiClient {
+    pub fn new_from_env() -> Self {
+        let base_url = std::env::var("TEAMS_API_URL").unwrap_or(BASE_URL.to_string());
+        Self::new(base_url)
+    }
+
+    pub fn new(base_url: String) -> Self {
+        Self {
+            base_url,
+            client: Client::new(),
+        }
+    }
+
+    pub async fn zulip_map(&self) -> anyhow::Result<ZulipMapping> {
+        download(&self.client, &self.base_url, "/zulip-map.json")
+            .await
+            .context("team-api: zulip-map.json")
+    }
+
+    pub async fn teams(&self) -> anyhow::Result<Teams> {
+        download(&self.client, &self.base_url, "/teams.json")
+            .await
+            .context("team-api: teams.json")
+    }
+
+    pub async fn people(&self) -> anyhow::Result<People> {
+        download(&self.client, &self.base_url, "/people.json")
+            .await
+            .context("team-api: people.json")
+    }
+}
+
+async fn download<T: DeserializeOwned>(
+    client: &Client,
+    base_url: &str,
+    path: &str,
+) -> anyhow::Result<T> {
+    let url = format!("{base_url}{path}");
     for _ in 0i32..3 {
-        let map: Result<T, _> = client.json(client.raw().get(&url)).await;
-        match map {
-            Ok(v) => return Ok(v),
+        let response = client.get(&url).send().await;
+        match response {
+            Ok(v) => {
+                return Ok(v.json().await?);
+            }
             Err(e) => {
-                if e.downcast_ref::<reqwest::Error>()
-                    .map_or(false, |e| e.is_timeout())
-                {
+                if e.is_timeout() {
                     continue;
                 } else {
-                    return Err(e);
+                    return Err(e.into());
                 }
             }
         }
     }
 
-    Err(anyhow::anyhow!("Failed to retrieve {} in 3 requests", url))
-}
-
-pub async fn zulip_map(client: &GithubClient) -> anyhow::Result<ZulipMapping> {
-    by_url(client, "/zulip-map.json")
-        .await
-        .context("team-api: zulip-map.json")
-}
-
-pub async fn teams(client: &GithubClient) -> anyhow::Result<Teams> {
-    by_url(client, "/teams.json")
-        .await
-        .context("team-api: teams.json")
-}
-
-pub async fn people(client: &GithubClient) -> anyhow::Result<People> {
-    by_url(client, "/people.json")
-        .await
-        .context("team-api: people.json")
+    Err(anyhow::anyhow!("Failed to retrieve {url} in 3 requests"))
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -3,6 +3,7 @@ use crate::db::users::record_username;
 use crate::db::{make_client, ClientPool, PooledClient};
 use crate::github::GithubClient;
 use crate::handlers::Context;
+use crate::team_data::TeamApiClient;
 use crate::zulip::client::ZulipClient;
 use octocrab::Octocrab;
 use std::future::Future;
@@ -72,9 +73,11 @@ impl TestContext {
             "https://rust-fake.zulipchat.com".to_string(),
             "test-bot@zulipchat.com".to_string(),
         );
+        let team_api = TeamApiClient::new_from_env();
         let ctx = Context {
             github,
             zulip,
+            team_api,
             db: pool,
             username: "triagebot-test".to_string(),
             octocrab,

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -5,12 +5,12 @@ mod commands;
 use crate::db::notifications::add_metadata;
 use crate::db::notifications::{self, delete_ping, move_indices, record_ping, Identifier};
 use crate::db::review_prefs::{get_review_prefs, upsert_review_prefs, RotationMode};
-use crate::github::{get_id_for_username, GithubClient, User};
+use crate::github::{get_id_for_username, User};
 use crate::handlers::docs_update::docs_update;
 use crate::handlers::pr_tracking::get_assigned_prs;
 use crate::handlers::project_goals::{self, ping_project_goals_owners};
 use crate::handlers::Context;
-use crate::team_data::{people, teams};
+use crate::team_data::TeamApiClient;
 use crate::utils::pluralize;
 use crate::zulip::api::{MessageApiResponse, Recipient};
 use crate::zulip::client::ZulipClient;
@@ -83,16 +83,16 @@ struct Response {
     content: String,
 }
 
-pub async fn to_github_id(client: &GithubClient, zulip_id: u64) -> anyhow::Result<Option<u64>> {
-    let map = crate::team_data::zulip_map(client).await?;
+pub async fn to_github_id(client: &TeamApiClient, zulip_id: u64) -> anyhow::Result<Option<u64>> {
+    let map = client.zulip_map().await?;
     Ok(map.users.get(&zulip_id).copied())
 }
 
 pub async fn username_from_gh_id(
-    client: &GithubClient,
+    client: &TeamApiClient,
     gh_id: u64,
 ) -> anyhow::Result<Option<String>> {
-    let people_map = crate::team_data::people(client).await?;
+    let people_map = client.people().await?;
     Ok(people_map
         .people
         .into_iter()
@@ -101,8 +101,8 @@ pub async fn username_from_gh_id(
         .next())
 }
 
-pub async fn to_zulip_id(client: &GithubClient, github_id: u64) -> anyhow::Result<Option<u64>> {
-    let map = crate::team_data::zulip_map(client).await?;
+pub async fn to_zulip_id(client: &TeamApiClient, github_id: u64) -> anyhow::Result<Option<u64>> {
+    let map = client.zulip_map().await?;
     Ok(map
         .users
         .iter()
@@ -157,7 +157,7 @@ async fn process_zulip_request(ctx: &Context, req: Request) -> anyhow::Result<Op
     log::trace!("zulip hook: {req:?}");
 
     // Zulip commands are only available to users in the team database
-    let gh_id = match to_github_id(&ctx.github, req.message.sender_id).await {
+    let gh_id = match to_github_id(&ctx.team_api, req.message.sender_id).await {
         Ok(Some(gh_id)) => gh_id,
         Ok(None) => {
             return Err(anyhow::anyhow!(
@@ -282,10 +282,11 @@ async fn handle_command<'a>(
                 threshold,
                 next_update,
             } => {
-                if project_goals::check_project_goal_acl(&ctx.github, gh_id).await? {
+                if project_goals::check_project_goal_acl(&ctx.team_api, gh_id).await? {
                     ping_project_goals_owners(
                         &ctx.github,
                         &ctx.zulip,
+                        &ctx.team_api,
                         false,
                         threshold as i64,
                         &format!("on {next_update}"),
@@ -331,7 +332,7 @@ async fn workqueue_commands(
 ) -> anyhow::Result<Option<String>> {
     let db_client = ctx.db.get().await;
 
-    let gh_username = username_from_gh_id(&ctx.github, gh_id)
+    let gh_username = username_from_gh_id(&ctx.team_api, gh_id)
         .await?
         .ok_or_else(|| anyhow::anyhow!("Cannot find your GitHub username in the team database"))?;
     let user = User {
@@ -439,10 +440,12 @@ async fn workqueue_commands(
 
 /// The `whoami` command displays the user's membership in Rust teams.
 async fn whoami_cmd(ctx: &Context, gh_id: u64) -> anyhow::Result<Option<String>> {
-    let gh_username = username_from_gh_id(&ctx.github, gh_id)
+    let gh_username = username_from_gh_id(&ctx.team_api, gh_id)
         .await?
         .ok_or_else(|| anyhow::anyhow!("Cannot find your GitHub username in the team database"))?;
-    let teams = teams(&ctx.github)
+    let teams = ctx
+        .team_api
+        .teams()
         .await
         .context("cannot load team information")?;
     let mut entries = teams
@@ -528,10 +531,10 @@ async fn lookup_github_username(ctx: &Context, zulip_username: &str) -> anyhow::
         Some(name) => name.to_string(),
         None => {
             let zulip_id = zulip_user.user_id;
-            let Some(gh_id) = to_github_id(&ctx.github, zulip_id).await? else {
+            let Some(gh_id) = to_github_id(&ctx.team_api, zulip_id).await? else {
                 return Ok(format!("Zulip user {zulip_username} was not found in team Zulip mapping. Maybe they do not have zulip-id configured in team."));
             };
-            let Some(username) = username_from_gh_id(&ctx.github, gh_id).await? else {
+            let Some(username) = username_from_gh_id(&ctx.team_api, gh_id).await? else {
                 return Ok(format!(
                     "Zulip user {zulip_username} was not found in the team database."
                 ));
@@ -577,7 +580,7 @@ async fn lookup_zulip_username(ctx: &Context, gh_username: &str) -> anyhow::Resu
         ctx: &Context,
         gh_username: &str,
     ) -> anyhow::Result<Option<u64>> {
-        let people = people(&ctx.github).await?.people;
+        let people = ctx.team_api.people().await?.people;
 
         // Lookup the person in the team DB
         let Some(person) = people.get(gh_username).or_else(|| {
@@ -590,7 +593,7 @@ async fn lookup_zulip_username(ctx: &Context, gh_username: &str) -> anyhow::Resu
             return Ok(None);
         };
 
-        let Some(zulip_id) = to_zulip_id(&ctx.github, person.github_id).await? else {
+        let Some(zulip_id) = to_zulip_id(&ctx.team_api, person.github_id).await? else {
             return Ok(None);
         };
         Ok(Some(zulip_id))

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -5,12 +5,11 @@ mod commands;
 use crate::db::notifications::add_metadata;
 use crate::db::notifications::{self, delete_ping, move_indices, record_ping, Identifier};
 use crate::db::review_prefs::{get_review_prefs, upsert_review_prefs, RotationMode};
-use crate::github::{get_id_for_username, User};
+use crate::github::User;
 use crate::handlers::docs_update::docs_update;
 use crate::handlers::pr_tracking::get_assigned_prs;
 use crate::handlers::project_goals::{self, ping_project_goals_owners};
 use crate::handlers::Context;
-use crate::team_data::TeamApiClient;
 use crate::utils::pluralize;
 use crate::zulip::api::{MessageApiResponse, Recipient};
 use crate::zulip::client::ZulipClient;
@@ -83,33 +82,6 @@ struct Response {
     content: String,
 }
 
-pub async fn to_github_id(client: &TeamApiClient, zulip_id: u64) -> anyhow::Result<Option<u64>> {
-    let map = client.zulip_map().await?;
-    Ok(map.users.get(&zulip_id).copied())
-}
-
-pub async fn username_from_gh_id(
-    client: &TeamApiClient,
-    gh_id: u64,
-) -> anyhow::Result<Option<String>> {
-    let people_map = client.people().await?;
-    Ok(people_map
-        .people
-        .into_iter()
-        .filter(|(_, p)| p.github_id == gh_id)
-        .map(|p| p.0)
-        .next())
-}
-
-pub async fn to_zulip_id(client: &TeamApiClient, github_id: u64) -> anyhow::Result<Option<u64>> {
-    let map = client.zulip_map().await?;
-    Ok(map
-        .users
-        .iter()
-        .find(|&(_, &github)| github == github_id)
-        .map(|v| *v.0))
-}
-
 /// Top-level handler for Zulip webhooks.
 ///
 /// Returns a JSON response.
@@ -157,7 +129,7 @@ async fn process_zulip_request(ctx: &Context, req: Request) -> anyhow::Result<Op
     log::trace!("zulip hook: {req:?}");
 
     // Zulip commands are only available to users in the team database
-    let gh_id = match to_github_id(&ctx.team_api, req.message.sender_id).await {
+    let gh_id = match ctx.team_api.zulip_to_github_id(req.message.sender_id).await {
         Ok(Some(gh_id)) => gh_id,
         Ok(None) => {
             return Err(anyhow::anyhow!(
@@ -187,7 +159,9 @@ async fn handle_command<'a>(
         let mut impersonated = false;
         if let Some(&"as") = words.get(0) {
             if let Some(username) = words.get(1) {
-                let impersonated_gh_id = match get_id_for_username(&ctx.github, username)
+                let impersonated_gh_id = match ctx
+                    .team_api
+                    .get_gh_id_from_username(username)
                     .await
                     .context("getting ID of github user")?
                 {
@@ -228,7 +202,9 @@ async fn handle_command<'a>(
 
         // Let the impersonated person know about the impersonation if the command was sensitive
         if impersonated && is_sensitive_command(&cmd) {
-            let impersonated_zulip_id = to_zulip_id(&ctx.github, gh_id)
+            let impersonated_zulip_id = ctx
+                .team_api
+                .github_to_zulip_id(gh_id)
                 .await?
                 .ok_or_else(|| anyhow::anyhow!("Zulip user for GitHub ID {gh_id} was not found"))?;
             let users = ctx.zulip.get_zulip_users().await?;
@@ -332,7 +308,9 @@ async fn workqueue_commands(
 ) -> anyhow::Result<Option<String>> {
     let db_client = ctx.db.get().await;
 
-    let gh_username = username_from_gh_id(&ctx.team_api, gh_id)
+    let gh_username = ctx
+        .team_api
+        .username_from_gh_id(gh_id)
         .await?
         .ok_or_else(|| anyhow::anyhow!("Cannot find your GitHub username in the team database"))?;
     let user = User {
@@ -440,7 +418,9 @@ async fn workqueue_commands(
 
 /// The `whoami` command displays the user's membership in Rust teams.
 async fn whoami_cmd(ctx: &Context, gh_id: u64) -> anyhow::Result<Option<String>> {
-    let gh_username = username_from_gh_id(&ctx.team_api, gh_id)
+    let gh_username = ctx
+        .team_api
+        .username_from_gh_id(gh_id)
         .await?
         .ok_or_else(|| anyhow::anyhow!("Cannot find your GitHub username in the team database"))?;
     let teams = ctx
@@ -531,10 +511,10 @@ async fn lookup_github_username(ctx: &Context, zulip_username: &str) -> anyhow::
         Some(name) => name.to_string(),
         None => {
             let zulip_id = zulip_user.user_id;
-            let Some(gh_id) = to_github_id(&ctx.team_api, zulip_id).await? else {
+            let Some(gh_id) = ctx.team_api.zulip_to_github_id(zulip_id).await? else {
                 return Ok(format!("Zulip user {zulip_username} was not found in team Zulip mapping. Maybe they do not have zulip-id configured in team."));
             };
-            let Some(username) = username_from_gh_id(&ctx.team_api, gh_id).await? else {
+            let Some(username) = ctx.team_api.username_from_gh_id(gh_id).await? else {
                 return Ok(format!(
                     "Zulip user {zulip_username} was not found in the team database."
                 ));
@@ -593,7 +573,7 @@ async fn lookup_zulip_username(ctx: &Context, gh_username: &str) -> anyhow::Resu
             return Ok(None);
         };
 
-        let Some(zulip_id) = to_zulip_id(&ctx.team_api, person.github_id).await? else {
+        let Some(zulip_id) = ctx.team_api.github_to_zulip_id(person.github_id).await? else {
             return Ok(None);
         };
         Ok(Some(zulip_id))

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -4,7 +4,9 @@ mod commands;
 
 use crate::db::notifications::add_metadata;
 use crate::db::notifications::{self, delete_ping, move_indices, record_ping, Identifier};
-use crate::db::review_prefs::{get_review_prefs, upsert_review_prefs, RotationMode};
+use crate::db::review_prefs::{
+    get_review_prefs, get_review_prefs_batch, upsert_review_prefs, RotationMode,
+};
 use crate::github::User;
 use crate::handlers::docs_update::docs_update;
 use crate::handlers::pr_tracking::get_assigned_prs;
@@ -17,7 +19,8 @@ use crate::zulip::commands::{
     parse_cli, ChatCommand, LookupCmd, StreamCommand, WorkqueueCmd, WorkqueueLimit,
 };
 use anyhow::{format_err, Context as _};
-use rust_team_data::v1::TeamKind;
+use rust_team_data::v1::{TeamKind, TeamMember};
+use std::cmp::Reverse;
 use std::fmt::Write as _;
 use subtle::ConstantTimeEq;
 use tracing as log;
@@ -196,6 +199,7 @@ async fn handle_command<'a>(
             ChatCommand::Whoami => whoami_cmd(&ctx, gh_id).await,
             ChatCommand::Lookup(cmd) => lookup_cmd(&ctx, cmd).await,
             ChatCommand::Work(cmd) => workqueue_commands(ctx, gh_id, cmd).await,
+            ChatCommand::TeamStats { name } => team_status_cmd(ctx, &name).await,
         };
 
         let output = output?;
@@ -281,6 +285,104 @@ async fn handle_command<'a>(
     }
 }
 
+async fn team_status_cmd(ctx: &Context, team_name: &str) -> anyhow::Result<Option<String>> {
+    use std::fmt::Write;
+
+    let Some(team) = ctx.team_api.get_team(team_name).await? else {
+        return Ok(Some(format!("Team {team_name} not found")));
+    };
+
+    let mut members = team.members;
+    members.sort_by(|a, b| a.github.cmp(&b.github));
+
+    let usernames: Vec<&str> = members
+        .iter()
+        .map(|member| member.github.as_str())
+        .collect();
+
+    let db = ctx.db.get().await;
+    let review_prefs = get_review_prefs_batch(&db, &usernames)
+        .await
+        .context("cannot load review preferences")?;
+
+    let workqueue = ctx.workqueue.read().await;
+    let total_assigned: u64 = members
+        .iter()
+        .map(|member| workqueue.assigned_pr_count(member.github_id))
+        .sum();
+
+    let table_header = |title: &str| {
+        format!(
+            r"### {title}
+| Username | Name | Assigned PRs | Review capacity |
+|----------|------|-------------:|----------------:|"
+        )
+    };
+
+    let format_member_row = |member: &TeamMember| {
+        let review_prefs = review_prefs.get(member.github.as_str());
+        let max_capacity = review_prefs
+            .as_ref()
+            .and_then(|prefs| prefs.max_assigned_prs);
+        let assigned_prs = workqueue.assigned_pr_count(member.github_id);
+
+        let max_capacity = max_capacity
+            .map(|c| c.to_string())
+            .unwrap_or_else(|| "unlimited".to_string());
+        format!(
+            "| `{}` | {} | `{assigned_prs}` | `{max_capacity}` |",
+            member.github, member.name
+        )
+    };
+
+    let (mut on_rotation, mut off_rotation): (Vec<&TeamMember>, Vec<&TeamMember>) =
+        members.iter().partition(|member| {
+            let rotation_mode = review_prefs
+                .get(member.github.as_str())
+                .map(|prefs| prefs.rotation_mode)
+                .unwrap_or_default();
+            matches!(rotation_mode, RotationMode::OnRotation)
+        });
+    on_rotation.sort_by_key(|member| Reverse(workqueue.assigned_pr_count(member.github_id)));
+    off_rotation.sort_by_key(|member| Reverse(workqueue.assigned_pr_count(member.github_id)));
+
+    let on_rotation = on_rotation
+        .into_iter()
+        .map(format_member_row)
+        .collect::<Vec<_>>();
+    let off_rotation = off_rotation
+        .into_iter()
+        .map(format_member_row)
+        .collect::<Vec<_>>();
+
+    // e.g. 2 members, 5 PRs assigned
+    let mut msg = format!(
+        "{} {}, {} {} assigned\n\n",
+        members.len(),
+        pluralize("member", members.len()),
+        total_assigned,
+        pluralize("PR", total_assigned as usize)
+    );
+    if !on_rotation.is_empty() {
+        writeln!(
+            msg,
+            "{}",
+            table_header(&format!("ON rotation ({})", on_rotation.len()))
+        )?;
+        writeln!(msg, "{}\n", on_rotation.join("\n"))?;
+    }
+    if !off_rotation.is_empty() {
+        writeln!(
+            msg,
+            "{}",
+            table_header(&format!("OFF rotation ({})", on_rotation.len()))
+        )?;
+        writeln!(msg, "{}\n", off_rotation.join("\n"))?;
+    }
+
+    Ok(Some(msg))
+}
+
 /// Returns true if we should notify user who was impersonated by someone who executed this command.
 /// More or less, the following holds: `sensitive` == `not read-only`.
 fn is_sensitive_command(cmd: &ChatCommand) -> bool {
@@ -289,8 +391,7 @@ fn is_sensitive_command(cmd: &ChatCommand) -> bool {
         | ChatCommand::Add { .. }
         | ChatCommand::Move { .. }
         | ChatCommand::Meta { .. } => true,
-        ChatCommand::Whoami => false,
-        ChatCommand::Lookup(_) => false,
+        ChatCommand::Whoami | ChatCommand::Lookup(_) | ChatCommand::TeamStats { .. } => false,
         ChatCommand::Work(cmd) => match cmd {
             WorkqueueCmd::Show => false,
             WorkqueueCmd::SetPrLimit { .. } => true,

--- a/src/zulip/commands.rs
+++ b/src/zulip/commands.rs
@@ -36,6 +36,12 @@ pub enum ChatCommand {
     /// Inspect or modify your reviewer workqueue.
     #[clap(subcommand)]
     Work(WorkqueueCmd),
+    /// Print the review statistics of the given Rust team.
+    /// Shows the reviewer queue contents of the team members.
+    TeamStats {
+        /// Name of the team to query.
+        name: String,
+    },
 }
 
 #[derive(clap::Parser, Debug, PartialEq)]


### PR DESCRIPTION
Discussed here: [#t-compiler > Review queue tracking in triagebot @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Review.20queue.20tracking.20in.20triagebot/near/522624418).

Based on: https://github.com/rust-lang/triagebot/pull/2055

Example output (only the assigned PR count is real, review preferences and rotation ON/OFF are mocked):
58 members, 140 PRs assigned

### ON rotation (58)
| Username | Name | Assigned PRs | Review capacity |
|----------|------|-------------:|----------------:|
| `compiler-errors` | Michael Goulet | `16` | `unlimited` |
| `lcnr` | lcnr | `11` | `unlimited` |
| `wesleywiser` | Wesley Wiser | `11` | `unlimited` |
| `m-ou-se` | Mara Bos | `9` | `unlimited` |
| `workingjubilee` | Jubilee | `9` | `unlimited` |
| `BoxyUwU` | Boxy | `7` | `unlimited` |
| `oli-obk` | Oliver Scherer | `7` | `unlimited` |
| `tgross35` | Trevor Gross | `7` | `unlimited` |
| `fmease` | León Orell Valerian Liehr | `6` | `unlimited` |
| `scottmcm` | Scott McMurray | `6` | `unlimited` |
| `the8472` | The 8472 | `6` | `unlimited` |
| `Kobzol` | Jakub Beránek | `5` | `unlimited` |
| `Mark-Simulacrum` | Mark Rousskov | `5` | `unlimited` |
| `camelid` | Noah Lev | `3` | `unlimited` |
| `davidtwco` | David Wood | `3` | `unlimited` |
| `fee1-dead` | Deadbeef | `3` | `unlimited` |
| `jieyouxu` | Jieyou Xu | `3` | `unlimited` |
| `Noratrieb` | nora | `2` | `unlimited` |
| `RalfJung` | Ralf Jung | `2` | `unlimited` |
| `Urgau` | Urgau | `2` | `unlimited` |
| `bjorn3` | bjorn3 | `2` | `unlimited` |
| `eholk` | Eric Holk | `2` | `unlimited` |
| `saethlin` | Ben Kimock | `2` | `unlimited` |
| `ChrisDenton` | Chris Denton | `1` | `unlimited` |
| `Nadrieril` | Nadrieril | `1` | `unlimited` |
| `Zalathar` | Stuart Cook | `1` | `unlimited` |
| `chenyukang` | Yukang | `1` | `unlimited` |
| `cuviper` | Josh Stone | `1` | `unlimited` |
| `est31` | est31 | `1` | `unlimited` |
| `jdonszelmann` | Jana Dönszelmann | `1` | `unlimited` |
| `madsmtm` | Mads Marquart | `1` | `unlimited` |
| `nikic` | Nikita Popov | `1` | `unlimited` |
| `nnethercote` | Nicholas Nethercote | `1` | `unlimited` |
| `petrochenkov` | Vadim Petrochenkov | `1` | `unlimited` |
| `SparrowLii` | Sparrow Li | `0` | `unlimited` |
| `TaKO8Ki` | Takayuki Maeda | `0` | `unlimited` |
| `WaffleLapkin` | Waffle Maybe | `0` | `unlimited` |
| `ZuseZ4` | Manuel Drehwald | `0` | `unlimited` |
| `alexcrichton` | Alex Crichton | `0` | `unlimited` |
| `apiraino` | apiraino | `0` | `unlimited` |
| `b-naber` | b-naber | `0` | `unlimited` |
| `cjgillot` | Camille Gillot | `0` | `unlimited` |
| `dianqk` | dianqk | `0` | `unlimited` |
| `durin42` | Augie Fackler | `0` | `unlimited` |
| `estebank` | Esteban Kuber | `0` | `unlimited` |
| `flodiebold` | Florian Diebold | `0` | `unlimited` |
| `jackh726` | Jack Huey | `0` | `unlimited` |
| `jswrenn` | Jack Wrenn | `0` | `unlimited` |
| `lqd` | Rémy Rakic | `0` | `unlimited` |
| `lukas-code` | Lukas Markeffsky | `0` | `unlimited` |
| `mati865` | Mateusz Mikuła | `0` | `unlimited` |
| `matthewjasper` | Matthew Jasper | `0` | `unlimited` |
| `nagisa` | Simonas Kazlauskas | `0` | `unlimited` |
| `nikomatsakis` | Niko Matsakis | `0` | `unlimited` |
| `rcvalle` | Ramon de C Valle | `0` | `unlimited` |
| `spastorino` | Santiago Pastorino | `0` | `unlimited` |
| `tmandry` | Tyler Mandry | `0` | `unlimited` |
| `tmiasko` | tmiasko | `0` | `unlimited` |