### PR TITLE
Add `robots.txt` and block all user-agents

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -163,6 +163,10 @@ async fn run_server(addr: SocketAddr) -> anyhow::Result<()> {
 
     let app = Router::new()
         .route("/", get(|| async { "Triagebot is awaiting triage." }))
+        .route(
+            "/robots.txt",
+            get(|| async { "User-Agent: *\nDisallow: /\n" }),
+        )
         .route("/triage", get(triagebot::triage::index))
         .route("/triage/{owner}/{repo}", get(triagebot::triage::pulls))
         .route(


### PR DESCRIPTION
Looking at the logs I can see that a bunch of requests are being made to `/robots.txt` by crawlers, and in particular AI crawlers, probably because of the gha-logs links we post on GitHub.

Let's tell then that we do not have anything interesting for them, by adding a `robots.txt` that indicates that bots shouldn't interact with us.