### PR TITLE
Fix GitHub base change de-serialization

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -1194,10 +1194,16 @@ pub struct ChangeInner {
 }
 
 #[derive(Debug, serde::Deserialize)]
+pub struct BaseChange {
+    pub r#ref: ChangeInner,
+    pub sha: ChangeInner,
+}
+
+#[derive(Debug, serde::Deserialize)]
 pub struct Changes {
     pub title: Option<ChangeInner>,
     pub body: Option<ChangeInner>,
-    pub base: Option<ChangeInner>,
+    pub base: Option<BaseChange>,
 }
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]

--- a/src/handlers/check_commits.rs
+++ b/src/handlers/check_commits.rs
@@ -515,8 +515,13 @@ r#":warning: **Warning** :warning:
         event.changes = Some(crate::github::Changes {
             title: None,
             body: None,
-            base: Some(crate::github::ChangeInner {
-                from: "master".to_string(),
+            base: Some(crate::github::BaseChange {
+                r#ref: crate::github::ChangeInner {
+                    from: "master".to_string(),
+                },
+                sha: crate::github::ChangeInner {
+                    from: "fake-sha".to_string(),
+                },
             }),
         });
         assert!(should_handle_event(&event));


### PR DESCRIPTION
Looks like our `base` field for the "changes" in an issue/PR has always been wrong, it has two additional fields. Found while looking at the logs.

https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=edited#pull_request