### PR TITLE
Misc changes for our range-diff

### DIFF
--- a/src/gh_range_diff.rs
+++ b/src/gh_range_diff.rs
@@ -315,6 +315,8 @@ fn process_old_new(
 "#
     )?;
 
+    let mut diff_displayed = 0;
+
     let mut process_diffs = |filename, old_patch, new_patch| -> anyhow::Result<()> {
         // Removes diff markers to avoid false-positives
         let new_marker = format!("@@ {filename}:");
@@ -346,6 +348,7 @@ fn process_old_new(
                 html,
                 r#"<details open=""><summary>{filename} <a href="{before_href}">before</a> <a href="{after_href}">after</a></summary><pre class="diff-content">{diff}</pre></details>"#
             )?;
+            diff_displayed += 1;
         }
         Ok(())
     };
@@ -377,6 +380,11 @@ fn process_old_new(
         }
 
         process_diffs(filename, "", &*new_file.patch)?;
+    }
+
+    // Print message when there aren't any differences
+    if diff_displayed == 0 {
+        writeln!(html, "<p>No differences</p>")?;
     }
 
     writeln!(

--- a/src/handlers/check_commits/force_push_range_diff.rs
+++ b/src/handlers/check_commits/force_push_range_diff.rs
@@ -1,10 +1,22 @@
 use anyhow::Context as _;
 
 use crate::config::RangeDiffConfig;
+use crate::db::issue_data::IssueData;
 use crate::github::GithubCompare;
 use crate::github::IssueRepository;
 use crate::github::IssuesEvent;
+use crate::github::ReportedContentClassifiers;
 use crate::handlers::Context;
+
+/// Key for the state in the database
+const RANGE_DIFF_LINK_KEY: &str = "range-diff-link";
+
+/// State stored in the database
+#[derive(Debug, Default, serde::Deserialize, serde::Serialize, Clone, PartialEq)]
+struct RangeDiffLinkState {
+    /// ID of the most recent range-diff comment.
+    last_comment: Option<String>,
+}
 
 pub(super) async fn handle_event(
     ctx: &Context,
@@ -54,10 +66,49 @@ pub(super) async fn handle_event(
     let (oldbase, oldhead) = (&compare_before.merge_base_commit.sha, before);
     let (newbase, newhead) = (&compare_after.merge_base_commit.sha, after);
 
-    // Rebase detected, post a comment to our range-diff.
-    event.issue.post_comment(&ctx.github,
-        &format!(r#"This PR was rebased onto a different {branch} commit! Check out the changes with our [`range-diff`]({protocol}://{host}/gh-range-diff/{org}/{repo}/{oldbase}..{oldhead}/{newbase}..{newhead})."#)
-    ).await.context("failed to post range-diff comment")?;
+    let message = format!(
+        r#"This PR was rebased onto a different {branch} commit! Check out the changes with our [`range-diff`]({protocol}://{host}/gh-range-diff/{org}/{repo}/{oldbase}..{oldhead}/{newbase}..{newhead})."#
+    );
+
+    // Rebase detected, post a comment linking to our range-diff.
+    post_new_comment(ctx, event, message).await?;
+
+    Ok(())
+}
+
+async fn post_new_comment(
+    ctx: &Context,
+    event: &IssuesEvent,
+    message: String,
+) -> anyhow::Result<()> {
+    let mut db = ctx.db.get().await;
+    let mut state: IssueData<'_, RangeDiffLinkState> =
+        IssueData::load(&mut db, &event.issue, RANGE_DIFF_LINK_KEY).await?;
+
+    // Hide previous range-diff comment.
+    if let Some(last_comment) = state.data.last_comment {
+        event
+            .issue
+            .hide_comment(
+                &ctx.github,
+                &last_comment,
+                ReportedContentClassifiers::Outdated,
+            )
+            .await
+            .context("failed to hide previous range-diff comment")?;
+    }
+
+    // Post new range-diff comment and remember it.
+    state.data.last_comment = Some(
+        event
+            .issue
+            .post_comment(&ctx.github, &message)
+            .await
+            .context("failed to post range-diff comment")?
+            .node_id,
+    );
+
+    state.save().await?;
 
     Ok(())
 }

--- a/src/handlers/check_commits/force_push_range_diff.rs
+++ b/src/handlers/check_commits/force_push_range_diff.rs
@@ -67,7 +67,9 @@ pub(super) async fn handle_event(
     let (newbase, newhead) = (&compare_after.merge_base_commit.sha, after);
 
     let message = format!(
-        r#"This PR was rebased onto a different {branch} commit! Check out the changes with our [range-diff]({protocol}://{host}/gh-range-diff/{org}/{repo}/{oldbase}..{oldhead}/{newbase}..{newhead})."#
+        r#"This PR was rebased onto a different {branch} commit. Here's a [range-diff]({protocol}://{host}/gh-range-diff/{org}/{repo}/{oldbase}..{oldhead}/{newbase}..{newhead}) highlighting what actually changed.
+
+*Rebasing is a normal part of keeping PRs up to date, so no action is needed—this note is just to help reviewers.*"#
     );
 
     // Rebase detected, post a comment linking to our range-diff.

--- a/src/handlers/check_commits/force_push_range_diff.rs
+++ b/src/handlers/check_commits/force_push_range_diff.rs
@@ -67,7 +67,7 @@ pub(super) async fn handle_event(
     let (newbase, newhead) = (&compare_after.merge_base_commit.sha, after);
 
     let message = format!(
-        r#"This PR was rebased onto a different {branch} commit! Check out the changes with our [`range-diff`]({protocol}://{host}/gh-range-diff/{org}/{repo}/{oldbase}..{oldhead}/{newbase}..{newhead})."#
+        r#"This PR was rebased onto a different {branch} commit! Check out the changes with our [range-diff]({protocol}://{host}/gh-range-diff/{org}/{repo}/{oldbase}..{oldhead}/{newbase}..{newhead})."#
     );
 
     // Rebase detected, post a comment linking to our range-diff.


### PR DESCRIPTION
This PR contains some changes regarding our range-diff feature:
 1. We indicate to the users when there aren't any differences (instead of showing nothing)
 2. We hide the previous range-diff comment when posting a new one
 3. Remove code quote around range-diff link
 4. Clarify the comment regarding PR authors and it's usefulness
    [#t-compiler/help > ✔ rustbot tells me my PR was rebased on a different master](https://rust-lang.zulipchat.com/#narrow/channel/182449-t-compiler.2Fhelp/topic/.E2.9C.94.20rustbot.20tells.20me.20my.20PR.20was.20rebased.20on.20a.20different.20master)
 5. Add tests for the comment logic