### PR TITLE
Improve automatic GHA logs scrolling for desktop and mobile

### DIFF
--- a/src/gha_logs.rs
+++ b/src/gha_logs.rs
@@ -150,6 +150,9 @@ async fn process_logs(
         .timestamp:hover {{
             text-decoration: underline;
         }}
+        .error-marker {{
+            scroll-margin-bottom: 15vh;
+        }}
     </style>
     <script type="module" nonce="{nonce}">
         import {{ AnsiUp }} from '{ANSI_UP_URL}'
@@ -174,7 +177,7 @@ async fn process_logs(
         // 4. Add a anchor around every "##[error]" string
         let errorCounter = -1;
         html = html.replace(/##\[error\]/g, () =>
-            `<a id="error-${{++errorCounter}}">##[error]</a>`
+            `<a id="error-${{++errorCounter}}" class="error-marker">##[error]</a>`
         );
 
         // 5. Add the html to the DOM
@@ -183,9 +186,11 @@ async fn process_logs(
         
         // 6. If no anchor is given, scroll to the last error
         if (location.hash === "" && errorCounter >= 0) {{
+            const hasSmallViewport = window.innerWidth <= 750;
             document.getElementById(`error-${{errorCounter}}`).scrollIntoView({{
-                behavior: 'smooth',
-                block: 'center'
+                behavior: 'instant',
+                block: 'end',
+                inline: hasSmallViewport ? 'start' : 'center'
             }});
         }}
     </script>


### PR DESCRIPTION
This PR improves the automatic GHA logs scrolling for desktop and mobile by:
 1. putting the error marker at the bottom of the viewport -15vh
     - (instead of being at the center and potentially missing part of the error)
 2. by masking by default the timestamps on mobile/small viewport

This should improve the scrolling by making it more likely to be at the right place from the start without having the user needing to adjust it.

| Mobile | Desktop - 1 | Desktop - 2 |
|--------|-------|---|
| ![image](https://github.com/user-attachments/assets/0aee1a08-3f4b-4df4-bae4-273bc24a0ce3) | ![Screenshot 2025-07-06 at 00-24-38 rust-lang_rust$43666277064 - triagebot](https://github.com/user-attachments/assets/68b94a4b-9a77-45ec-b7e0-38b058cb4ea4) | ![Screenshot 2025-07-06 at 00-24-53 rust-lang_compiler-builtins$45387265068 - triagebot](https://github.com/user-attachments/assets/e316c0ed-56b7-4459-b563-2935d3c5dbfd) |
