### PR TITLE
Rename ShortcutCommand to ReviewCommand

### DIFF
--- a/parser/src/command.rs
+++ b/parser/src/command.rs
@@ -23,7 +23,7 @@ pub enum Command<'a> {
     Nominate(Result<nominate::NominateCommand, Error<'a>>),
     Prioritize(Result<prioritize::PrioritizeCommand, Error<'a>>),
     Second(Result<second::SecondCommand, Error<'a>>),
-    Shortcut(Result<shortcut::ShortcutCommand, Error<'a>>),
+    Review(Result<shortcut::ReviewCommand, Error<'a>>),
     Close(Result<close::CloseCommand, Error<'a>>),
     Note(Result<note::NoteCommand, Error<'a>>),
     Concern(Result<concern::ConcernCommand, Error<'a>>),
@@ -125,8 +125,8 @@ impl<'a> Input<'a> {
             &original_tokenizer,
         ));
         success.extend(parse_single_command(
-            shortcut::ShortcutCommand::parse,
-            Command::Shortcut,
+            shortcut::ReviewCommand::parse,
+            Command::Review,
             &original_tokenizer,
         ));
         success.extend(parse_single_command(
@@ -210,7 +210,7 @@ impl<'a> Command<'a> {
             Command::Nominate(r) => r.is_ok(),
             Command::Prioritize(r) => r.is_ok(),
             Command::Second(r) => r.is_ok(),
-            Command::Shortcut(r) => r.is_ok(),
+            Command::Review(r) => r.is_ok(),
             Command::Close(r) => r.is_ok(),
             Command::Note(r) => r.is_ok(),
             Command::Concern(r) => r.is_ok(),

--- a/parser/src/command/shortcut.rs
+++ b/parser/src/command/shortcut.rs
@@ -1,4 +1,4 @@
-//! The shortcut command parser.
+//! Parser for commands handling a PR review status
 //!
 //! This can parse predefined shortcut input, single word commands.
 //!
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use std::fmt;
 
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
-pub enum ShortcutCommand {
+pub enum ReviewCommand {
     Ready,
     Author,
     Blocked,
@@ -31,14 +31,14 @@ impl fmt::Display for ParseError {
     }
 }
 
-impl ShortcutCommand {
+impl ReviewCommand {
     pub fn parse<'a>(input: &mut Tokenizer<'a>) -> Result<Option<Self>, Error<'a>> {
         let mut shortcuts = HashMap::new();
-        shortcuts.insert("ready", ShortcutCommand::Ready);
-        shortcuts.insert("review", ShortcutCommand::Ready);
-        shortcuts.insert("reviewer", ShortcutCommand::Ready);
-        shortcuts.insert("author", ShortcutCommand::Author);
-        shortcuts.insert("blocked", ShortcutCommand::Blocked);
+        shortcuts.insert("ready", ReviewCommand::Ready);
+        shortcuts.insert("review", ReviewCommand::Ready);
+        shortcuts.insert("reviewer", ReviewCommand::Ready);
+        shortcuts.insert("author", ReviewCommand::Author);
+        shortcuts.insert("blocked", ReviewCommand::Blocked);
 
         let mut toks = input.clone();
         if let Some(Token::Word(word)) = toks.peek_token()? {
@@ -55,32 +55,32 @@ impl ShortcutCommand {
 }
 
 #[cfg(test)]
-fn parse(input: &str) -> Result<Option<ShortcutCommand>, Error<'_>> {
+fn parse(input: &str) -> Result<Option<ReviewCommand>, Error<'_>> {
     let mut toks = Tokenizer::new(input);
-    Ok(ShortcutCommand::parse(&mut toks)?)
+    Ok(ReviewCommand::parse(&mut toks)?)
 }
 
 #[test]
 fn test_1() {
-    assert_eq!(parse("ready."), Ok(Some(ShortcutCommand::Ready)));
+    assert_eq!(parse("ready."), Ok(Some(ReviewCommand::Ready)));
 }
 
 #[test]
 fn test_2() {
-    assert_eq!(parse("ready"), Ok(Some(ShortcutCommand::Ready)));
+    assert_eq!(parse("ready"), Ok(Some(ReviewCommand::Ready)));
 }
 
 #[test]
 fn test_3() {
-    assert_eq!(parse("author"), Ok(Some(ShortcutCommand::Author)),);
+    assert_eq!(parse("author"), Ok(Some(ReviewCommand::Author)),);
 }
 
 #[test]
 fn test_4() {
-    assert_eq!(parse("ready word"), Ok(Some(ShortcutCommand::Ready)));
+    assert_eq!(parse("ready word"), Ok(Some(ReviewCommand::Ready)));
 }
 
 #[test]
 fn test_5() {
-    assert_eq!(parse("blocked"), Ok(Some(ShortcutCommand::Blocked)));
+    assert_eq!(parse("blocked"), Ok(Some(ReviewCommand::Blocked)));
 }


### PR DESCRIPTION
The ShortcutCommand was born to handle one case (reviews) but I'd like to expand its scope to handle more convenience custom shortcuts for commands that will modify labels.

However just adding more code would make things a bit confusing, so I'd first start clarifying the scope of the existing code and in subsequent patches add more shortcut commands.

At a high level, I can imagine something like this:
- shortcut::ReviewCommand to handle commands like `author`, `review`, `ready`, etc.
- shortcut::RegressionCommand to handle future commands for quick switching label regressions (todo)
- shortcut:NewCommand (and so on)

Functionally this patch changes nothing, it's just renaming things.

I wrote about this on [Zulip](https://rust-lang.zulipchat.com/#narrow/channel/224082-triagebot/topic/Generic.20shorcut.20handler/near/535472560).

Thanks for having a look here. I'd like to get some opinons if this makes sense before moving forward with further work.

r?