### PR TITLE
Handle issue closed state reason in our GitHub comments viewer

### DIFF
--- a/src/gh_comments/style.css
+++ b/src/gh_comments/style.css
@@ -13,6 +13,7 @@
     --bg-success: #1f883d;
     --bg-danger: #cf222e;
     --bg-done: #8250df;
+    --bg-neutral: #59636e;
     --fg-default: #24292f;
     --fg-muted: #57606a;
     --fg-accent: #0969da;
@@ -23,6 +24,7 @@
     :root {
         --bg-default: #0d1117;
         --bg-muted: #161b22;
+        --bg-neutral: #656c76;
         --fg-default: #e6edf3;
         --fg-muted: #8b949e;
         --fg-accent: #58a6ff;
@@ -212,6 +214,11 @@ details:not([open]) > .review-thread-header {
 .badge-danger {
     color: white;
     background-color: var(--bg-danger);
+}
+
+.badge-neutral {
+    color: white;
+    background-color: var(--bg-neutral);
 }
 
 .octicon {

--- a/src/github.rs
+++ b/src/github.rs
@@ -2975,6 +2975,7 @@ query ($owner: String!, $repo: String!, $issueNumber: Int!, $commentsCursor: Str
       ... on Issue {
         url
         state
+        stateReason
         title
         titleHTML
         bodyHTML
@@ -3331,6 +3332,8 @@ pub struct GitHubIssueWithComments {
     #[serde(rename = "bodyHTML")]
     pub body_html: String,
     pub state: GitHubIssueState,
+    #[serde(rename = "stateReason")]
+    pub state_reason: Option<GitHubIssueStateReason>,
     pub url: String,
     pub author: Option<GitHubSimplifiedAuthor>,
     #[serde(rename = "createdAt")]
@@ -3493,6 +3496,14 @@ pub enum GitHubIssueState {
     Open,
     Closed,
     Merged,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum GitHubIssueStateReason {
+    Completed,
+    Duplicate,
+    NotPlanned,
 }
 
 #[derive(Debug, serde::Deserialize)]


### PR DESCRIPTION
Currently the closed state is represented the same for issue and PR, but that's not accurate. A closed issue has three possible reason (completed, duplicated, not planned).

This PR handles those three states and displays the same colors as GitHub.

- Closed as completed (http://localhost:8000/gh-comments/rust-lang/rust/issues/82450)
  <img width="980" height="177" alt="image" src="https://github.com/user-attachments/assets/a6551d0c-d2e8-4765-ac89-ccb637268f92" />
- Closed as not planned (http://localhost:8000/gh-comments/rust-lang/rust/issues/152078)
  <img width="980" height="100" alt="image" src="https://github.com/user-attachments/assets/baf317d4-0e35-45eb-ada7-2bdba9a16088" />
- Closed as duplicate (http://localhost:8000/gh-comments/rust-lang/rust/issues/152177)
  <img width="980" height="143" alt="image" src="https://github.com/user-attachments/assets/6871976c-97e2-4b00-b76d-0860eb985fc8" />
- PR closed (http://localhost:8000/gh-comments/rust-lang/rust/issues/152307)
  <img width="980" height="96" alt="image" src="https://github.com/user-attachments/assets/ef2928cb-e3e5-4bf1-b6d3-95df8dd9242c" />