### PR TITLE
Add `exclude-titles` option to no-mentions 

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -515,7 +515,12 @@ pub(crate) struct IssueLinksConfig {
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
-pub(crate) struct NoMentionsConfig {}
+pub(crate) struct NoMentionsConfig {
+    /// The check will not be performed on titles that include any of these substrings (case
+    /// insensitive)
+    #[serde(default)]
+    pub(crate) exclude_titles: Vec<String>,
+}
 
 /// Configuration for PR behind commits checks
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]
@@ -681,6 +686,7 @@ mod tests {
             trigger-files = ["posts/"]
 
             [no-mentions]
+            exclude-titles = ["subtree update"]
 
             [behind-upstream]
             days-threshold = 14
@@ -769,7 +775,9 @@ mod tests {
                 issue_links: Some(IssueLinksConfig {
                     check_commits: true,
                 }),
-                no_mentions: Some(NoMentionsConfig {}),
+                no_mentions: Some(NoMentionsConfig {
+                    exclude_titles: vec!["subtree update".into()],
+                }),
                 behind_upstream: Some(BehindUpstreamConfig {
                     days_threshold: Some(14),
                 }),

--- a/src/handlers/check_commits.rs
+++ b/src/handlers/check_commits.rs
@@ -106,7 +106,11 @@ pub(super) async fn handle(ctx: &Context, event: &Event, config: &Config) -> any
     }
 
     if let Some(no_mentions) = &config.no_mentions {
-        warnings.extend(no_mentions::mentions_in_commits(no_mentions, &commits));
+        warnings.extend(no_mentions::mentions_in_commits(
+            &event.issue.title,
+            no_mentions,
+            &commits,
+        ));
     }
 
     if let Some(issue_links) = &config.issue_links {

--- a/src/handlers/check_commits/no_mentions.rs
+++ b/src/handlers/check_commits/no_mentions.rs
@@ -8,7 +8,11 @@ pub(super) fn mentions_in_commits(
     conf: &NoMentionsConfig,
     commits: &[GithubCommit],
 ) -> Option<String> {
-    if conf.exclude_titles.iter().any(|s| pr_title.contains(s)) {
+    if conf
+        .exclude_titles
+        .iter()
+        .any(|s| pr_title.to_lowercase().contains(&s.to_lowercase()))
+    {
         return None;
     }
 
@@ -73,7 +77,7 @@ Co-authored-by: Baz Qux <bazqux@example.com>",
     );
 
     commits.push(dummy_commit_from_body(
-        "6565ffdd8af4ca0ec7c8faceee59c582edcd83b2",
+        "4894129179b361200c9cd733ba0e906bf98747a2",
         "This is a body that mentions @rustbot for a command! And then a user @mention",
     ));
 
@@ -82,7 +86,7 @@ Co-authored-by: Baz Qux <bazqux@example.com>",
         Some(
             r"There are username mentions (such as `@user`) in the commit messages of the following commits.
 *Please remove the mentions to avoid spamming these users.*
-- 6565ffdd8af4ca0ec7c8faceee59c582edcd83b2
+- 4894129179b361200c9cd733ba0e906bf98747a2
 ".to_string()
         )
     );

--- a/src/handlers/check_commits/no_mentions.rs
+++ b/src/handlers/check_commits/no_mentions.rs
@@ -4,12 +4,20 @@
 use crate::{config::NoMentionsConfig, github::GithubCommit};
 
 pub(super) fn mentions_in_commits(
-    _conf: &NoMentionsConfig,
+    pr_title: &str,
+    conf: &NoMentionsConfig,
     commits: &[GithubCommit],
 ) -> Option<String> {
+    if conf.exclude_titles.iter().any(|s| pr_title.contains(s)) {
+        return None;
+    }
+
     let mentions_commits = commits
         .into_iter()
-        .filter(|c| !parser::get_mentions(&c.commit.message).is_empty())
+        .filter(|c| {
+            let mentions = parser::get_mentions(&c.commit.message);
+            !mentions.is_empty() && mentions.iter().any(|m| *m != "rustbot")
+        })
         .map(|c| format!("- {}\n", c.sha))
         .collect::<String>();
 
@@ -33,7 +41,14 @@ fn test_mentions_in_commits() {
         "This is simple without mentions!",
     )];
 
-    assert_eq!(mentions_in_commits(&NoMentionsConfig {}, &commits), None);
+    let default_conf = NoMentionsConfig {
+        exclude_titles: vec![],
+    };
+
+    assert_eq!(
+        mentions_in_commits("any title", &default_conf, &commits),
+        None
+    );
 
     commits.push(dummy_commit_from_body(
         "10b96a74c484cae79164cbbcdfcd412109e0e4cf",
@@ -42,7 +57,37 @@ Signed-off-by: Foo Bar <foobar123@example.com>
 Co-authored-by: Baz Qux <bazqux@example.com>",
     ));
 
-    assert_eq!(mentions_in_commits(&NoMentionsConfig {}, &commits), None);
+    assert_eq!(
+        mentions_in_commits("any title", &default_conf, &commits,),
+        None
+    );
+
+    commits.push(dummy_commit_from_body(
+        "6565ffdd8af4ca0ec7c8faceee59c582edcd83b2",
+        "This is a body that only mentions @rustbot for a command!",
+    ));
+
+    assert_eq!(
+        mentions_in_commits("any title", &default_conf, &commits),
+        None
+    );
+
+    commits.push(dummy_commit_from_body(
+        "6565ffdd8af4ca0ec7c8faceee59c582edcd83b2",
+        "This is a body that mentions @rustbot for a command! And then a user @mention",
+    ));
+
+    assert_eq!(
+        mentions_in_commits("any title", &default_conf, &commits, ),
+        Some(
+            r"There are username mentions (such as `@user`) in the commit messages of the following commits.
+*Please remove the mentions to avoid spamming these users.*
+- 6565ffdd8af4ca0ec7c8faceee59c582edcd83b2
+".to_string()
+        )
+    );
+
+    let _ = commits.pop(); // Remove that @rustbot & @mention case
 
     commits.push(dummy_commit_from_body(
         "d7daa17bc97df9377640b0d33cbd0bbeed703c3a",
@@ -50,12 +95,13 @@ Co-authored-by: Baz Qux <bazqux@example.com>",
     ));
 
     assert_eq!(
-        mentions_in_commits(&NoMentionsConfig {}, &commits),
-        Some(
-            r"There are username mentions (such as `@user`) in the commit messages of the following commits.
-*Please remove the mentions to avoid spamming these users.*
-- d7daa17bc97df9377640b0d33cbd0bbeed703c3a
-".to_string()
-        )
+        mentions_in_commits(
+            "exclude this pull from checking ",
+            &NoMentionsConfig {
+                exclude_titles: vec![String::from("exclude this")]
+            },
+            &commits
+        ),
+        None
     );
 }


### PR DESCRIPTION
Previously, users were getting warnings for including merge commits to PRs that mentioned only @rustbot ([Example](https://github.com/rust-lang/rust/pull/145056#issuecomment-3164621504)). Now it has to have at least one human mentioned in order to trigger a comment.