### PR TITLE
Add `pr_merged` option in `[autolabel]` to label PRs after merged

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -354,6 +354,8 @@ pub(crate) struct AutolabelLabelConfig {
     pub(crate) new_issue: bool,
     #[serde(default)]
     pub(crate) new_draft: bool,
+    #[serde(default)]
+    pub(crate) pr_merged: bool,
 }
 
 #[derive(PartialEq, Eq, Debug, serde::Deserialize)]
@@ -1247,5 +1249,35 @@ Multi text body with ${mcp_issue} and ${mcp_title}
         };
 
         assert_eq!(config.relabel, Some(expected_cfg));
+    }
+
+    #[test]
+    fn autolabel() {
+        let config = r#"
+            [autolabel."needs-relnotes-triage"]
+            pr_merged = true
+        "#;
+        let config = toml::from_str::<Config>(&config).unwrap();
+        assert_eq!(
+            config.autolabel,
+            Some(AutolabelConfig {
+                labels: {
+                    let mut hm = HashMap::new();
+                    hm.insert(
+                        "needs-relnotes-triage".to_string(),
+                        AutolabelLabelConfig {
+                            trigger_labels: vec![],
+                            exclude_labels: vec![],
+                            trigger_files: vec![],
+                            new_pr: false,
+                            new_issue: false,
+                            new_draft: false,
+                            pr_merged: true,
+                        },
+                    );
+                    hm
+                }
+            })
+        );
     }
 }

--- a/src/handlers/autolabel.rs
+++ b/src/handlers/autolabel.rs
@@ -100,6 +100,7 @@ pub(super) async fn parse_input(
 
                 let is_opened =
                     matches!(event.action, IssuesAction::Opened | IssuesAction::Reopened);
+                let is_closed = matches!(event.action, IssuesAction::Closed);
 
                 // Treat the following situations as a "new PR":
                 // 1) PRs that were (re)opened and are not draft
@@ -113,12 +114,20 @@ pub(super) async fn parse_input(
                 let is_opened_as_draft = is_opened && event.issue.draft;
                 let is_converted_to_draft = event.action == IssuesAction::ConvertedToDraft;
 
+                // Treat the following situations as a "pr merged":
+                // 1) PRs that were closed and have the merged status
+                let is_closed_as_merged = is_closed && event.issue.merged;
+
                 #[expect(clippy::if_same_then_else, reason = "suggested code looks ugly")]
                 if cfg.new_pr && (is_opened_non_draft || is_ready_for_review) {
                     autolabels.push(Label {
                         name: label.to_owned(),
                     });
                 } else if cfg.new_draft && (is_opened_as_draft || is_converted_to_draft) {
+                    autolabels.push(Label {
+                        name: label.to_owned(),
+                    });
+                } else if cfg.pr_merged && is_closed_as_merged {
                     autolabels.push(Label {
                         name: label.to_owned(),
                     });


### PR DESCRIPTION
As requested in https://rust-lang.zulipchat.com/#narrow/channel/224082-triagebot/topic/On-merge.20label.3F, this PR adds a new option for `[autolabel]`: `pr_merged` label PRs after merged.

```toml
[autolabel."needs-relnotes-triage"]
pr_merged = true
```

*Note that I haven't tested it but I don't see why it wouldn't work.*

cc @jieyouxu @ytmimi