### PR TITLE
Store tokens as secret strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2451,6 +2451,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
+ "serde",
  "zeroize",
 ]
 
@@ -3202,6 +3203,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rust_team_data",
+ "secrecy",
  "serde",
  "serde_json",
  "serde_path_to_error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ imara-diff = "0.2.0"
 pulldown-cmark-escape = "0.11.0"
 axum-extra = { version = "0.10.1", default-features = false }
 unicode-segmentation = "1.12.0"
+secrecy = { version = "0.10", features = ["serde"] }
 
 [dependencies.serde]
 version = "1"

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -64,7 +64,7 @@ impl TestContext {
 
         let octocrab = Octocrab::builder().build().unwrap();
         let github = GithubClient::new(
-            "gh-test-fake-token".to_string(),
+            "gh-test-fake-token".into(),
             "https://api.github.com".to_string(),
             "https://api.github.com/graphql".to_string(),
             "https://raw.githubusercontent.com".to_string(),


### PR DESCRIPTION
To avoid leaking them into logs by accident.

@apiraino found out about tokens being leaked into logs.

r? @apiraino
