### PR TITLE
Retrieve team that handles a backport

### DIFF
--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -43,19 +43,21 @@ use tracing::log;
 fn get_text_backport_approved(
     channel: &BackportChannelArgs,
     verb: &BackportVerbArgs,
+    team_name: &str,
     zulip_link: &str,
 ) -> String {
     format!(
-        "{channel} backport {verb} as per compiler team [on Zulip]({zulip_link}). A backport PR will be authored by the release team at the end of the current development cycle. Backport labels are handled by them."
+        "{channel} backport {verb} as per {team_name} team [on Zulip]({zulip_link}). A backport PR will be authored by the release team at the end of the current development cycle. Backport labels are handled by them."
     )
 }
 
 fn get_text_backport_declined(
     channel: &BackportChannelArgs,
     verb: &BackportVerbArgs,
+    team_name: &str,
     zulip_link: &str,
 ) -> String {
-    format!("{channel} backport {verb} as per compiler team [on Zulip]({zulip_link}).")
+    format!("{channel} backport {verb} as per {team_name} team [on Zulip]({zulip_link}).")
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -407,6 +409,14 @@ async fn accept_decline_backport(
     let stream_id = message.stream_id.unwrap();
     let subject = message.subject.unwrap();
     let zulip_client = &ctx.zulip;
+    let zulip_stream = zulip_client.get_zulip_channel_by_id(stream_id).await?;
+    // expected something like `t-{team_name}/foo` or `t-{team_name}`
+    let team_name = &zulip_stream
+        .name
+        .rsplit_once('/')
+        .map_or(&*zulip_stream.name, |s| s.0)
+        .strip_prefix("t-")
+        .unwrap_or_default();
 
     // Repository owner and name are hardcoded
     // This command is only used in this repository
@@ -443,11 +453,11 @@ async fn accept_decline_backport(
         | BackportVerbArgs::Accepted
         | BackportVerbArgs::Approve
         | BackportVerbArgs::Approved => (
-            get_text_backport_approved(&args.channel, &args.verb, &zulip_link),
+            get_text_backport_approved(&args.channel, &args.verb, team_name, &zulip_link),
             true,
         ),
         BackportVerbArgs::Decline | BackportVerbArgs::Declined => (
-            get_text_backport_declined(&args.channel, &args.verb, &zulip_link),
+            get_text_backport_declined(&args.channel, &args.verb, team_name, &zulip_link),
             false,
         ),
     };

--- a/src/zulip/api.rs
+++ b/src/zulip/api.rs
@@ -93,6 +93,17 @@ impl Recipient<'_> {
     }
 }
 
+#[derive(serde::Deserialize)]
+pub struct ZulipChannel {
+    pub stream: ZulipChannelData,
+}
+
+#[derive(serde::Deserialize)]
+pub struct ZulipChannelData {
+    pub name: String,
+    pub stream_id: u64,
+}
+
 #[cfg(test)]
 fn check_encode(topic: &str, expected: &str) {
     const PREFIX: &str = "stream/0-xxx/topic/";

--- a/src/zulip/client.rs
+++ b/src/zulip/client.rs
@@ -2,7 +2,9 @@
 //! Documentation: https://zulip.com/api/send-message
 
 use crate::zulip::Recipient;
-use crate::zulip::api::{MessageApiResponse, ZulipUser, ZulipUsers};
+use crate::zulip::api::{
+    MessageApiResponse, ZulipChannel, ZulipChannelData, ZulipUser, ZulipUsers,
+};
 use anyhow::Context;
 use reqwest::{Client, Method, RequestBuilder, Response};
 use secrecy::{ExposeSecret, SecretString};
@@ -168,6 +170,21 @@ impl ZulipClient {
         }
 
         Ok(())
+    }
+
+    /// Retrieve a stream (channel) from its ID
+    /// https://zulip.com/api/get-stream-by-id
+    pub async fn get_zulip_channel_by_id(
+        &self,
+        stream_id: u64,
+    ) -> anyhow::Result<ZulipChannelData> {
+        let resp = self
+            .make_request(Method::GET, &format!("streams/{stream_id}"))
+            .send()
+            .await?;
+        deserialize_response::<ZulipChannel>(resp)
+            .await
+            .map(|channel| channel.stream)
     }
 
     fn make_request(&self, method: Method, url: &str) -> RequestBuilder {


### PR DESCRIPTION
Closes #2391 

This patch adds a call to the Zulip API to get the the stream name from where the message is sent. The stream name is then used to infer the team name that approve/decline a backport.

It's not easy to figure out in a reliable way which team approves a backport:
- Look at the `t-*` labels of a PR? What if there are more than one?
- Look at the person sending the message `backport approve beta 123`? Anybody can use `@**triagebot**`
- Look from which Zulip stream the message comes? Well, Zulip comments can be written anywhere

So unless I missed a better way to do it, I choose the third option. In the worst case the team name will be empty rather than wrong :shrug: 

r? @Urgau 

thanks