### PR TITLE
Normalize Windows Carriage Return to simple Line Feed in GHA logs

### DIFF
--- a/src/gha_logs.rs
+++ b/src/gha_logs.rs
@@ -275,18 +275,19 @@ table {{
         // 1. Tranform the ANSI escape codes to HTML
         var html = ansi_up.ansi_to_html(logs);
 
-        // 2. Remove UTF-8 useless BOM
+        // 2. Remove UTF-8 useless BOM and Windows Carriage Return
         html = html.replace(/^\uFEFF/gm, "");
+        html = html.replace(/\r\n/g, "\n");
         
         // 3. Transform each log lines that doesn't start with a timestamp into a row where everything is in the second column
-        const untsRegex = /^(?!\d{{4}}-\d{{2}}-\d{{2}}T\d{{2}}:\d{{2}}:\d{{2}}\.\d+Z)(.*)(\r?\n)?/gm;
+        const untsRegex = /^(?!\d{{4}}-\d{{2}}-\d{{2}}T\d{{2}}:\d{{2}}:\d{{2}}\.\d+Z)(.*)(\n)?/gm;
         html = html.replace(untsRegex, (match, log) => 
             `<tr><td></td><td>${{log}}</td></tr>`
         );
         
         // 3.b Transform each log lines that start with a timestamp in a row with two columns and make the timestamp be a
         //  self-referencial anchor.
-        const tsRegex = /^(\d{{4}}-\d{{2}}-\d{{2}}T\d{{2}}:\d{{2}}:\d{{2}}\.\d+Z) (.*)(\r?\n)?/gm;
+        const tsRegex = /^(\d{{4}}-\d{{2}}-\d{{2}}T\d{{2}}:\d{{2}}:\d{{2}}\.\d+Z) (.*)(\n)?/gm;
         html = html.replace(tsRegex, (match, ts, log) => 
             `<tr><td><a id="${{ts}}" href="#${{ts}}" class="timestamp">${{ts}}</a></td><td>${{log}}</td></tr>`
         );


### PR DESCRIPTION
As can be seen currently on https://triage.rust-lang.org/gha-logs/rust-lang/rust/57767792533, the timestamps are not split up, but even worse we have create empty lines in the table.

This seems to be due to JavaScript treating `\r\n` as two lines, which break our logic.

This PR proposes that we normalize them away be using the normal standard Line Feed `\n`.

<img width="1688" height="689" alt="image" src="https://github.com/user-attachments/assets/b1064139-ede0-4440-bf60-3129fa77fc6b" />
