### PR TITLE
Fix `[mentions]` glob matching to not match partial directories

### DIFF
--- a/src/handlers/mentions.rs
+++ b/src/handlers/mentions.rs
@@ -430,6 +430,36 @@ mod tests {
     }
 
     #[test]
+    fn entry_submodule_and_normal_dir_modified() {
+        assert_eq!(
+            modified_paths_matches(
+                &[
+                    Path::new("src/tools/cargo"),
+                    Path::new("src/tools/cargotest")
+                ],
+                "src/tools/cargo{,test}"
+            ),
+            vec![
+                PathBuf::from("src/tools/cargo"),
+                PathBuf::from("src/tools/cargotest")
+            ]
+        );
+        assert_eq!(
+            modified_paths_matches(
+                &[
+                    Path::new("src/tools/cargo"),
+                    Path::new("src/tools/cargotest")
+                ],
+                "src/tools/cargo*"
+            ),
+            vec![
+                PathBuf::from("src/tools/cargo"),
+                PathBuf::from("src/tools/cargotest")
+            ]
+        );
+    }
+
+    #[test]
     fn entry_submodule_modified_with_trailing_slash() {
         assert_eq!(
             modified_paths_matches(


### PR DESCRIPTION
This PR fixes our `[mentions]` glob matching to not match on partial directories.

This is particularly relevant if an entry is `src/tools/cargo` and the modified paths contains `src/tools/cargotest` which shouldn't be considered to be matching (as per `Path::starts_with` rules).

Reported at [#triagebot > Mentions glob matching](https://rust-lang.zulipchat.com/#narrow/channel/224082-triagebot/topic/Mentions.20glob.20matching/with/567093226)

cc @jieyouxu @tgross35