### PR TITLE
Add a simple word-highlighting to our range-diff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2576,7 +2576,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1961e2ef424c1424204d3a5d6975f934f56b6d50ff5732382d84ebf460e147f7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.98",
@@ -3127,6 +3127,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "unicode-segmentation",
  "url",
  "uuid 0.8.2",
  "x509-cert",
@@ -3235,6 +3236,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ sha2 = "0.10.9"
 imara-diff = "0.2.0"
 pulldown-cmark-escape = "0.11.0"
 axum-extra = { version = "0.10.1", default-features = false }
+unicode-segmentation = "1.12.0"
 
 [dependencies.serde]
 version = "1"


### PR DESCRIPTION
As suggested in [#triagebot > range-diff should highlight the changed span within lines](https://rust-lang.zulipchat.com/#narrow/channel/224082-triagebot/topic/range-diff.20should.20highlight.20the.20changed.20span.20within.20lines), this PR adds a simple word-highlighting to our range-diff.

It's simple in the sense that we only look at hunks that have the same number of lines removed and added, otherwise it's much more complex. We also just use `unicode-segmentation` to split the lines by words.

| Example 1 | Example 2 |
| ---- | ---- |
| <img width="1165" height="971" alt="image" src="https://github.com/user-attachments/assets/65ae9769-8ed5-4c66-ae39-82f099a9aa65" /> | <img width="903" height="501" alt="image" src="https://github.com/user-attachments/assets/c20ad77e-e3fb-4c2a-a0e1-8e088e9b1d4e" /> |
