### PR TITLE
Add self-contained export option to our GitHub comments viewer

### DIFF
--- a/src/gh_comments/self_contained.js
+++ b/src/gh_comments/self_contained.js
@@ -1,0 +1,97 @@
+document.addEventListener('DOMContentLoaded', function() {
+  document.getElementById('gh-comments-export-btn').addEventListener('click', async () => {
+    try {
+      // Generate the a self-contained version of the current webpage
+      const htmlContent = await generateSelfContainedHTML();
+
+      // Trigger a download of the HTML content
+      triggerUserDownload(htmlContent, `gh-comments-${ISSUE_ID}-export-${new Date().toISOString().slice(0,10)}.html`);
+    } catch (e) {
+      console.log(e);
+      alert(`Error: ${e.message}`);
+    }
+  });
+});
+
+async function generateSelfContainedHTML() {
+  // Clone current DOM into a new document
+  const doc = new DOMParser().parseFromString(document.documentElement.outerHTML, 'text/html');
+
+  // Remove all elements with the data-to-remove-on-export attribute
+  const dataElementsToRemove = doc.querySelectorAll('[data-to-remove-on-export]');
+  dataElementsToRemove.forEach(el => el.remove());
+  
+  // Remove all elements <link rel="stylesheet"> attribute
+  const linkElementsToRemove = doc.querySelectorAll('link[rel="stylesheet"]');
+  linkElementsToRemove.forEach(el => el.remove());
+
+  // Inline styles and images
+  inlineStyles(doc);
+  await inlineImages(doc);
+
+  return `<!DOCTYPE html>${doc.documentElement.outerHTML}`;
+}
+
+function inlineStyles(doc) {
+  const styleSheets = [...document.styleSheets];
+
+  for (const sheet of styleSheets) {
+    const rules = sheet.cssRules;
+    if (!rules) continue;
+
+    // Collect all CSS text from this stylesheet
+    let cssText = '';
+    for (const rule of rules) {
+      cssText += rule.cssText + '\n';
+    }
+
+    // Create an inline <style> using the collected rules
+    const style = doc.createElement('style');
+    style.textContent = cssText;
+
+    doc.head.appendChild(style);
+  }
+}
+
+async function inlineImages(doc) {
+  const imgs = Array.from(doc.querySelectorAll('img[src]'));
+  await Promise.all(imgs.map(async img => {
+    const src = img.getAttribute('src');
+    if (src.startsWith('data:')) return;
+    
+    // Use the original document’s image size (not the cloned doc, as it's not render)
+    const originalImg = document.querySelector(`img[src="${src}"]`);
+    const cs = originalImg ? window.getComputedStyle(originalImg) : {};
+    const w = Math.floor(parseFloat(cs.width) || originalImg?.width || 0) || 0;
+    const h = Math.floor(parseFloat(cs.height) || originalImg?.height || 0) || 0;
+
+    // Fetch the image, compress it and assign it to the img element as a data: URI    
+    img.src = await new Promise((resolve, reject) => {
+      const tempImg = new Image();
+      tempImg.crossOrigin = 'anonymous';
+      tempImg.onload = () => {
+        const canvas = document.createElement('canvas');
+        canvas.width = w || tempImg.width;
+        canvas.height = h || tempImg.height;
+        canvas.getContext('2d').drawImage(tempImg, 0, 0, canvas.width, canvas.height);
+        resolve(canvas.toDataURL('image/png'));
+      };
+      tempImg.onerror = reject;
+      tempImg.src = src;
+    });
+  }));
+}
+
+function triggerUserDownload(content, filename) {
+  const blob = new Blob([content], { type: 'text/html;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,6 +246,10 @@ async fn run_server(addr: SocketAddr) -> anyhow::Result<()> {
             triagebot::gh_comments::MARKDOWN_URL,
             get(triagebot::gh_comments::markdown_css),
         )
+        .route(
+            triagebot::gh_comments::SELF_CONTAINED_URL,
+            get(triagebot::gh_comments::self_contained_js),
+        )
         .merge(protected)
         .nest("/agenda", agenda)
         .route("/bors-commit-list", get(triagebot::bors::bors_commit_list))


### PR DESCRIPTION
This PR adds an "Export" button to our GitHub comments viewer in order to be able to save a conversation (issue or PR) at a point in time.

The exported HTML is self-contained (apart from the favicon), it contains all the stylesheets, images and javascript we use. The images are compressed.

cf. [#triagebot > Feature request: conversation snapshotting](https://rust-lang.zulipchat.com/#narrow/channel/224082-triagebot/topic/Feature.20request.3A.20conversation.20snapshotting/with/572469188)