### PR TITLE
Fix Rust favicon location

### DIFF
--- a/src/gh_range_diff.rs
+++ b/src/gh_range_diff.rs
@@ -227,7 +227,7 @@ fn process_old_new(
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" sizes="32x32" type="image/png" href="https://www.rust-lang.org/static/images/favicon-32x32.png">
+    <link rel="icon" sizes="32x32" type="image/png" href="https://rust-lang.org/static/images/favicon-32x32.png">
     <title>range-diff of {oldbase}...{oldhead} {newbase}...{newhead}</title>
     <style>
     body {{
@@ -425,7 +425,7 @@ fn process_old_new(
     headers.insert(
         CONTENT_SECURITY_POLICY,
         HeaderValue::from_static(
-            "default-src 'none'; style-src 'unsafe-inline'; img-src www.rust-lang.org",
+            "default-src 'none'; style-src 'unsafe-inline'; img-src rust-lang.org",
         ),
     );
 

--- a/src/gha_logs.rs
+++ b/src/gha_logs.rs
@@ -199,7 +199,7 @@ pub async fn gha_logs(
             format!(r#"<link rel="icon" sizes="any" type="image/svg+xml" href="{SUCCESS_URL}">"#)
         }
         _ => {
-            r#"<link rel="icon" sizes="32x32" type="image/png" href="https://www.rust-lang.org/static/images/favicon-32x32.png">"#.to_string()
+            r#"<link rel="icon" sizes="32x32" type="image/png" href="https://rust-lang.org/static/images/favicon-32x32.png">"#.to_string()
         }
     };
 
@@ -360,7 +360,7 @@ body {{
         CONTENT_SECURITY_POLICY,
         HeaderValue::from_str(&*
         format!(
-            "default-src 'none'; script-src 'nonce-{nonce}' 'self'; style-src 'unsafe-inline'; img-src 'self' www.rust-lang.org"
+            "default-src 'none'; script-src 'nonce-{nonce}' 'self'; style-src 'unsafe-inline'; img-src 'self' rust-lang.org"
         )).unwrap(),
     );
 


### PR DESCRIPTION
Due to the migration of the website to GitHub Sites the favicon is no longer under `www.rust-lang.org` but under `rust-lang.org` which is blocked by our CSP headers. Let's update the CSP headers and links.