### PR TITLE
Prefer GitHub `issues` endpoint as it accept both PR and issues

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -1930,7 +1930,7 @@ impl Repository {
     }
 
     pub async fn get_issue(&self, client: &GithubClient, issue_num: u64) -> anyhow::Result<Issue> {
-        let url = format!("{}/pulls/{issue_num}", self.url(client));
+        let url = format!("{}/issues/{issue_num}", self.url(client));
         client
             .json(client.get(&url))
             .await


### PR DESCRIPTION
Using the `pulls` API with an issue doesn't work, but using the `issues` endpoint with PR or issue works, so let's switch to that.

Example:
 - PR #2055: https://api.github.com/repos/rust-lang/triagebot/issues/2055
 - Issue #2069: https://api.github.com/repos/rust-lang/triagebot/issues/2069

https://github.com/rust-lang/triagebot/issues/2069#issuecomment-2955503524