### PR TITLE
Prevent copying links and timestamps in our GHA logs viewer

### DIFF
--- a/src/gha_logs.rs
+++ b/src/gha_logs.rs
@@ -338,6 +338,15 @@ body {{
             }});
         }}
 
+        // 8. Add a copy handler that force plain/text copy and removes the timestamps
+        //  from the copied selection.
+        const dateRegexWithSpace = /^(\d{{4}}-\d{{2}}-\d{{2}}T\d{{2}}:\d{{2}}:\d{{2}}\.\d+Z )/gm;
+        document.addEventListener("copy", function(e) {{
+            var text = window.getSelection().toString().replace(dateRegexWithSpace, '');
+            e.clipboardData.setData('text/plain', text);
+            e.preventDefault();
+        }});
+
         }} catch (e) {{
            console.error(e);
            document.body.innerText = `Something went wrong: ${{e}}\n\n{REPORT_TO}`;


### PR DESCRIPTION
This PR adds a bit of javascript to prevent copying links in our GHA logs viewer.

I also made it so that we don't copy the timestamps, as they are IMO always unintended.

Fixes https://github.com/rust-lang/triagebot/issues/2197