### PR TITLE
Return JSON content type in Zulip webhook responses

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -155,6 +155,7 @@ async fn serve_req(
 
         return Ok(Response::builder()
             .status(StatusCode::OK)
+            .header("Content-Type", "application/json")
             .body(Body::from(triagebot::zulip::respond(&ctx, req).await))
             .unwrap());
     }


### PR DESCRIPTION
I suspect that this might have caused the [encoding problems](https://github.com/rust-lang/triagebot/issues/2078). If not, then I'm out of ideas, on the Rust side everything is UTF-8, I checked the contents of the team API and the strings are correct there.