### PR TITLE
Update t-compiler triage agenda template

### DIFF
--- a/src/agenda.rs
+++ b/src/agenda.rs
@@ -241,7 +241,7 @@ pub fn prioritization<'a>() -> Box<dyn Action> {
                         kind: QueryKind::List,
                         query: Arc::new(github::Query {
                             filters: vec![("state", "open")],
-                            include_labels: vec!["S-waiting-on-team", "T-compiler"],
+                            include_labels: vec!["S-waiting-on-t-compiler", "T-compiler"],
                             exclude_labels: vec![],
                         }),
                     },

--- a/templates/prioritization_agenda.tt
+++ b/templates/prioritization_agenda.tt
@@ -51,9 +51,9 @@ note_id: xxx
 {{-issues::render(issues=beta_nominated_t_types, backport_branch=":beta:", empty="No beta nominations for `T-types` this time.")}}
 {{-issues::render(issues=stable_nominated_t_types, backport_branch=":stable:", empty="No stable nominations for `T-types` this time.")}}
 
-## PRs S-waiting-on-team
+## PRs S-waiting-on-t-compiler
 
-[T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Aopen+label%3AS-waiting-on-team+label%3AT-compiler)
+[T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Aopen+label%3AS-waiting-on-t-compiler)
 {{-issues::render(issues=prs_waiting_on_team_t_compiler, empty="No PRs waiting on `T-compiler` this time.")}}
 - [Issues in progress or waiting on other teams](https://hackmd.io/XYr1BrOWSiqCrl8RCWXRaQ)
 


### PR DESCRIPTION
Follow-up to #2195 

Filters some open issues relevant to T-compiler replacing the old `S-waiting-on-team` label with the new `S-waiting-on-t-compiler`