### PR TITLE
Also verify that the end boundary isn't path-like

### DIFF
--- a/src/gha_logs.rs
+++ b/src/gha_logs.rs
@@ -335,14 +335,16 @@ body {{
         //
         //  Any other paths, in particular if prefixed by `./` or `obj/` should not taken.
         const pathRegex = new RegExp(
-            "(?<boundary>[^a-zA-Z0-9.\\/])(?<inner>(?:[\\\/]?(?:checkout[\\\/])?(?<path>(?:"
-            + tree_roots.map(p => RegExp.escape(p)).join("|") +
-            ")(?:[\\\/][a-zA-Z0-9_$\\\-.\\\/]+)?))(?::(?<line>[0-9]+):(?<col>[0-9]+))?)",
+            "(?<boundary_start>[^a-zA-Z0-9.\\/])"
+            + "(?<inner>(?:[\\\/]?(?:checkout[\\\/])?(?<path>(?:"
+                + tree_roots.map(p => RegExp.escape(p)).join("|")
+                + ")(?:[\\\/][a-zA-Z0-9_$\\\-.\\\/]+)?))"
+            + "(?::(?<line>[0-9]+):(?<col>[0-9]+))?)(?<boundary_end>[^a-zA-Z0-9.])",
             "g"
         );
-        html = html.replace(pathRegex, (match, boundary, inner, path, line, col) => {{
+        html = html.replace(pathRegex, (match, boundary_start, inner, path, line, col, boundary_end) => {{
             const pos = (line !== undefined) ? `#L${{line}}` : "";
-            return `${{boundary}}<a href="https://github.com/{owner}/{repo}/blob/{sha}/${{path}}${{pos}}" class="path-marker">${{inner}}</a>`;
+            return `${{boundary_start}}<a href="https://github.com/{owner}/{repo}/blob/{sha}/${{path}}${{pos}}" class="path-marker">${{inner}}</a>${{boundary_end}}`;
         }});
 
         // 6. Add the html to the DOM


### PR DESCRIPTION
The sorting of paths introduced in https://github.com/rust-lang/triagebot/pull/2124 for the tree roots isn't enough as `library/std` can still to be recognized for `library/stdarch`.

This is the case when `library/stdarch` is not included in the tree roots, which is the case in the lastest versions of https://github.com/rust-lang/triagebot/pull/2124 since we exclude submodules.

To fix this, we add an end boundary to the regex that checks that we don't match if there are path-like elements after the path we found.

Can be tested here https://regex101.com/r/cKwJql/1

I also the opportunity to split-up the regex in logical pieces to better see what each part does.