### PR TITLE
Enable using a test git repository when sending commands from Zulip

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -32,6 +32,12 @@ GITHUB_WEBHOOK_SECRET=MUST_BE_CONFIGURED
 # Authenticates inbound webhooks from Github
 # ZULIP_WEBHOOK_SECRET=xxx
 
+# Which GitHub repository should be used when triagebot executes commands sent from Zulip
+# For testing purposes, you can use another repository
+# Defaults: "rust-lang" and "rust"
+# MAIN_GH_REPO_OWNER="rust-lang"
+# MAIN_GH_REPO_NAME="rust"
+
 # Use another endpoint to retrieve teams of the Rust project (useful for local testing)
 # default: https://team-api.infra.rust-lang.org/v1
 # TEAMS_API_URL=http://localhost:8080

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -376,8 +376,8 @@ async fn accept_decline_backport(
 
     // Repository owner and name are hardcoded
     // This command is only used in this repository
-    let repo_owner = "rust-lang";
-    let repo_name = "rust";
+    let repo_owner = std::env::var("MAIN_GH_REPO_OWNER").unwrap_or("rust-lang".to_string());
+    let repo_name = std::env::var("MAIN_GH_REPO_NAME").unwrap_or("rust".to_string());
 
     // TODO: factor out the Zulip "URL encoder" to make it practical to use
     let zulip_send_req = crate::zulip::MessageApiRequest {


### PR DESCRIPTION
This adds two environment variables (by default pointing to "rust-lang/rust") allowing to set a different git repository as destination for those Zulip commands interacting with a git repo (example: setting labels on issues/PRs).

The idea is to avoid using our production git repository for testing stuff (which I did and ended up applying labelks to random issues on r-l/r :sweat_smile: )

r? @Kobzol 

This is just a small proposal, it makes my life easier when testing messages bouncing from GH to Zulip and viceversa. But I'm totally fine discarding this change if you are not happy with too many env vars around :)

Thanks