### PR TITLE
Format Rust file generated by cynic

### DIFF
--- a/github-graphql/build.rs
+++ b/github-graphql/build.rs
@@ -4,4 +4,11 @@ pub fn main() {
         .unwrap()
         .as_default()
         .unwrap();
+    std::process::Command::new("rustfmt")
+        .arg(format!(
+            "{}/cynic-schemas/github.rs",
+            std::env::var("OUT_DIR").unwrap()
+        ))
+        .status()
+        .expect("failed to execute rustfmt");
 }


### PR DESCRIPTION
When unformatted, the file contains a single line with 3.4M characters. This makes running Clippy on this repository very slow because some lints manipulate the source code, for example to detect mistyped doc comment markers.