### PR TITLE
Avoid adding review changes link on merged pull-request

### DIFF
--- a/src/handlers/review_changes_since.rs
+++ b/src/handlers/review_changes_since.rs
@@ -37,10 +37,12 @@ pub(crate) async fn handle(
     if let Event::IssueComment(
         event @ IssueCommentEvent {
             action: IssueCommentAction::Created,
-            issue: Issue {
-                pull_request: Some(_),
-                ..
-            },
+            issue:
+                Issue {
+                    pull_request: Some(_),
+                    merged: false,
+                    ..
+                },
             comment:
                 Comment {
                     in_reply_to_id: None,


### PR DESCRIPTION
As mentioned in https://github.com/rust-lang/triagebot/issues/2369, it's not very useful to add the "View changes since this/the review" link when a PR is merged, as no changes can be made anymore. 

Fixes https://github.com/rust-lang/triagebot/issues/2369
cc @fmease 