### PR TITLE
Avoid registering duplicate concern name across different comments

### DIFF
--- a/src/handlers/concern.rs
+++ b/src/handlers/concern.rs
@@ -91,11 +91,7 @@ pub(super) async fn handle_command(
     match cmd {
         ConcernCommand::Concern { title } => {
             // Only add a concern if it wasn't already added, we could be in an edit
-            if !concern_data
-                .concerns
-                .iter()
-                .any(|c| c.title == title && c.comment_url == comment_url)
-            {
+            if !concern_data.concerns.iter().any(|c| c.title == title) {
                 concern_data.concerns.push(Concern {
                     title,
                     status: ConcernStatus::Active,


### PR DESCRIPTION
Fixes https://github.com/rust-lang/triagebot/issues/2101