### PR TITLE
Post a user message when a command processing fails

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -422,6 +422,11 @@ macro_rules! command_handlers {
                                     if let Some(err) = err.downcast_mut::<UserError>() {
                                         errors.push(HandlerError::Message(std::mem::take(&mut err.0)));
                                     } else {
+                                        errors.push(HandlerError::Message(format!(
+                                            "`{}` handler unexpectedly failed in [this comment]({}): {err}",
+                                            stringify!($name),
+                                            event.html_url().expect("has html url"),
+                                        )));
                                         errors.push(HandlerError::Other(err.context(format!(
                                             "error when processing {} command handler",
                                             stringify!($name)


### PR DESCRIPTION
This PR adds a user message when a command handler unexpectedly fails with a link to the comment in question as well as a the header of error.

It's not perfect as it may leak unwanted information but it's better than silently failing.

It even works fairly well with `UnknownLabels`:
>**Error**: `shortcut` handler unexpectedly failed in [this comment](https://github.com/todo/pull/1#issuecomment-3445023213): Unknown labels: S-waiting-on-review
>
>Please file an issue on GitHub at [triagebot](https://github.com/rust-lang/triagebot) if there's a problem with this bot, or reach out on [#triagebot](https://rust-lang.zulipchat.com/#narrow/channel/224082-triagebot) on Zulip.
