### PR TITLE
Fix error about duplicated entry for `updated_at` in pull request review events

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -470,8 +470,10 @@ pub struct Comment {
     pub body: String,
     pub html_url: String,
     pub user: User,
-    #[serde(default, alias = "submitted_at")] // for pull request reviews
-    pub updated_at: chrono::DateTime<Utc>,
+    #[serde(default, alias = "submitted_at")] // for pull-request review comments
+    pub created_at: Option<chrono::DateTime<Utc>>,
+    #[serde(default)]
+    pub updated_at: Option<chrono::DateTime<Utc>>,
     #[serde(default, rename = "state")]
     pub pr_review_state: Option<PullRequestReviewState>,
     pub author_association: AuthorAssociation,
@@ -2402,7 +2404,11 @@ impl Event {
         match self {
             Event::Create(_) => None,
             Event::Issue(e) => Some(e.issue.created_at.into()),
-            Event::IssueComment(e) => Some(e.comment.updated_at.into()),
+            Event::IssueComment(e) => e
+                .comment
+                .updated_at
+                .or(e.comment.created_at)
+                .map(Into::into),
             Event::Push(_) => None,
         }
     }


### PR DESCRIPTION
It seems like GitHub has started sending the `updated_at` field for the `review` object when a review comment is updated, it's not (yet?) reflected in their documentation[^1].

Unfortunately for us this creates a conflict the `submitted_at` field, which is also passed, which makes us fail the de-serialization as serde doesn't know which one to use.

To fix this I separated the time of creation (`created_at` for regular comment and `submitted_at` review comment) from the updated time (`updated_at` for both it seems).

We then prefer the updated time over the creation time in the `Event::time` method.

[^1]: https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request_review