### PR TITLE
Automatically scroll to the latest error in our GHA logs viewer

### DIFF
--- a/src/gha_logs.rs
+++ b/src/gha_logs.rs
@@ -129,7 +129,7 @@ async fn process_logs(
     let nonce = Uuid::new_v4().to_hyphenated().to_string();
 
     let html = format!(
-        r##"<!DOCTYPE html>
+        r###"<!DOCTYPE html>
 <html>
 <head>
     <title>{log_uuid} - triagebot</title>
@@ -171,13 +171,28 @@ async fn process_logs(
             `<a id="${{ts}}" href="#${{ts}}" class="timestamp">${{ts}}</a>`
         );
 
+        // 4. Add a anchor around every "##[error]" string
+        let errorCounter = -1;
+        html = html.replace(/##\[error\]/g, () =>
+            `<a id="error-${{++errorCounter}}">##[error]</a>`
+        );
+
+        // 5. Add the html to the DOM
         var cdiv = document.getElementById("console");
         cdiv.innerHTML = html;
+        
+        // 6. If no anchor is given, scroll to the last error
+        if (location.hash === "" && errorCounter >= 0) {{
+            document.getElementById(`error-${{errorCounter}}`).scrollIntoView({{
+                behavior: 'smooth',
+                block: 'center'
+            }});
+        }}
     </script>
 </head>
 <body id="console">
 </body>
-</html>"##,
+</html>"###,
     );
 
     tracing::info!("gha_logs: serving logs for {log_uuid}");


### PR DESCRIPTION
This pull request adds some very basic logic for scrolling to the last error in our GHA logs viewer.

This is achieved by finding all the special GitHub `##[error]` annotation and automatically smoothly scrolling to it if no was requested. The goal is to find the `##[error]Process completed with exit code 1.` when it fails[^1].

We could also just scroll to the end as GitHub does, but it seems nicer to scroll to the latest error.

Requested at [#t-compiler > Enhanced plain logs with rla @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Enhanced.20plain.20logs.20with.20rla/near/527260617)

[^1]: http://localhost:8000/gha-logs/rust-lang/rust/43666277064#2025-06-07T14:42:45.4628085Z