### PR TITLE
Zulip stream type check

### DIFF
--- a/src/zulip/api.rs
+++ b/src/zulip/api.rs
@@ -47,7 +47,7 @@ pub(crate) enum Recipient<'a> {
         id: u64,
         topic: &'a str,
     },
-    Private {
+    Direct {
         #[serde(skip)]
         id: u64,
         #[serde(rename = "to")]
@@ -81,7 +81,7 @@ impl Recipient<'_> {
                 }
                 format!("stream/{}-xxx/topic/{}", id, encoded_topic)
             }
-            Recipient::Private { id, .. } => format!("pm-with/{}-xxx", id),
+            Recipient::Direct { id, .. } => format!("pm-with/{}-xxx", id),
         }
     }
 

--- a/src/zulip/client.rs
+++ b/src/zulip/client.rs
@@ -70,15 +70,15 @@ impl ZulipClient {
             .form(&SerializedApi {
                 type_: match recipient {
                     Recipient::Stream { .. } => "stream",
-                    Recipient::Private { .. } => "private",
+                    Recipient::Direct { .. } => "direct",
                 },
                 to: match recipient {
                     Recipient::Stream { id, .. } => id.to_string(),
-                    Recipient::Private { email, .. } => email.to_string(),
+                    Recipient::Direct { email, .. } => email.to_string(),
                 },
                 topic: match recipient {
                     Recipient::Stream { topic, .. } => Some(topic),
-                    Recipient::Private { .. } => None,
+                    Recipient::Direct { .. } => None,
                 },
                 content,
             })


### PR DESCRIPTION
The Zulip Message API has changed a little bit since we implemented our client. This patch:
- replaces "private" with "direct" for direct messages (see [docs](https://zulip.com/api/send-message#parameter-type)), no functional change.
- fixes/improves the direct vs. stream check we do when the triagebot server receives a message from the Zulip server. The previous check was not *wrong* per se but the correct check should be on the message `type`.
- Rewrote/fixed and (hopefully) clarified the documentation about testing Zulip stuff 

tbh these changes are not *really* necessary but slightly improve the correctness of our client.

For anyone who has an opinion :)