### PR TITLE
Add full ranges support for our range-diff feature

### DIFF
--- a/src/handlers/check_commits/force_push_range_diff.rs
+++ b/src/handlers/check_commits/force_push_range_diff.rs
@@ -51,10 +51,12 @@ pub(super) async fn handle_event(
     };
 
     let branch = &base.git_ref;
+    let (oldbase, oldhead) = (&compare_before.merge_base_commit.sha, before);
+    let (newbase, newhead) = (&compare_after.merge_base_commit.sha, after);
 
     // Rebase detected, post a comment to our range-diff.
     event.issue.post_comment(&ctx.github,
-        &format!(r#"This PR was rebased onto a different {branch} commit! Check out the changes with our [`range-diff`]({protocol}://{host}/gh-range-diff/{org}/{repo}/{before}..{after})."#)
+        &format!(r#"This PR was rebased onto a different {branch} commit! Check out the changes with our [`range-diff`]({protocol}://{host}/gh-range-diff/{org}/{repo}/{oldbase}..{oldhead}/{newbase}..{newhead})."#)
     ).await.context("failed to post range-diff comment")?;
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,6 +189,10 @@ async fn run_server(addr: SocketAddr) -> anyhow::Result<()> {
             "/gh-range-diff/{owner}/{repo}/{basehead}",
             get(triagebot::gh_range_diff::gh_range_diff),
         )
+        .route(
+            "/gh-range-diff/{owner}/{repo}/{oldbasehead}/{newbasehead}",
+            get(triagebot::gh_range_diff::gh_ranges_diff),
+        )
         .nest("/agenda", agenda)
         .route("/bors-commit-list", get(triagebot::bors::bors_commit_list))
         .route(


### PR DESCRIPTION
This PR adds a variant to our existing `gh-range-diff` endpoint which takes the full ranges of old and new instead of trying to guessing them.

This is useful for us as the new comment we added in #2158 as access to the full ranges. So instead of wasting resources trying to re-fetch the same information, let's just re-use it.

I opted for a new endpoint, as the old one is still useful (in particular for older PRs, or repos that don't have `[range-diff]` comment activated). We also just announced it, so it would be kind-of silly to remove it less than 6 hours after launching it.

I tested it locally.