### PR TITLE
Apply labels from left to right in relabel

### DIFF
--- a/parser/src/command/relabel.rs
+++ b/parser/src/command/relabel.rs
@@ -19,7 +19,7 @@ pub enum LabelDelta {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct Label(String);
+pub struct Label(pub String);
 
 #[derive(PartialEq, Eq, Debug)]
 pub enum ParseError {

--- a/src/github.rs
+++ b/src/github.rs
@@ -324,7 +324,7 @@ impl User {
     }
 }
 
-#[derive(PartialEq, Eq, Debug, Clone, serde::Deserialize)]
+#[derive(PartialEq, Eq, Debug, Clone, Ord, PartialOrd, serde::Deserialize)]
 pub struct Label {
     pub name: String,
 }


### PR DESCRIPTION
As we discussed in #2172 and in [#t-compiler/contrib-private > RFC: triagebot parsing command aliases](https://rust-lang.zulipchat.com/#narrow/channel/244344-t-compiler.2Fcontrib-private/topic/RFC.3A.20triagebot.20parsing.20command.20aliases/with/541247373) the way labels are applied in relabel is weird when the same label is used multiple times.

This PR makes the behavior more user friendly by pre-computing a "final state" where all the label deltas are applied from left to right, meaning that `+label -label`/`-label +label` would cancel each other instead of using the issue state.

Best reviewed commit by commit.