### PR TITLE
Avoid emit [behind-upstream] more than once

### DIFF
--- a/src/handlers/check_commits/behind_upstream.rs
+++ b/src/handlers/check_commits/behind_upstream.rs
@@ -27,8 +27,9 @@ pub(super) async fn behind_upstream(
             days_old
         );
 
+        // The message remain the same to ensure the warning is emit only once.
         Some(format!(
-            r"This PR is based on an [upstream commit]({upstream_commit_url}) that is {days_old} days old.
+            r"This PR is based on an [upstream commit]({upstream_commit_url}) that is older than {age_threshold} days.
 
 *It's recommended to update your branch according to the [rustc-dev-guide](https://rustc-dev-guide.rust-lang.org/contributing.html#keeping-your-branch-up-to-date).*",
         ))

--- a/src/handlers/check_commits/behind_upstream.rs
+++ b/src/handlers/check_commits/behind_upstream.rs
@@ -27,7 +27,7 @@ pub(super) async fn behind_upstream(
             days_old
         );
 
-        // The message remain the same to ensure the warning is emit only once.
+        // The message remain the same to ensure the warning is emit only once for each base commit.
         Some(format!(
             r"This PR is based on an [upstream commit]({upstream_commit_url}) that is older than {age_threshold} days.
 


### PR DESCRIPTION
I set the warning message for `[behind-upstream]` to be unchange when `upstream_commit_url` is the same so that it does not issue continuous warnings (i.e. `last_warnings==warnings`). 

The original `days_old` always changes, but `age_threshold` does not change. This is the smallest modification I can think of, but there may be more refined control methods.

It is suggested by [#triagebot > Outdated commit message @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/224082-triagebot/topic/Outdated.20commit.20message/near/533598281)


cc @Urgau @Kobzol 