### PR TITLE
Increase the default maximum response size for GraphQl queries

### DIFF
--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -143,7 +143,7 @@ impl GithubClient {
                 Ok(e) => {
                     return Err(anyhow::Error::new(*e)).with_context(|| {
                             format!(
-                                "req={req_url} (x-github-request-id: {}): lenght exceeded (over {max_response_size} bytes)",
+                                "req={req_url} (x-github-request-id: {}): max response size exceeded (over {max_response_size} bytes)",
                                 github_request_id
                                     .as_ref()
                                     .and_then(|v| v.to_str().ok())
@@ -333,11 +333,21 @@ impl GithubClient {
         query: &str,
         vars: serde_json::Value,
     ) -> anyhow::Result<serde_json::Value> {
-        self.json(self.post(&self.graphql_url).json(&serde_json::json!({
-            "query": query,
-            "variables": vars,
-        })))
-        .await
+        // Our GraphQl query can end-up being quite big, let's set a higher default
+        // response size than for normal REST Api response.
+        const MAX_DEFAULT_GRAPH_QL_RESPONSE_SIZE: usize = 6 * 1024 * 1024;
+
+        let (body, _dbg) = self
+            .send_req_with_limit(
+                self.post(&self.graphql_url).json(&serde_json::json!({
+                    "query": query,
+                    "variables": vars,
+                })),
+                MAX_DEFAULT_GRAPH_QL_RESPONSE_SIZE,
+            )
+            .await?;
+
+        Ok(serde_json::from_slice(&body)?)
     }
 
     /// Issues an ad-hoc GraphQL query.


### PR DESCRIPTION
This PR increases the default maximum response size for our GraphQl queries to GitHub as they are way above the normal (1Mb) limit added in https://github.com/rust-lang/triagebot/issues/2386.

 - https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/133502
    1. 1_372_045 bytes
    2. 307_929
    3. 347_981
    4. 896_346
 - https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rfcs/pull/3875
    1. 3_337_690 bytes
    2. 27_861

I put the new limit for GraphQl queries to 6Mb, double the max seen above, we can of course adjust it.

cc [#triagebot > triage bot fetching comments fails](https://rust-lang.zulipchat.com/#narrow/channel/224082-triagebot/topic/triage.20bot.20fetching.20comments.20fails/with/592095135)