### PR TITLE
Fix a bunch of small issues with our GitHub comments viewer

### DIFF
--- a/src/gh_comments.rs
+++ b/src/gh_comments.rs
@@ -551,8 +551,8 @@ fn write_comment_as_html(
               <img src="{author_avatar_url}" alt="{author_login} Avatar" class="avatar">
             </a>
             <div class="author-info">
-              <a href="https://github.com/{author_login}" target="_blank">{author_login}</a>
-              <span>on <span data-utc-time="{created_at_rfc3339}">{created_at}</span></span><span> · hidden as {minimized_reason}</span>
+              <a href="https://github.com/{author_login}" target="_blank" class="author-info-name">{author_login}</a>
+              <a href="#{id}">on <span data-utc-time="{created_at_rfc3339}">{created_at}</span></a><span> · hidden as {minimized_reason}</span>
             </div>
           </div>
 
@@ -584,8 +584,8 @@ fn write_comment_as_html(
       <div id="{id}" class="comment">
         <div class="comment-header">
           <div class="author-info desktop">
-            <a href="https://github.com/{author_login}" target="_blank">{author_login}</a>
-            <span>on <span data-utc-time="{created_at_rfc3339}">{created_at}</span></span>{edited}
+            <a href="https://github.com/{author_login}" target="_blank" class="author-info-name">{author_login}</a>
+            <a href="#{id}">on <span data-utc-time="{created_at_rfc3339}">{created_at}</span></a>{edited}
           </div>
 
           <div class="author-mobile">
@@ -593,8 +593,8 @@ fn write_comment_as_html(
               <img src="{author_avatar_url}" alt="{author_login} Avatar" class="avatar">
             </a>
             <div class="author-info">
-              <a href="https://github.com/{author_login}" target="_blank">{author_login}</a>
-              <span>on <span data-utc-time="{created_at_rfc3339}">{created_at}</span></span>{edited}
+              <a href="https://github.com/{author_login}" target="_blank" class="author-info-name">{author_login}</a>
+              <a href="#{id}">on <span data-utc-time="{created_at_rfc3339}">{created_at}</span></a>{edited}
             </div>
           </div>
 
@@ -672,8 +672,8 @@ fn write_review_as_html(
       <div class="review-header">
         <div class="review-badge {badge_color}">{badge_svg}</div>
         <div class="author-info">
-          <a href="https://github.com/{author_login}" target="_blank">{author_login}</a>
-          <span>{state_message} on <span data-utc-time="{submitted_at_rfc3339}">{submitted_at}</span></span>
+          <a href="https://github.com/{author_login}" target="_blank" class="author-info-name">{author_login}</a>
+          <a href="#{id}">{state_message} on <span data-utc-time="{submitted_at_rfc3339}">{submitted_at}</span></a>
         </div>
       </div>
     </div>
@@ -803,8 +803,8 @@ fn write_review_thread_as_html(
               <a href="https://github.com/{author_login}" target="_blank">
                 <img src="{author_avatar_url}" alt="{author_login} Avatar" class="avatar avatar-small">
               </a>
-              <a href="https://github.com/{author_login}" target="_blank">{author_login}</a>
-              <span>on <span data-utc-time="{created_at_rfc3339}">{created_at}</span></span>{edited}
+              <a href="https://github.com/{author_login}" target="_blank" class="author-info-name">{author_login}</a>
+              <a href="#{id}">on <span data-utc-time="{created_at_rfc3339}">{created_at}</span></a>{edited}
             </div>
             <a href="{comment_url}" target="_blank" class="github-link">View on GitHub</a>
           </div>

--- a/src/gh_comments.rs
+++ b/src/gh_comments.rs
@@ -894,7 +894,7 @@ fn write_reaction_groups_as_html(
 
             write!(
                 buffer,
-                r##"<div class="reaction">{emoji}<span class="reaction-number">{total_count}</span></div>"##
+                r##"<button class="reaction" disabled="disabled">{emoji}<span class="reaction-number">{total_count}</span></button>"##
             )?;
         }
 

--- a/src/gh_comments.rs
+++ b/src/gh_comments.rs
@@ -29,7 +29,7 @@ use crate::{
     utils::{immutable_headers, is_known_and_public_repo},
 };
 
-pub const STYLE_URL: &str = "/gh-comments/style@0.0.7.css";
+pub const STYLE_URL: &str = "/gh-comments/style@0.0.8.css";
 pub const MARKDOWN_URL: &str = "/gh-comments/github-markdown@20260117.css";
 pub const SELF_CONTAINED_URL: &str = "/gh-comments/self_contained@0.0.2.js";
 
@@ -270,7 +270,7 @@ pub async fn gh_comments(
     write!(
         html,
         r###"<main class="comments-container">
-<h1 class="title"><bdi class="markdown-body">{title_html}</bdi> <a class="github-link" href="https://github.com/{owner}/{repo}/issues/{issue_id}">{owner}/{repo}#{issue_id}</a></h1>
+<h1 class="title"><span class="markdown-body">{title_html}</span> <a class="github-link" href="https://github.com/{owner}/{repo}/issues/{issue_id}">{owner}/{repo}#{issue_id}</a></h1>
 "###,
     )?;
 

--- a/src/gh_comments/style.css
+++ b/src/gh_comments/style.css
@@ -65,7 +65,7 @@ body {
     margin-bottom: 0;
 }
 
-.title bdi {
+.title .markdown-body {
     font-size: 28px;
     font-weight: 600;
     display: inline-block;
@@ -300,6 +300,7 @@ details:not([open]) > .review-thread-header {
 /* === Markdown overrides === */
 .markdown-body {
     font-size: 14px;
+    overflow-wrap: anywhere;
 }
 
 .markdown-body .user-mention {

--- a/src/gh_comments/style.css
+++ b/src/gh_comments/style.css
@@ -223,6 +223,7 @@ details:not([open]) > .review-thread-header {
     display: flex;
     align-items: center;
     justify-content: center;
+    flex-shrink: 0;
     width: 2rem;
     height: 2rem;
     border-radius: 50%;

--- a/src/gh_comments/style.css
+++ b/src/gh_comments/style.css
@@ -296,12 +296,14 @@ details:not([open]) > .review-thread-header {
 .reaction {
     border-radius: 100px;
     border: 0.00625rem solid var(--border-default);
+    background-color: transparent;
     padding: 5px 9px;
     font-size: 13px;
 }
 
 .reaction .reaction-number {
     margin-left: 0.35rem;
+    color: var(--fg-muted);
 }
 
 /* === Tab links === */

--- a/src/gh_comments/style.css
+++ b/src/gh_comments/style.css
@@ -105,6 +105,9 @@ body {
     padding: 8px 12px;
     font-size: 0.9em;
     color: var(--fg-muted);
+}
+
+.review-thread-header {
     cursor: pointer;
 }
 

--- a/src/gh_comments/style.css
+++ b/src/gh_comments/style.css
@@ -19,6 +19,8 @@
     --fg-accent: #0969da;
     --border-default: #d0d7de;
     --toc-width: min(330px, 75vw);
+    --bgColor-success-muted: #46954a26;
+    --bgColor-danger-muted: #e5534b1a;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/gh_comments/style.css
+++ b/src/gh_comments/style.css
@@ -210,13 +210,17 @@ details:not([open]) > .review-thread-header {
 }
 
 .author-info a {
-    color: var(--fg-default);
-    font-weight: 600;
+    color: var(--fg-muted);
     text-decoration: none;
 }
 
 .author-info a:hover {
     text-decoration: underline;
+}
+
+.author-info .author-info-name {
+    color: var(--fg-default);
+    font-weight: 600;
 }
 
 .github-link {

--- a/src/gh_comments/style.css
+++ b/src/gh_comments/style.css
@@ -91,6 +91,10 @@ body {
     overflow: hidden;
 }
 
+.comment:target, .review-thread:target {
+    box-shadow: 0 0 0 1px var(--fg-accent);
+}
+
 .review-thread {
     margin-left: 80px;
     margin-bottom: 1rem;
@@ -120,13 +124,17 @@ details:not([open]) > .review-thread-header {
     padding: 16px;
 }
 
+.review-thread-comment {
+    position: relative;
+    padding: 0.5rem 1rem;
+}
+
 .review-thread-comment:first-child {
     padding-top: 1rem;
 }
 
-.review-thread-comment {
-    position: relative;
-    padding: 0.5rem 1rem;
+.review-thread-comment:target {
+    box-shadow: inset 0 0 0 1px var(--fg-accent);
 }
 
 .review-header, .review-thread-comment-header {


### PR DESCRIPTION
Just a bunch of small issues I saw and wanted to fix:
 - [Keep the badges round no matter the outer constraint](https://github.com/rust-lang/triagebot/commit/f948780ea16d15eb3141b9060335bc3a2031c182)
    - Before: <img width="333" height="66" alt="image" src="https://github.com/user-attachments/assets/9263ebe5-8e05-40ca-a8fa-b289f49ce86e" />
    - After: <img width="327" height="58" alt="image" src="https://github.com/user-attachments/assets/6016029b-532d-4b27-9476-8c314a11266d" />
 - [Wrap the issue/PR title if too long](https://github.com/rust-lang/triagebot/commit/3de577162065e2a07bcaee167b98ddbdb30377ed)
    - Before: <img width="385" height="373" alt="image" src="https://github.com/user-attachments/assets/d6d50022-e87a-404b-a3fe-7e23e5e1f91a" />
    - After: <img width="389" height="361" alt="image" src="https://github.com/user-attachments/assets/6519d6d0-43f9-49af-beac-3fa9f82c1fb9" />
 - [Only make the cursor a pointer for review thread headers](https://github.com/rust-lang/triagebot/commit/5af26ddb50a352351a137f83ff2b2cb36e2e5f58)
 - [Add highlighting around the targeted (by url) comment or review-thread](https://github.com/rust-lang/triagebot/commit/ef20cec76f5d19bf75cac518fef28eb3b47f0b15)
    - <img width="506" height="197" alt="image" src="https://github.com/user-attachments/assets/c63bf401-bf61-4cf5-9c5a-6181ff3ac472" />
 - [Add self-link to the author-ship time of each comment/review comment](https://github.com/rust-lang/triagebot/commit/113117806602f14d5fbb9f80f4a5d5f4f6d8f877)
 - [Add missing background color in suggested code](https://github.com/rust-lang/triagebot/commit/f5a83e72cc59a9d02d7ae677039b65085a89d57e)
   - Before: <img width="555" height="238" alt="image" src="https://github.com/user-attachments/assets/85ca66c6-ae15-423f-acb0-ec5694e700fc" />
   - After: <img width="635" height="236" alt="image" src="https://github.com/user-attachments/assets/0aa2eecf-508b-4c5d-b4a4-113299022019" />
 - [Make the reaction buttons so the emoji and number act as one entity](https://github.com/rust-lang/triagebot/commit/268042b95dd24107ebdb14e2139cc8f2230a529c)

Testing links:
 - http://localhost:8000/gh-comments/rust-lang/rust-forge/pull/1040#issuecomment-4267465591
 - https://triage.rust-lang.org/gh-comments/rust-lang/rust-forge/pull/1040#discussion_r3100388285
 - http://localhost:8000/gh-comments/rust-lang/rust/pull/155433