### PR TITLE
Fix case label removal

### DIFF
--- a/src/github/issue.rs
+++ b/src/github/issue.rs
@@ -965,7 +965,6 @@ impl IssueRepository {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::Label;
@@ -973,13 +972,19 @@ mod tests {
     #[test]
     fn test_case_insensitive_label_matching() {
         let issue_labels = vec![
-            Label { name: "E-needs-mcve".to_string() },
-            Label { name: "T-compiler".to_string() },
+            Label {
+                name: "E-needs-mcve".to_string(),
+            },
+            Label {
+                name: "T-compiler".to_string(),
+            },
         ];
 
         // Simulate what remove_labels does with the fix
         let to_remove = vec![
-            Label { name: "e-needs-mcve".to_string() }, // lowercase version
+            Label {
+                name: "e-needs-mcve".to_string(),
+            }, // lowercase version
         ];
 
         let matched: Vec<Label> = to_remove
@@ -992,6 +997,11 @@ mod tests {
             })
             .collect();
 
-        assert_eq!(matched, vec![Label { name: "E-needs-mcve".to_string() }]);
+        assert_eq!(
+            matched,
+            vec![Label {
+                name: "E-needs-mcve".to_string()
+            }]
+        );
     }
 }

--- a/src/github/issue.rs
+++ b/src/github/issue.rs
@@ -267,11 +267,16 @@ impl Issue {
         log::info!("remove_labels from {}: {:?}", self.global_id(), labels);
 
         // Don't try to remove labels not already present on this issue.
+        // Use case-insensitive comparison to match GitHub's behavior when adding labels.
         let labels = labels
             .into_iter()
-            .filter(|l| self.labels().contains(l))
+            .filter_map(|l| {
+                self.labels()
+                    .iter()
+                    .find(|existing| existing.name.to_lowercase() == l.name.to_lowercase())
+                    .cloned()
+            })
             .collect::<Vec<_>>();
-
         log::info!(
             "remove_labels: {} filtered to {:?}",
             self.global_id(),

--- a/src/github/issue.rs
+++ b/src/github/issue.rs
@@ -964,3 +964,34 @@ impl IssueRepository {
         Ok(permission)
     }
 }
+
+
+#[cfg(test)]
+mod tests {
+    use super::Label;
+
+    #[test]
+    fn test_case_insensitive_label_matching() {
+        let issue_labels = vec![
+            Label { name: "E-needs-mcve".to_string() },
+            Label { name: "T-compiler".to_string() },
+        ];
+
+        // Simulate what remove_labels does with the fix
+        let to_remove = vec![
+            Label { name: "e-needs-mcve".to_string() }, // lowercase version
+        ];
+
+        let matched: Vec<Label> = to_remove
+            .into_iter()
+            .filter_map(|l| {
+                issue_labels
+                    .iter()
+                    .find(|existing| existing.name.to_lowercase() == l.name.to_lowercase())
+                    .cloned()
+            })
+            .collect();
+
+        assert_eq!(matched, vec![Label { name: "E-needs-mcve".to_string() }]);
+    }
+}

--- a/src/github/issue.rs
+++ b/src/github/issue.rs
@@ -258,6 +258,11 @@ impl Issue {
             .context("failed to edit review comment")?;
         Ok(comment)
     }
+    fn find_label_case_insensitive<'a>(labels: &'a [Label], name: &str) -> Option<&'a Label> {
+        labels
+            .iter()
+            .find(|l| l.name.to_lowercase() == name.to_lowercase())
+    }
 
     pub async fn remove_labels(
         &self,
@@ -270,12 +275,7 @@ impl Issue {
         // Use case-insensitive comparison to match GitHub's behavior when adding labels.
         let labels = labels
             .into_iter()
-            .filter_map(|l| {
-                self.labels()
-                    .iter()
-                    .find(|existing| existing.name.to_lowercase() == l.name.to_lowercase())
-                    .cloned()
-            })
+            .filter_map(|l| Self::find_label_case_insensitive(self.labels(), &l.name).cloned())
             .collect::<Vec<_>>();
         log::info!(
             "remove_labels: {} filtered to {:?}",
@@ -967,8 +967,7 @@ impl IssueRepository {
 
 #[cfg(test)]
 mod tests {
-    use super::Label;
-
+    use super::{Issue, Label};
     #[test]
     fn test_case_insensitive_label_matching() {
         let issue_labels = vec![
@@ -980,28 +979,23 @@ mod tests {
             },
         ];
 
-        // Simulate what remove_labels does with the fix
-        let to_remove = vec![
-            Label {
-                name: "e-needs-mcve".to_string(),
-            }, // lowercase version
-        ];
-
-        let matched: Vec<Label> = to_remove
-            .into_iter()
-            .filter_map(|l| {
-                issue_labels
-                    .iter()
-                    .find(|existing| existing.name.to_lowercase() == l.name.to_lowercase())
-                    .cloned()
+        assert_eq!(
+            Issue::find_label_case_insensitive(&issue_labels, "e-needs-mcve"),
+            Some(&Label {
+                name: "E-needs-mcve".to_string()
             })
-            .collect();
+        );
 
         assert_eq!(
-            matched,
-            vec![Label {
+            Issue::find_label_case_insensitive(&issue_labels, "E-NEEDS-MCVE"),
+            Some(&Label {
                 name: "E-needs-mcve".to_string()
-            }]
+            })
+        );
+
+        assert_eq!(
+            Issue::find_label_case_insensitive(&issue_labels, "non-existent"),
+            None
         );
     }
 }


### PR DESCRIPTION
 So like when removing labels using @rustbot label -E-needs-mcve, the removal fails for labels with capital letters. This is cause the comparison in remove_labels was case-sensitive so -e-needs-mcve wouldn't match E-needs-mcve on the issue.
Adding labels works fine because GitHub's API handles case-insensitivity on their end. But removing requires an exact match with the label name as it exists on GitHub.
Now 
Changed filter and contains to filter_map + find with a case-insensitive comparison. This also ensures we use the actual label name from the issue in the DELETE request, not the user-typed version.
#2214 