### PR TITLE
Reorder CI, make it fail fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
       - uses: actions/checkout@v4
       - run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
-      - name: Run tests
-        run: cargo test --workspace --all-targets
       - name: Check formatting
         run: cargo fmt --all --check
+      - name: Run tests
+        run: cargo test --workspace --all-targets
 
   deploy:
     name: Deploy


### PR DESCRIPTION
The test suite takes about 1m 42 seconds to run, while `cargo fmt --check` takes less than a second. This PR reorders them