### PR TITLE
Fix `/gh-comments` de-serialization of the review state

### DIFF
--- a/src/gh_comments.rs
+++ b/src/gh_comments.rs
@@ -497,7 +497,7 @@ fn write_review_as_html(
                 r##"<svg class="octicon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z"></path></svg>"##,
             )
         }
-        GitHubReviewState::RequestChanges => {
+        GitHubReviewState::ChangesRequested => {
             // https://primer.github.io/octicons/file-diff-16
             (
                 "badge-danger",

--- a/src/github.rs
+++ b/src/github.rs
@@ -3338,7 +3338,7 @@ pub enum GitHubGraphQlReactionContent {
 pub enum GitHubReviewState {
     Commented,
     Approved,
-    RequestChanges,
+    ChangesRequested,
     Dismissed,
 }
 


### PR DESCRIPTION
It's `CHANGES_REQUESTED`[^1], not `REQUEST_CHANGES`.

Can be tested with https://github.com/rust-lang/rust/pull/140560.

[^1]: Look for `PullRequestReviewState` in https://docs.github.com/en/graphql/overview/public-schema.