### PR TITLE
Execute `ping-goals` command in the background to avoid timeout and infinite retries

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -168,7 +168,7 @@ async fn serve_req(
         return Ok(Response::builder()
             .status(StatusCode::OK)
             .header("Content-Type", "application/json")
-            .body(Body::from(triagebot::zulip::respond(&ctx, req).await))
+            .body(Body::from(triagebot::zulip::respond(ctx, req).await))
             .unwrap());
     }
     if req.uri.path() != "/github-hook" {

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,6 +151,7 @@ async fn serve_req(
             payload.extend_from_slice(&chunk);
         }
 
+        log::info!("/zulip-hook request body: {:?}", str::from_utf8(&payload));
         let req = match serde_json::from_slice(&payload) {
             Ok(r) => r,
             Err(e) => {

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -188,6 +188,8 @@ async fn handle_command<'a>(
         }
 
         let cmd = parse_cli::<ChatCommand, _>(words.into_iter())?;
+        tracing::info!("command parsed to {cmd:?} (impersonated: {impersonated})");
+
         let output = match &cmd {
             ChatCommand::Acknowledge { identifier } => {
                 acknowledge(&ctx, gh_id, identifier.into()).await
@@ -249,7 +251,10 @@ async fn handle_command<'a>(
         if cmd_index >= words.len() {
             return Ok(Some("Unknown command".to_string()));
         }
+
         let cmd = parse_cli::<StreamCommand, _>(words[cmd_index..].into_iter().copied())?;
+        tracing::info!("command parsed to {cmd:?}");
+
         match cmd {
             StreamCommand::EndTopic => post_waiter(&ctx, message_data, WaitingMessage::end_topic())
                 .await

--- a/src/zulip/commands.rs
+++ b/src/zulip/commands.rs
@@ -165,7 +165,7 @@ pub enum StreamCommand {
     DocsUpdate,
 }
 
-#[derive(clap::Parser, Debug, PartialEq)]
+#[derive(clap::Parser, Debug, PartialEq, Clone)]
 pub struct PingGoalsArgs {
     /// Number of days before an update is considered stale
     pub threshold: u64,


### PR DESCRIPTION
This PR updates the handling of the `ping-goals` command to be executed in the background to avoid timeout and infinite retries from Zulip side, which resulted in multiple pings being sent to people.

cc @tomassedovic
Fixes https://github.com/rust-lang/triagebot/issues/2108
