### PR TITLE
Add way to do mentions of content changes

### DIFF
--- a/src/handlers/mentions.rs
+++ b/src/handlers/mentions.rs
@@ -3,7 +3,7 @@
 //! interested people.
 
 use crate::{
-    config::{MentionsConfig, MentionsPathConfig},
+    config::{MentionsConfig, MentionsEntryConfig, MentionsEntryType},
     db::issue_data::IssueData,
     github::{IssuesAction, IssuesEvent},
     handlers::Context,
@@ -17,12 +17,13 @@ use tracing as log;
 const MENTIONS_KEY: &str = "mentions";
 
 pub(super) struct MentionsInput {
-    paths: Vec<String>,
+    to_mention: Vec<String>,
 }
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
 struct MentionState {
-    paths: Vec<String>,
+    #[serde(alias = "paths")]
+    entries: Vec<String>,
 }
 
 pub(super) async fn parse_input(
@@ -61,23 +62,31 @@ pub(super) async fn parse_input(
     {
         let file_paths: Vec<_> = files.iter().map(|fd| Path::new(&fd.filename)).collect();
         let to_mention: Vec<_> = config
-            .paths
+            .entries
             .iter()
-            .filter(|(path, MentionsPathConfig { cc, .. })| {
-                let path = Path::new(path);
-                // Only mention matching paths.
-                let touches_relevant_files = file_paths.iter().any(|p| p.starts_with(path));
+            .filter(|(entry, MentionsEntryConfig { cc, type_, .. })| {
+                let relevent = match type_ {
+                    MentionsEntryType::Filename => {
+                        let path = Path::new(entry);
+                        // Only mention matching paths.
+                        file_paths.iter().any(|p| p.starts_with(path))
+                    }
+                    MentionsEntryType::Content => {
+                        // Only mentions byte-for-byte matching content inside the patch.
+                        files.iter().any(|f| f.patch.contains(&**entry))
+                    }
+                };
                 // Don't mention if only the author is in the list.
                 let pings_non_author = match &cc[..] {
                     [only_cc] => only_cc.trim_start_matches('@') != &event.issue.user.login,
                     _ => true,
                 };
-                touches_relevant_files && pings_non_author
+                relevent && pings_non_author
             })
             .map(|(key, _mention)| key.to_string())
             .collect();
         if !to_mention.is_empty() {
-            return Ok(Some(MentionsInput { paths: to_mention }));
+            return Ok(Some(MentionsInput { to_mention }));
         }
     }
     Ok(None)
@@ -94,23 +103,30 @@ pub(super) async fn handle_input(
         IssueData::load(&mut client, &event.issue, MENTIONS_KEY).await?;
     // Build the message to post to the issue.
     let mut result = String::new();
-    for to_mention in &input.paths {
-        if state.data.paths.iter().any(|p| p == to_mention) {
+    for to_mention in &input.to_mention {
+        if state.data.entries.iter().any(|p| p == to_mention) {
             // Avoid duplicate mentions.
             continue;
         }
-        let MentionsPathConfig { message, cc } = &config.paths[to_mention];
+        let MentionsEntryConfig { message, cc, type_ } = &config.entries[to_mention];
         if !result.is_empty() {
             result.push_str("\n\n");
         }
         match message {
             Some(m) => result.push_str(m),
-            None => write!(result, "Some changes occurred in {to_mention}").unwrap(),
+            None => match type_ {
+                MentionsEntryType::Filename => {
+                    write!(result, "Some changes occurred in {to_mention}").unwrap()
+                }
+                MentionsEntryType::Content => {
+                    write!(result, "Some changes regarding `{to_mention}` occurred").unwrap()
+                }
+            },
         }
         if !cc.is_empty() {
             write!(result, "\n\ncc {}", cc.join(", ")).unwrap();
         }
-        state.data.paths.push(to_mention.to_string());
+        state.data.entries.push(to_mention.to_string());
     }
     if !result.is_empty() {
         event


### PR DESCRIPTION
This PR adds a way to do mentions of content changes (instead of just filename changes).

```
[mentions."#[rustc_attr]"]
type = "content"
message = "This is a message."
cc = ["@someone"]
```

Fixes https://github.com/rust-lang/triagebot/issues/1851