### PR TITLE
Hide by-default context-only changes in our range-diff viewer

### DIFF
--- a/src/gh_range_diff.rs
+++ b/src/gh_range_diff.rs
@@ -281,6 +281,15 @@ fn process_old_new(
       color: white;
       background-color: rgb(63, 128, 94);
     }}
+    .spacer {{
+      margin-bottom: 1rem;
+    }}
+    .hide {{
+      display: none;
+    }}
+    #show-context-only-changes-cb:checked ~ .hide {{
+      display: block;
+    }}
     @media (prefers-color-scheme: dark) {{
       body {{
         background: #0C0C0C;
@@ -330,7 +339,10 @@ fn process_old_new(
 </head>
 <body>
 <h3>range-diff of {a_oldbase}..{a_oldhead} {a_newbase}..{a_newhead} in {owner}/{repo}</h3>
-<p>Legend: {REMOVED_BLOCK_SIGN}&nbsp;before | {ADDED_BLOCK_SIGN}&nbsp;after</p>
+<span>Legend: {REMOVED_BLOCK_SIGN}&nbsp;before | {ADDED_BLOCK_SIGN}&nbsp;after</span>
+<input type="checkbox" id="show-context-only-changes-cb">
+<label for="show-context-only-changes-cb"> Show context-only changes</label>
+<div class="spacer"></div>
 "#
     )?;
 
@@ -355,6 +367,22 @@ fn process_old_new(
         let has_hunks = diff.hunks().next().is_some();
 
         if has_hunks {
+            let has_content_changes = 'context: {
+                for mut hunk in diff.hunks() {
+                    let contains_diff_marker = |idx: u32, source: &[Token]| {
+                        let line = &input.interner[source[idx as usize]];
+                        line.starts_with('+') || line.starts_with('-')
+                    };
+
+                    if hunk.before.any(|i| contains_diff_marker(i, &input.before))
+                        || hunk.after.any(|i| contains_diff_marker(i, &input.after))
+                    {
+                        break 'context true;
+                    }
+                }
+                false
+            };
+
             let printer = HtmlDiffPrinter(&input.interner);
             let diff = diff.unified_diff(&printer, config.clone(), &input);
 
@@ -363,10 +391,22 @@ fn process_old_new(
             let after_href =
                 format_args!("https://github.com/{owner}/{repo}/blob/{newhead}/{filename}");
 
-            writeln!(
+            if has_content_changes {
+                write!(html, r#"<details open=""><summary>{filename}"#)?;
+            } else {
+                /* Context only changes, hide by default */
+                write!(
+                    html,
+                    r#"<details open="" class="hide" data-context-only-changes=""><summary>{filename} <i>(context-only changes)</i>"#
+                )?;
+            }
+
+            write!(
                 html,
-                r#"<details open=""><summary>{filename} <a href="{before_href}">before</a> <a href="{after_href}">after</a></summary><pre class="diff-content">{diff}</pre></details>"#
+                r#" <a href="{before_href}">before</a> <a href="{after_href}">after</a></summary><pre class="diff-content">{diff}</pre>"#
             )?;
+            writeln!(html, "</details>")?;
+
             diff_displayed += 1;
         }
         Ok(())


### PR DESCRIPTION
This PR adds an off-by-default to control the default visibility of each file diff when it only contains context changes, that is when the different is not on the `+`/`-` lines.

This makes the diff more easy to read by hiding by default some mostly useless diff.

| Off | On |
|----|---|
| <img width="1004" height="1353" alt="image" src="https://github.com/user-attachments/assets/5da756cc-1b9b-4a4a-8fea-590e3bf8029c" /> | <img width="1004" height="1713" alt="image" src="https://github.com/user-attachments/assets/ac6320ed-2bc8-4526-91b9-58ab40c6edd9" /> |

http://localhost:8000/gh-range-diff/rust-lang/rust/12f35ad39ed3e39df4d953c46d4f6cc6c82adc96..e867ac9b8da8eeecbb143192fe0f08eff1c48260/4dbafc340b0f8e9ff9e95974d0ceef81ae2652c8..d3bdea115d929178e0a3189fb4fdf0e827529ed3