### PR TITLE
Add `new_draft` kind of labels in `[autolabel]`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -282,6 +282,8 @@ pub(crate) struct AutolabelLabelConfig {
     pub(crate) new_pr: bool,
     #[serde(default)]
     pub(crate) new_issue: bool,
+    #[serde(default)]
+    pub(crate) new_draft: bool,
 }
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]


### PR DESCRIPTION
This PR adds a new kind `new_draft` for labels in `[autolabel]`, this is so that we can handle `S-waiting-on-author` in a similar way to `S-waiting-on-review` (ie add it when the PR is in draft state and remove it when it's not).

```toml
[autolabel."S-waiting-on-author"]
new_draft = true
```

Fixes https://github.com/rust-lang/triagebot/issues/2102