### PR TITLE
Extract check-commits handler trigger logic and add tests for it

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -287,6 +287,7 @@ pub struct Label {
 /// and some don't. GitHub does include a few fields here, but they aren't
 /// needed at this time (merged_at, diff_url, html_url, patch_url, url).
 #[derive(Debug, serde::Deserialize)]
+#[cfg_attr(test, derive(Default))]
 pub struct PullRequestDetails {
     /// This is a slot to hold the diff for a PR.
     ///


### PR DESCRIPTION
This PR extracts the check-commits super-handler trigger logic and add tests for it, so we can make sure it doesn't regress accidentally.

Related to https://github.com/rust-lang/triagebot/pull/2110