### PR TITLE
Lock major change issue after it as been accepted

### DIFF
--- a/src/handlers/major_change.rs
+++ b/src/handlers/major_change.rs
@@ -1,6 +1,7 @@
 use std::fmt::Display;
 
 use crate::errors::user_error;
+use crate::github::LockReason;
 use crate::jobs::Job;
 use crate::utils::is_issue_under_rfcbot_fcp;
 use crate::zulip::api::Recipient;
@@ -781,6 +782,10 @@ As the automated representative, I want to express gratitude to the author for t
         .close(&ctx.github)
         .await
         .context("unable to close the issue")?;
+    issue
+        .lock(&ctx.github, Some(LockReason::Resolved))
+        .await
+        .context("unable to lock the major change issue")?;
 
     Ok(())
 }


### PR DESCRIPTION
Some people continue to post on closed major change despite our messages not to do so.

Let's be more decisive and lock the issue once the major change has been accepted (we tried locking from the started but that had to be reverted https://github.com/rust-lang/triagebot/pull/1876).

cf. https://github.com/rust-lang/compiler-team/issues/932#issuecomment-3625484531
cc @apiraino 