### PR TITLE
Avoid trailing new-lines between each line of the table in our GHA logs viewer

### DIFF
--- a/src/gha_logs.rs
+++ b/src/gha_logs.rs
@@ -216,7 +216,11 @@ body {{
   font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
   background: #0C0C0C;
   color: #CCC;
+}}
+table {{
   white-space: pre;
+  table-layout: fixed;
+  width: 100%;
 }}
 .timestamp {{
   color: #848484;
@@ -358,7 +362,7 @@ body {{
     </script>
 </head>
 <body>
-<table style="table-layout: fixed; width: 100%">
+<table>
     <colgroup>
         <col style="width: 29ch">
         <col style="width: 100%">


### PR DESCRIPTION
This PR fixes https://github.com/rust-lang/triagebot/issues/2223, which is triggered by having trailing new-lines between each line of the table, ie between each `<tr>`.

This is fixed by making our regex capture the new-lines instead of matching on them, this is done by replacing `$` by `(\r?\n)?`. 

The second commit fixes the trailing new-lines before and after our `<table>` to take effect by moving the `white-space: pre` to the `<table>` instead of the whole `<html>` body.

Best reviewed commit by commit.

