### PR TITLE
Add "View all comments" link feature

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -429,7 +429,7 @@ pub struct Issue {
     pub draft: bool,
 
     /// Number of comments
-    pub comments: Option<i32>,
+    pub comments: Option<u32>,
 
     /// The API URL for discussion comments.
     ///

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -46,6 +46,7 @@ pub mod rustc_commits;
 mod shortcut;
 mod transfer;
 pub mod types_planning_updates;
+mod view_all_comments_link;
 
 pub struct Context {
     pub github: GithubClient,
@@ -143,6 +144,20 @@ pub async fn handle(ctx: &Context, host: &str, event: &Event) -> Vec<HandlerErro
         }
     };
 
+    let view_all_comments_link = async {
+        if let Some(view_all_comments_config) = config
+            .as_ref()
+            .ok()
+            .and_then(|c| c.view_all_comments.as_ref())
+        {
+            view_all_comments_link::handle(ctx, event, host, view_all_comments_config)
+                .await
+                .map_err(|e| HandlerError::Other(e.context("view_all_comments handler failed")))
+        } else {
+            Ok(())
+        }
+    };
+
     let relnotes = async {
         relnotes::handle(ctx, event)
             .await
@@ -228,6 +243,7 @@ pub async fn handle(ctx: &Context, host: &str, event: &Event) -> Vec<HandlerErro
         rustc_commits,
         milestone_prs,
         rendered_link,
+        view_all_comments,
         relnotes,
         bot_pull_requests,
         review_submitted,
@@ -242,6 +258,7 @@ pub async fn handle(ctx: &Context, host: &str, event: &Event) -> Vec<HandlerErro
         rustc_commits,
         milestone_prs,
         rendered_link,
+        view_all_comments_link,
         relnotes,
         bot_pull_requests,
         review_submitted,
@@ -258,6 +275,7 @@ pub async fn handle(ctx: &Context, host: &str, event: &Event) -> Vec<HandlerErro
         rustc_commits,
         milestone_prs,
         rendered_link,
+        view_all_comments,
         relnotes,
         bot_pull_requests,
         review_submitted,

--- a/src/handlers/view_all_comments_link.rs
+++ b/src/handlers/view_all_comments_link.rs
@@ -1,0 +1,72 @@
+use anyhow::Context as _;
+
+use crate::{
+    config::ViewAllCommentsConfig,
+    github::{Event, Issue},
+    handlers::Context,
+};
+
+// Based on some crude experiments at around 25 events in timelines GitHub
+// starts being lazy and shows it's "Load more" button.
+//
+// Unfortunately the webhook don't give us the number of timeline events
+// but we get do the get number of comments (without doing any API calls!).
+//
+// So we approximate to 20 comments (+5 events) the minimum threashold.
+const DEFAULT_THRESHOLD: u32 = 20;
+
+pub(super) async fn handle(
+    ctx: &Context,
+    event: &Event,
+    host: &str,
+    config: &ViewAllCommentsConfig,
+) -> anyhow::Result<()> {
+    let Some(issue) = event.issue() else {
+        return Ok(());
+    };
+
+    if event.user().login == ctx.username {
+        // just in case, ignore our own events on issues/PRs
+        return Ok(());
+    }
+
+    if config.exclude_issues && !issue.is_pr() {
+        return Ok(());
+    }
+
+    if config.exclude_prs && issue.is_pr() {
+        return Ok(());
+    }
+
+    if issue.comments.unwrap_or(0) < config.threshold.unwrap_or(DEFAULT_THRESHOLD) {
+        return Ok(());
+    }
+
+    add_comments_link(ctx, issue, host).await
+}
+
+async fn add_comments_link(ctx: &Context, issue: &Issue, host: &str) -> anyhow::Result<()> {
+    let repo_name = issue.repository().full_repo_name();
+    let type_ = if issue.is_pr() { "pull" } else { "issues" };
+    let issue_number = issue.number;
+
+    let comments_link = format!(
+        "[View all comments](https://{host}/gh-comments/{repo_name}/{type_}/{issue_number})"
+    );
+
+    if !issue.body.contains("[View all comments](") {
+        // add comments link to the start of the body
+        let new_body = format!("{comments_link}\n\n{}", issue.body);
+
+        tracing::info!(
+            r#"adding "View all comments" link to {repo_name}#{}"#,
+            issue.number
+        );
+        issue
+            .edit_body(&ctx.github, &new_body)
+            .await
+            .context("failed to edit the body")?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This PR adds a new handler that will automatically add a "View all comments" link to the body of an issue or PR once it has more than 20 (by default) comments on it, and redirect to our `/gh-comments` endpoint.

```toml
[view-all-comments]
threshold = 25
exclude-prs = true
```

cf. [#triagebot > Our own GitHub issue comments viewer @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/224082-triagebot/topic/Our.20own.20GitHub.20issue.20comments.20viewer/near/572837289)