### PR TITLE
Also support `concern resolve` to resolve concerns

### DIFF
--- a/parser/src/command.rs
+++ b/parser/src/command.rs
@@ -375,6 +375,18 @@ fn concern() {
 }
 
 #[test]
+fn concern_resolve() {
+    let input = "@bot concern resolve this is my concern";
+    let mut input = Input::new(input, vec!["bot"]);
+    assert_eq!(
+        input.next(),
+        Some(Command::Concern(Ok(concern::ConcernCommand::Resolve {
+            title: "this is my concern".to_string()
+        })))
+    );
+}
+
+#[test]
 fn resolve() {
     let input = "@bot resolve this is my concern";
     let mut input = Input::new(input, vec!["bot"]);

--- a/parser/src/command/concern.rs
+++ b/parser/src/command/concern.rs
@@ -25,8 +25,15 @@ impl fmt::Display for ParseError {
 impl ConcernCommand {
     pub fn parse<'a>(input: &mut Tokenizer<'a>) -> Result<Option<Self>, Error<'a>> {
         let mut toks = input.clone();
-        if let Some(Token::Word(action @ ("concern" | "resolve"))) = toks.peek_token()? {
+        if let Some(Token::Word(mut action @ ("concern" | "resolve"))) = toks.peek_token()? {
             toks.next_token()?;
+
+            if action == "concern" {
+                if let Some(Token::Word(sub_action @ "resolve")) = toks.peek_token()? {
+                    toks.next_token()?;
+                    action = sub_action;
+                }
+            }
 
             let title = toks.take_line()?.trim().to_string();
 


### PR DESCRIPTION
This PR adds an alias to `@bot resolve` in the form of `@bot concern resolve`, this adds a parallel with `@bot note remove`.

This came up here https://github.com/rust-lang/rust/pull/142824#issuecomment-3016579109.

cc @jieyouxu 