### PR TITLE
Add missing newlines when doing word-highlighting in our range-diff

### DIFF
--- a/src/gh_range_diff.rs
+++ b/src/gh_range_diff.rs
@@ -564,6 +564,13 @@ impl UnifiedDiffPrinter for HtmlDiffPrinter<'_> {
                 )?;
             }
 
+            // Add potentially missing new-line after the last before diff line
+            if let Some(&last) = before.last() {
+                if !self.0[last].ends_with('\n') {
+                    writeln!(f)?;
+                }
+            }
+
             // Then process all after lines
             for (diff, input) in &diffs_and_inputs {
                 self.handle_hunk_line(
@@ -573,6 +580,13 @@ impl UnifiedDiffPrinter for HtmlDiffPrinter<'_> {
                         (input.interner[*a_token], diff.is_added(a_pos as u32))
                     }),
                 )?;
+            }
+
+            // Add potentially missing new-line after the last after diff line
+            if let Some(&last) = after.last() {
+                if !self.0[last].ends_with('\n') {
+                    writeln!(f)?;
+                }
             }
         } else {
             // Can't do word-highlighting, simply print each line.


### PR DESCRIPTION
This PR adds missing newlines at the end of the before/after diff when doing word-highlighting in our range-diff.

We were already adding missing newlines when not doing word-highlighting, now we do it in both cases.

| Before | After |
| ------ | ----- |
| <img width="715" height="455" alt="image" src="https://github.com/user-attachments/assets/cdfd1412-70b4-44cd-87d8-7f528045f269" /> | <img width="772" height="470" alt="image" src="https://github.com/user-attachments/assets/46cb2d8b-c16f-4f24-9deb-9d3d57ca511d" /> |