### PR TITLE
Fix off rotation count in team-stats

### DIFF
--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -382,7 +382,7 @@ async fn team_status_cmd(ctx: &Context, team_name: &str) -> anyhow::Result<Optio
         writeln!(
             msg,
             "{}",
-            table_header(&format!("OFF rotation ({})", on_rotation.len()))
+            table_header(&format!("OFF rotation ({})", off_rotation.len()))
         )?;
         writeln!(msg, "{}\n", off_rotation.join("\n"))?;
     }


### PR DESCRIPTION
Fixes the wrong count being used in the header of "OFF rotation".

<img src="https://github.com/user-attachments/assets/fcd4ead8-6831-4021-bbdf-df34cca9abbe" width="500">
