### PR TITLE
Add `r? me` as an alias for self-assignment

### DIFF
--- a/src/handlers/assign.rs
+++ b/src/handlers/assign.rs
@@ -803,6 +803,13 @@ async fn find_reviewer_from_names(
         return Ok(ReviewerSelection::from_name(name.clone()));
     }
 
+    // Allow `me` as an alias for self-assign, which is always allowed.
+    if let [name] = names
+        && name == "me"
+    {
+        return Ok(ReviewerSelection::from_name(requested_by.to_string()));
+    }
+
     let candidates =
         candidate_reviewers_from_names(db, workqueue, teams, config, issue, names).await?;
     assert!(!candidates.is_empty());


### PR DESCRIPTION
Suggested at [#t-compiler/contrib-private > Encouraing more compiler reviewer on rotation? @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/244344-t-compiler.2Fcontrib-private/topic/Encouraing.20more.20compiler.20reviewer.20on.20rotation.3F/near/547714257)