### PR TITLE
Revert "Add alias for compound labels"

### DIFF
--- a/parser/src/command/relabel.rs
+++ b/parser/src/command/relabel.rs
@@ -102,7 +102,6 @@ fn delta_empty() {
 }
 
 impl RelabelCommand {
-    /// Parse and validate command tokens
     pub fn parse<'a>(input: &mut Tokenizer<'a>) -> Result<Option<Self>, Error<'a>> {
         let mut toks = input.clone();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,5 @@
 use crate::changelogs::ChangelogFormat;
 use crate::github::{GithubClient, Repository};
-use parser::command::relabel::{Label, LabelDelta, RelabelCommand};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::sync::{Arc, LazyLock, RwLock};
@@ -251,64 +250,10 @@ pub(crate) struct MentionsEntryConfig {
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields)]
 pub(crate) struct RelabelConfig {
     #[serde(default)]
     pub(crate) allow_unauthenticated: Vec<String>,
-    // alias identifier -> labels
-    #[serde(flatten)]
-    pub(crate) aliases: HashMap<String, RelabelAliasConfig>,
-}
-
-impl RelabelConfig {
-    pub(crate) fn retrieve_command_from_alias(&self, input: RelabelCommand) -> RelabelCommand {
-        let mut deltas = vec![];
-        if !self.aliases.is_empty() {
-            // parse all tokens: if one matches an alias, extract the labels
-            // else, it will assumed to be a valid label
-            for tk in input.0.into_iter() {
-                let name = tk.label() as &str;
-                if let Some(alias) = self.aliases.get(name) {
-                    let cmd = alias.to_command(matches!(tk, LabelDelta::Remove(_)));
-                    deltas.extend(cmd.0);
-                } else {
-                    deltas.push(tk);
-                }
-            }
-        }
-        RelabelCommand(deltas)
-    }
-}
-
-#[derive(Default, PartialEq, Eq, Debug, serde::Deserialize)]
-#[serde(rename_all = "kebab-case")]
-#[serde(deny_unknown_fields)]
-pub(crate) struct RelabelAliasConfig {
-    /// Labels to be added
-    pub(crate) add_labels: Vec<String>,
-    /// Labels to be removed
-    pub(crate) rem_labels: Vec<String>,
-}
-
-impl RelabelAliasConfig {
-    /// Translate a RelabelAliasConfig into a RelabelCommand for GitHub consumption
-    fn to_command(&self, inverted: bool) -> RelabelCommand {
-        let mut deltas = Vec::new();
-        let mut add_labels = &self.add_labels;
-        let mut rem_labels = &self.rem_labels;
-
-        // if the polarity of the alias is inverted, swap labels before parsing the command
-        if inverted {
-            std::mem::swap(&mut add_labels, &mut rem_labels);
-        }
-
-        for l in add_labels.iter() {
-            deltas.push(LabelDelta::Add(Label(l.into())));
-        }
-        for l in rem_labels.iter() {
-            deltas.push(LabelDelta::Remove(Label(l.into())));
-        }
-        RelabelCommand(deltas)
-    }
 }
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]
@@ -816,11 +761,11 @@ mod tests {
 
             [mentions."src/"]
             cc = ["@someone"]
-
+            
             [mentions."target/"]
             message = "This is a message."
             cc = ["@someone"]
-
+            
             [mentions."#[rustc_attr]"]
             type = "content"
             message = "This is a message."
@@ -890,7 +835,6 @@ mod tests {
             Config {
                 relabel: Some(RelabelConfig {
                     allow_unauthenticated: vec!["C-*".into()],
-                    aliases: HashMap::new()
                 }),
                 assign: Some(AssignConfig {
                     warn_non_default_branch: WarnNonDefaultBranchConfig::Simple(false),
@@ -1090,76 +1034,6 @@ mod tests {
     }
 
     #[test]
-    fn relabel_alias_config() {
-        let config = r#"
-            [relabel.to-stable]
-            add-labels = ["regression-from-stable-to-stable"]
-            rem-labels = ["regression-from-stable-to-beta", "regression-from-stable-to-nightly"]
-        "#;
-        let config = toml::from_str::<Config>(&config).unwrap();
-
-        let mut relabel_configs = HashMap::new();
-        relabel_configs.insert(
-            "to-stable".into(),
-            RelabelAliasConfig {
-                add_labels: vec!["regression-from-stable-to-stable".to_string()],
-                rem_labels: vec![
-                    "regression-from-stable-to-beta".to_string(),
-                    "regression-from-stable-to-nightly".to_string(),
-                ],
-            },
-        );
-
-        let expected_cfg = RelabelConfig {
-            allow_unauthenticated: vec![],
-            aliases: relabel_configs,
-        };
-
-        assert_eq!(config.relabel, Some(expected_cfg));
-    }
-
-    #[test]
-    fn relabel_alias() {
-        // [relabel.my-alias]
-        // add-labels = ["Alpha"]
-        // rem-labels = ["Bravo", "Charlie"]
-        let relabel_cfg = RelabelConfig {
-            allow_unauthenticated: vec![],
-            aliases: HashMap::from([(
-                "my-alias".to_string(),
-                RelabelAliasConfig {
-                    add_labels: vec!["Alpha".to_string()],
-                    rem_labels: vec!["Bravo".to_string(), "Charlie".to_string()],
-                },
-            )]),
-        };
-
-        // @triagebot label my-alias
-        let deltas = vec![LabelDelta::Add(Label("my-alias".into()))];
-        let new_input = relabel_cfg.retrieve_command_from_alias(RelabelCommand(deltas));
-        assert_eq!(
-            new_input,
-            RelabelCommand(vec![
-                LabelDelta::Add(Label("Alpha".into())),
-                LabelDelta::Remove(Label("Bravo".into())),
-                LabelDelta::Remove(Label("Charlie".into())),
-            ])
-        );
-
-        // @triagebot label -my-alias
-        let deltas = vec![LabelDelta::Remove(Label("my-alias".into()))];
-        let new_input = relabel_cfg.retrieve_command_from_alias(RelabelCommand(deltas));
-        assert_eq!(
-            new_input,
-            RelabelCommand(vec![
-                LabelDelta::Add(Label("Bravo".into())),
-                LabelDelta::Add(Label("Charlie".into())),
-                LabelDelta::Remove(Label("Alpha".into())),
-            ])
-        );
-    }
-
-    #[test]
     fn issue_links_uncanonicalized() {
         let config = r#"
             [issue-links]
@@ -1218,37 +1092,5 @@ Multi text body with ${mcp_issue} and ${mcp_title}
                 })
             })
         );
-    }
-
-    #[test]
-    fn relabel_new_config() {
-        let config = r#"
-            [relabel]
-            allow-unauthenticated = ["ABCD-*"]
-
-            [relabel.to-stable]
-            add-labels = ["regression-from-stable-to-stable"]
-            rem-labels = ["regression-from-stable-to-beta", "regression-from-stable-to-nightly"]
-        "#;
-        let config = toml::from_str::<Config>(&config).unwrap();
-
-        let mut relabel_configs = HashMap::new();
-        relabel_configs.insert(
-            "to-stable".into(),
-            RelabelAliasConfig {
-                add_labels: vec!["regression-from-stable-to-stable".to_string()],
-                rem_labels: vec![
-                    "regression-from-stable-to-beta".to_string(),
-                    "regression-from-stable-to-nightly".to_string(),
-                ],
-            },
-        );
-
-        let expected_cfg = RelabelConfig {
-            allow_unauthenticated: vec!["ABCD-*".to_string()],
-            aliases: relabel_configs,
-        };
-
-        assert_eq!(config.relabel, Some(expected_cfg));
     }
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -1339,6 +1339,9 @@ impl IssuesEvent {
 }
 
 #[derive(Debug, serde::Deserialize)]
+struct PullRequestEventFields {}
+
+#[derive(Debug, serde::Deserialize)]
 pub struct WorkflowRunJob {
     pub name: String,
     pub head_sha: String,


### PR DESCRIPTION
This reverts commit 154a7e764c3d9b9c405006053e67e4f6b3d75bfe.

I broke everything, see [Zulip](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/triagebot.20ignoring.20labeling.20commands.20in.20Clippy.20repo/near/546401069).

cc @Urgau 