### PR TITLE
Turn automatic backport nominations into suggestions

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -408,7 +408,8 @@ pub struct Issue {
     // User performing an `action` (or PR/issue author)
     pub user: User,
     pub labels: Vec<Label>,
-    // Users assigned to the issue/pr after `action` has been performed
+    // Users assigned to the issue/pr after `action` has been performed issue
+    // (PR reviewers or issue assignees)
     // These are NOT the same as `IssueEvent.assignee`
     pub assignees: Vec<User>,
     /// Indicator if this is a pull request.

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -708,7 +708,7 @@ async fn lookup_github_username(ctx: &Context, zulip_username: &str) -> anyhow::
     ))
 }
 
-fn render_zulip_username(zulip_id: u64) -> String {
+pub fn render_zulip_username(zulip_id: u64) -> String {
     // Rendering the username directly was running into some encoding issues, so we use
     // the special `|<user-id>` syntax instead.
     // @**|<zulip-id>** is Zulip syntax that will render as the username (and a link) of the user


### PR DESCRIPTION
Beta backport nominations were confusing so we decided to turn them into suggestions for reviewers and author of a PR fixing a regression. The idea is to raise awareness on patches fixing P-high/P-critical regressions but at the same time not make it look like a *mandatory* decision for T-compiler to take.

After this patch, I will modify the template that creates Zulip topics for backport nominations. For example it could look like this:
```
PR #123456 "Fix insulation in flux capacitor" fixes a regression.
Cc: @user1, @user2, @user3 please evaluate nominating this PR for backport, thanks!
The following poll is a vibe-check and not binding.

/poll Should #123456 be beta backported?
approve
decline
don't know
```

<details><summary>(visual representation)</summary>
<p>

<img width="1211" height="297" alt="grafik" src="https://github.com/user-attachments/assets/613a50c2-efcd-4adc-bfe6-77a099b38d10" />

</p>
</details> 



(`@user1, @user2, @user3`) are PR author and reviewers.
 
As per [Zulip](https://rust-lang.zulipchat.com/#narrow/channel/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202025-10-02/near/542758900) discussion.