### PR TITLE
repo-aware team-stats queries

### DIFF
--- a/src/zulip/commands.rs
+++ b/src/zulip/commands.rs
@@ -45,6 +45,11 @@ pub enum ChatCommand {
     TeamStats {
         /// Name of the team to query.
         name: String,
+        /// Name of the repository that is specifically being queried (e.g. `rust-lang/rust`)
+        ///
+        /// Someone might be on the review queue in the triagebot database but not listed in
+        /// `triagebot.toml` so in practice isn't getting reviews.
+        repo: Option<String>,
     },
 }
 


### PR DESCRIPTION
`team-stats` isn't especially useful as it doesn't consider whether any particular reviewer is in the `adhoc-groups` for a team for a given repository. This means that in practice, most of a team can be considered on rotation even when the majority aren't actually on rotation.

Adds a `team-stats <team> <repo>` variant of the `team-stats` Zulip command that considers the `adhoc-groups` of the relevant team in the repository requested.

I haven't tested this because it's tricky to receive Zulip webhooks on my work machine.