### PR TITLE
Fix merge conflict detection

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -1981,6 +1981,16 @@ impl Repository {
             .with_context(|| format!("{} failed to get issue {issue_num}", self.full_name))
     }
 
+    pub async fn get_pr(&self, client: &GithubClient, pr_num: u64) -> anyhow::Result<Issue> {
+        let url = format!("{}/pulls/{pr_num}", self.url(client));
+        let mut pr: Issue = client
+            .json(client.get(&url))
+            .await
+            .with_context(|| format!("{} failed to get pr {pr_num}", self.full_name))?;
+        pr.pull_request = Some(PullRequestDetails::new());
+        Ok(pr)
+    }
+
     /// Fetches information about merge conflicts on open PRs.
     pub async fn get_merge_conflict_prs(
         &self,


### PR DESCRIPTION
This fixes the merge-conflict handler which recently stopped working. From what I can tell, the `/issues/` endpoint no longer returns all the same details when fetching a pull request. This changes it to use the `/pulls/` endpoint instead which contains all of the necessary fields.

Fixes https://github.com/rust-lang/triagebot/issues/2154