### PR TITLE
Skip `@**triagebot**` when parsing Zulip command in a stream

### DIFF
--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -282,6 +282,16 @@ async fn handle_command<'a>(
                 continue;
             };
 
+            // Skip @**triagebot**
+            let cmd_index = cmd_index + 1;
+
+            // Error on unexpected end-of-line
+            if cmd_index >= words.len() {
+                return Ok(Some(
+                    "Error parsing command: unexpected end-of-line".to_string(),
+                ));
+            }
+
             let cmd = parse_cli::<StreamCommand, _>(words[cmd_index..].iter().copied())?;
             tracing::info!("command parsed to {cmd:?}");
 


### PR DESCRIPTION
cf. [#triagebot > MCP Playground for tracking issue triagebot#2204 @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/224082-triagebot/topic/MCP.20Playground.20for.20tracking.20issue.20triagebot.232204/near/546990970)