### PR TITLE
Make timestamps visually uncopyable and simplify the impl

### DIFF
--- a/src/gha_logs.rs
+++ b/src/gha_logs.rs
@@ -212,18 +212,29 @@ pub async fn gha_logs(
     <title>{job_name} - {owner}/{repo}@{short_sha}</title>
     {icon_status}
     <style>
+:root {{
+    --timestamp-length: 28ch;
+}}
 body {{
   font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
   background: #0C0C0C;
   color: #CCC;
   white-space: pre;
+  padding-left: calc(var(--timestamp-length) + 1ch);
+  margin: 0;
 }}
 .timestamp {{
   color: #848484;
   text-decoration: none;
+  position: absolute;
+  left: 0;
+  width: var(--timestamp-length);
 }}
 .timestamp:hover {{
   text-decoration: underline;
+}}
+.timestamp::before {{
+  content: attr(data-timestamp);
 }}
 .error-marker {{
   scroll-margin-bottom: 15vh;
@@ -276,9 +287,9 @@ body {{
         }}
 
         // 3. Add a self-referencial anchor to all timestamps at the start of the lines
-        const dateRegex = /^(\d{{4}}-\d{{2}}-\d{{2}}T\d{{2}}:\d{{2}}:\d{{2}}\.\d+Z)/gm;
-        html = html.replace(dateRegex, (ts) => 
-            `<a id="${{ts}}" href="#${{ts}}" class="timestamp">${{ts}}</a>`
+        const dateRegex = /^(\d{{4}}-\d{{2}}-\d{{2}}T\d{{2}}:\d{{2}}:\d{{2}}\.\d+Z) /gm;
+        html = html.replace(dateRegex, (match, ts) => 
+            `<a id="${{ts}}" href="#${{ts}}" class="timestamp" data-timestamp="${{ts}}"></a>`
         );
 
         // 4. Add a anchor around every "##[error]" string
@@ -338,11 +349,9 @@ body {{
             }});
         }}
 
-        // 8. Add a copy handler that force plain/text copy and removes the timestamps
-        //  from the copied selection.
-        const dateRegexWithSpace = /^(\d{{4}}-\d{{2}}-\d{{2}}T\d{{2}}:\d{{2}}:\d{{2}}\.\d+Z )/gm;
+        // 8. Add a copy handler that force plain/text copy
         document.addEventListener("copy", function(e) {{
-            var text = window.getSelection().toString().replace(dateRegexWithSpace, '');
+            var text = window.getSelection().toString();
             e.clipboardData.setData('text/plain', text);
             e.preventDefault();
         }});


### PR DESCRIPTION
This PR improves https://github.com/rust-lang/triagebot/pull/2198 by making the timestamps visually unselect-able/uncopyable.

This is done by putting the timestamps in a "floating" `::before` element, which has the consequence of making the element actually uncopyable.

This also simplifies the implementation of our copy event by removing the timestamps removal as they are no longer select-able. This also as the advantage that partial selection of a timestamp does not leave it in the copy.

<img width="1480" height="455" alt="image" src="https://github.com/user-attachments/assets/c438865b-5fad-4fb7-bccf-5d3491d25d04" />
