### PR TITLE
Add quick start instructions and allow to skip DB migrations

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,13 @@
+# You can get this value from https://github.com/settings/tokens.
 # if `GITHUB_TOKEN` is not set here, the token can also be stored in `~/.gitconfig`
 GITHUB_TOKEN=MUST_BE_CONFIGURED
 DATABASE_URL=MUST_BE_CONFIGURED
+# If this variable is uncommented set to 1, the DB migrations will be skipped.
+# SKIP_DB_MIGRATIONS=0
+# If this variable is uncommented and set to 1, it will skip the workqueue
+# load (which takes ~10-15 seconds).
+# SKIP_WORKQUEUE=0
+
 GITHUB_WEBHOOK_SECRET=MUST_BE_CONFIGURED
 # for logging, refer to this document: https://rust-lang-nursery.github.io/rust-cookbook/development_tools/debugging/config_log.html
 # `RUSTC_LOG` is not required to run the application, but it makes local development easier

--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ To compile the Triagebot you need OpenSSL development library to be installed (e
 
 Run `cargo build` to compile the triagebot.
 
+## Quick start
+
+For local development/debugging for the log pages, do the following steps:
+
+ 1. Run `cp .env.sample .env`
+ 2. Change value of `SKIP_DB_MIGRATIONS` to `1`.
+ 3. Run `cargo run --bin triagebot`
+ 4. Go to this URL: <http://localhost:8000/gha-logs/rust-lang/rust/46814678314>
+
 ## Running triagebot
 
 It is possible to run triagebot yourself, and test changes against your own repository.

--- a/src/main.rs
+++ b/src/main.rs
@@ -316,9 +316,11 @@ async fn run_server(addr: SocketAddr) -> anyhow::Result<()> {
     // and the old instance potentially runs on an newer database schema.
     let db_url = std::env::var("DATABASE_URL").expect("needs DATABASE_URL");
     let pool = db::ClientPool::new(db_url.clone());
-    db::run_migrations(&mut *pool.get().await)
-        .await
-        .context("database migrations")?;
+    if !std::env::var("SKIP_DB_MIGRATIONS").is_ok_and(|value| value == "1") {
+        db::run_migrations(&mut *pool.get().await)
+            .await
+            .context("database migrations")?;
+    }
 
     let ctx = Arc::new(Context {
         username: std::env::var("TRIAGEBOT_USERNAME").or_else(|err| match err {


### PR DESCRIPTION
Luckily for me, I had @Urgau to help me getting started to work on this. However, this should not be a requirement so here are instructions to make it much simpler.

Also, added an environment variable check to allow skipping DB migrations (and thus removing the need to comment some code when you don't need to use the DB).

All in all, the dev experience is still subpar but that makes it more bearable. Some more improvements would be to provide fake data so we don't need to have a github token.

r? @Kobzol 