### PR TITLE
update team data to include datadog app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2563,7 +2563,7 @@ dependencies = [
 [[package]]
 name = "rust_team_data"
 version = "1.0.0"
-source = "git+https://github.com/rust-lang/team#a041d4e878209a7948367169dca6cc6142d48301"
+source = "git+https://github.com/rust-lang/team#646391069340d36807895469aa8937bae37409ea"
 dependencies = [
  "indexmap",
  "serde",


### PR DESCRIPTION
Include the new github app added in https://github.com/rust-lang/team/pull/2427