### PR TITLE
Fix check-commits trigger to not require base change

### DIFF
--- a/src/handlers/check_commits.rs
+++ b/src/handlers/check_commits.rs
@@ -44,15 +44,15 @@ pub(super) async fn handle(ctx: &Context, event: &Event, config: &Config) -> any
         return Ok(());
     };
 
-    if !matches!(
+    let should_check = matches!(
         event.action,
         IssuesAction::Opened
             | IssuesAction::Reopened
             | IssuesAction::Synchronize
             | IssuesAction::ReadyForReview
-    ) || !event.has_base_changed()
-        || !event.issue.is_pr()
-    {
+    ) || event.has_base_changed();
+
+    if !should_check || !event.issue.is_pr() {
         return Ok(());
     }
 


### PR DESCRIPTION
We should not required a PR base change, we should only allow it to check the commits.

Found when looking at why https://github.com/rust-lang/rust/pull/143794 didn't get the beta branch warning.