### PR TITLE
Use `ErrorComment` for emitting the validation config error

### DIFF
--- a/src/handlers/check_commits.rs
+++ b/src/handlers/check_commits.rs
@@ -4,6 +4,7 @@ use anyhow::Context as _;
 use anyhow::bail;
 
 use super::Context;
+use crate::interactions::ErrorComment;
 use crate::{
     config::Config,
     db::issue_data::IssueData,
@@ -157,7 +158,8 @@ async fn handle_new_state(
         }
 
         for error_to_add in errors_to_add {
-            let comment = event.issue.post_comment(&ctx.github, &error_to_add).await?;
+            let error_comment = ErrorComment::new(&event.issue, &error_to_add);
+            let comment = error_comment.post(&ctx.github).await?;
             state.data.last_errors.push((error_to_add, comment.node_id));
         }
     }

--- a/src/interactions.rs
+++ b/src/interactions.rs
@@ -4,7 +4,7 @@ use tokio_postgres::Client as DbClient;
 
 use crate::{
     db::issue_data::IssueData,
-    github::{GithubClient, Issue},
+    github::{Comment, GithubClient, Issue},
 };
 use std::fmt::Write;
 
@@ -24,7 +24,7 @@ impl<'a> ErrorComment<'a> {
         }
     }
 
-    pub async fn post(&self, client: &GithubClient) -> anyhow::Result<()> {
+    pub async fn post(&self, client: &GithubClient) -> anyhow::Result<Comment> {
         let mut body = String::new();
         writeln!(body, "**Error**: {}", self.message)?;
         writeln!(body)?;
@@ -33,8 +33,7 @@ impl<'a> ErrorComment<'a> {
             "Please file an issue on GitHub at [triagebot](https://github.com/rust-lang/triagebot) if there's \
             a problem with this bot, or reach out on [#t-infra](https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra) on Zulip."
         )?;
-        self.issue.post_comment(client, &body).await?;
-        Ok(())
+        self.issue.post_comment(client, &body).await
     }
 }
 


### PR DESCRIPTION
So it looks like [this](https://github.com/rust-lang/triagebot/pull/1942#issuecomment-2812130163), instead of [this](https://github.com/rust-lang/triagebot/pull/2085#issuecomment-2981899722).

Kind-of related, looking at both our check-commits warnings and this error, I'm wondering if we should use GitHub UI warning and error block.