### PR TITLE
Improve range-diff color contrast in dark mode

### DIFF
--- a/src/gh_range_diff.rs
+++ b/src/gh_range_diff.rs
@@ -303,7 +303,7 @@ fn process_old_new(
         color: rgba(0, 255, 0, 1);
       }}
       .line-removed-before {{
-        color: rgb(206, 48, 0);
+        color: rgb(255, 159, 131);
       }}
       .line-added-before {{
         color: rgba(11, 142, 0, 1);


### PR DESCRIPTION
The current colors are very low contrast, and therefore very hard to read. This replaces the colors with significantly brighter ones to improve contrast a lot.

The red drifted a lot into the orange, because when making the red brighter, it just got *harder* to read for me because red on black is bad combination. So i just made it slightly orange, which looks a lot better. I did not pick the colors from `git range-diff` itself because the red there is still pretty low contrast.

The colors now have a comfortable ~4.55 (AA accessibility) contrast according to developer tools.

<img width="960" height="473" alt="image" src="https://github.com/user-attachments/assets/8ed826a2-a931-4abe-8618-1378618ee947" />


fixes #2183