### PR TITLE
Log axum anyhow errors using `Debug` impl

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,7 +17,7 @@ pub struct AppError(anyhow::Error);
 
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
-        tracing::error!("error={}", &self.0);
+        tracing::error!("{:?}", &self.0);
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("Something went wrong: {}", self.0),


### PR DESCRIPTION
Otherwise the error is pretty useless:
<img width="1412" height="89" alt="image" src="https://github.com/user-attachments/assets/a14c3b69-9a2d-42b6-a442-5e577acafb9f" />