### PR TITLE
Add style_edition to rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
 edition = "2024"
+style_edition = "2024"


### PR DESCRIPTION
This adds the `style_edition` to rustfmt.toml. The `edition` field only affects parsing, not formatting. This helps with editors which invoke `rustfmt` directly, which cannot read `Cargo.toml`.