### PR TITLE
Add highlighting of log lines with URL support

### DIFF
--- a/src/gha_logs.rs
+++ b/src/gha_logs.rs
@@ -225,6 +225,11 @@ table {{
   white-space: pre;
   table-layout: fixed;
   width: 100%;
+  border-spacing: 0;
+  border-collapse: collapse;
+}}
+tr.selected {{
+  background: #1d1a16; /* similar to GitHub’s yellow-ish */
 }}
 .timestamp {{
   color: #848484;


### PR DESCRIPTION
This PR adds highlighting of selected log lines, similar to GitHub's highlighting of code.

Support is not only done with Normal click and Shift+click, but also with a custom `#anchor`, in the form of `L{timestamp}` (for a single line) or `L{timestamp}-L{timestamp}` (for multi line).

<img width="1186" height="462" alt="image" src="https://github.com/user-attachments/assets/49f51cc5-681f-4891-91ff-1b3ef2354344" />
