### PR TITLE
Remove "new issue" labels when the issue is closed

### DIFF
--- a/src/handlers/autolabel.rs
+++ b/src/handlers/autolabel.rs
@@ -146,10 +146,19 @@ pub(super) async fn parse_input(
                         name: label.to_owned(),
                     });
                 }
-            } else if cfg.new_issue && event.action == IssuesAction::Opened {
-                autolabels.push(Label {
-                    name: label.to_owned(),
-                });
+            } else {
+                if cfg.new_issue && event.action == IssuesAction::Opened {
+                    autolabels.push(Label {
+                        name: label.to_owned(),
+                    });
+                }
+
+                // If an issue is closed, remove all the "new issue" labels.
+                if cfg.new_issue && event.action == IssuesAction::Closed {
+                    to_remove.push(Label {
+                        name: label.to_owned(),
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
This PR updates the `[autolabel]` handler to handle `new_issue` labels the same way we handle `new_pr` and `new_draft` modifiers by removing the label when the issue is closed.

cf. https://rust-lang.zulipchat.com/#narrow/channel/224082-triagebot/topic/remove.20label.20on.20issue.20close.3F
cc @jieyouxu 