### PR TITLE
Move view changes link at the end of review comments

### DIFF
--- a/src/handlers/review_changes_since.rs
+++ b/src/handlers/review_changes_since.rs
@@ -138,7 +138,7 @@ pub(crate) async fn handle(
                 // parent review is empty, let's add the link to the review comment instead
 
                 let new_body = format!(
-                    "*[View changes since the review]({link})*\n\n{}",
+                    "{}\n\n*[View changes since the review]({link})*",
                     event.comment.body
                 );
 


### PR DESCRIPTION
As asked in https://github.com/rust-lang/triagebot/issues/2373#issuecomment-4241726939

cc @RalfJung