### PR TITLE
Filter-out context-only hunks in our range-diff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,12 +915,6 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -1131,6 +1125,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-imara-diff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39eb0623e15e4cb83c02ce6a959e48fadd1ae3b715b36b5acc01816e01388c82"
+dependencies = [
+ "bstr",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,9 +1220,6 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
-dependencies = [
- "foldhash 0.1.5",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1228,7 +1229,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -1458,16 +1459,6 @@ dependencies = [
  "thread_local",
  "walkdir",
  "winapi-util",
-]
-
-[[package]]
-name = "imara-diff"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f01d462f766df78ab820dd06f5eb700233c51f0f4c2e846520eaf4ba6aa5c5c"
-dependencies = [
- "hashbrown 0.15.2",
- "memchr",
 ]
 
 [[package]]
@@ -3448,6 +3439,7 @@ dependencies = [
  "dotenvy",
  "futures",
  "github-graphql",
+ "gix-imara-diff",
  "globset",
  "hex",
  "hmac",
@@ -3455,7 +3447,6 @@ dependencies = [
  "http-body-util",
  "hyper",
  "ignore",
- "imara-diff",
  "itertools",
  "native-tls",
  "octocrab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ clap = { version = "4", features = ["derive", "string"] }
 hmac = "0.12.1"
 subtle = "2.6.1"
 sha2 = "0.10.9"
-imara-diff = "0.2.0"
+gix-imara-diff = { version = "0.2.1", features = ["unified_diff"] }
 pulldown-cmark-escape = "0.11.0"
 axum-extra = { version = "0.10.1", default-features = false }
 unicode-segmentation = "1.12.0"

--- a/src/gh_range_diff.rs
+++ b/src/gh_range_diff.rs
@@ -9,9 +9,7 @@ use axum::{
     http::HeaderValue,
     response::IntoResponse,
 };
-use gix_imara_diff::{
-    Algorithm, Diff, InternedInput, Interner, Token, UnifiedDiffConfig, UnifiedDiffPrinter,
-};
+use gix_imara_diff::{Algorithm, Diff, InternedInput, Interner, Token, UnifiedDiffPrinter};
 use hyper::header::CACHE_CONTROL;
 use hyper::{
     HeaderMap, StatusCode,
@@ -200,7 +198,7 @@ fn process_old_new(
     (newbase, newhead, mut new): (&str, &str, GithubCompare),
 ) -> axum::response::Result<(StatusCode, HeaderMap, String), AppError> {
     // Configure unified diff
-    let config = UnifiedDiffConfig::default();
+    let config = CustomUnifiedDiffConfig { context_len: 3 };
 
     // Sort by filename, so it's consistent with GitHub UI
     old.files
@@ -394,7 +392,13 @@ fn process_old_new(
             };
 
             let printer = HtmlDiffPrinter(&input.interner, filename);
-            let diff = diff.unified_diff(&printer, config.clone(), &input);
+            let unified_diff = CustomUnifiedDiff {
+                printer: &printer,
+                diff: &diff,
+                config: config.clone(),
+                before: &input.before,
+                after: &input.after,
+            };
 
             let before_href =
                 format_args!("https://github.com/{owner}/{repo}/blob/{oldhead}/{filename}");
@@ -413,7 +417,7 @@ fn process_old_new(
 
             write!(
                 html,
-                r#" <a href="{before_href}">before</a> <a href="{after_href}">after</a></summary><pre class="diff-content">{diff}</pre>"#
+                r#" <a href="{before_href}">before</a> <a href="{after_href}">after</a></summary><pre class="diff-content">{unified_diff}</pre>"#
             )?;
             writeln!(html, "</details>")?;
 
@@ -674,6 +678,86 @@ impl UnifiedDiffPrinter for HtmlDiffPrinter<'_> {
                     writeln!(f)?;
                 }
             }
+        }
+        Ok(())
+    }
+}
+
+/// Custom imara-diff UnifiedDiff
+struct CustomUnifiedDiff<'a, P: UnifiedDiffPrinter> {
+    printer: &'a P,
+    diff: &'a Diff,
+    config: CustomUnifiedDiffConfig,
+    before: &'a [Token],
+    after: &'a [Token],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CustomUnifiedDiffConfig {
+    context_len: u32,
+}
+
+// Copied from https://github.com/GitoxideLabs/gitoxide/blob/8af2691270a72c711bbec8100ce07273de29f52a/gix-imara-diff/src/unified_diff.rs#L218
+impl<P: UnifiedDiffPrinter> fmt::Display for CustomUnifiedDiff<'_, P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let first_hunk = self.diff.hunks().next().unwrap_or_default();
+        let context_len = self.config.context_len.min(1024 * 1024);
+        let mut pos = first_hunk.before.start.saturating_sub(context_len);
+        let mut before_context_start = pos;
+        let mut after_context_start = first_hunk.after.start.saturating_sub(context_len);
+        let mut before_context_len = 0;
+        let mut after_context_len = 0;
+        let mut buffer = String::new();
+        for hunk in self.diff.hunks() {
+            if hunk.before.start - pos > 2 * context_len {
+                if !buffer.is_empty() {
+                    let end = (pos + context_len).min(self.before.len() as u32);
+                    self.printer.display_header(
+                        &mut *f,
+                        before_context_start,
+                        after_context_start,
+                        before_context_len + end - pos,
+                        after_context_len + end - pos,
+                    )?;
+                    write!(f, "{buffer}")?;
+                    for &token in &self.before[pos as usize..end as usize] {
+                        self.printer.display_context_token(&mut *f, token)?;
+                    }
+                    buffer.clear();
+                }
+                pos = hunk.before.start - context_len;
+                before_context_start = pos;
+                after_context_start = hunk.after.start - context_len;
+                before_context_len = 0;
+                after_context_len = 0;
+            }
+            for &token in &self.before[pos as usize..hunk.before.start as usize] {
+                self.printer.display_context_token(&mut buffer, token)?;
+            }
+            let context_len = hunk.before.start - pos;
+            before_context_len += hunk.before.len() as u32 + context_len;
+            after_context_len += hunk.after.len() as u32 + context_len;
+            self.printer.display_hunk(
+                &mut buffer,
+                &self.before[hunk.before.start as usize..hunk.before.end as usize],
+                &self.after[hunk.after.start as usize..hunk.after.end as usize],
+            )?;
+            pos = hunk.before.end;
+        }
+        if !buffer.is_empty() {
+            let end = (pos + context_len).min(self.before.len() as u32);
+            self.printer.display_header(
+                &mut *f,
+                before_context_start,
+                after_context_start,
+                before_context_len + end - pos,
+                after_context_len + end - pos,
+            )?;
+            write!(f, "{buffer}")?;
+            for &token in &self.before[pos as usize..end as usize] {
+                self.printer.display_context_token(&mut *f, token)?;
+            }
+            buffer.clear();
         }
         Ok(())
     }

--- a/src/gh_range_diff.rs
+++ b/src/gh_range_diff.rs
@@ -289,12 +289,6 @@ fn process_old_new(
     .spacer {{
       margin-bottom: 1rem;
     }}
-    .hide {{
-      display: none;
-    }}
-    #show-context-only-changes-cb:checked ~ .hide {{
-      display: block;
-    }}
     @media (prefers-color-scheme: dark) {{
       body {{
         background: #0C0C0C;
@@ -348,8 +342,6 @@ fn process_old_new(
 <body>
 <h3>range-diff of {a_oldbase}..{a_oldhead} {a_newbase}..{a_newhead} in {owner}/{repo}</h3>
 <span>Legend: {REMOVED_BLOCK_SIGN}&nbsp;before | {ADDED_BLOCK_SIGN}&nbsp;after</span>
-<input type="checkbox" id="show-context-only-changes-cb">
-<label for="show-context-only-changes-cb"> Show context-only changes</label>
 <div class="spacer"></div>
 "#
     )?;
@@ -383,10 +375,6 @@ fn process_old_new(
 
         // Show the changes if there are any hunks to be shown
         if !hunks.is_empty() {
-            // FIXME: Remove the checkbox as we now filter-out all the context-only hunks
-            // without the possibly to show them after afterwards
-            let has_content_changes = true;
-
             let printer = HtmlDiffPrinter(&input.interner, filename);
             let unified_diff = CustomUnifiedDiff {
                 printer: &printer,
@@ -401,16 +389,7 @@ fn process_old_new(
             let after_href =
                 format_args!("https://github.com/{owner}/{repo}/blob/{newhead}/{filename}");
 
-            if has_content_changes {
-                write!(html, r#"<details open=""><summary>{filename}"#)?;
-            } else {
-                /* Context only changes, hide by default */
-                write!(
-                    html,
-                    r#"<details open="" class="hide" data-context-only-changes=""><summary>{filename} <i>(context-only changes)</i>"#
-                )?;
-            }
-
+            write!(html, r#"<details open=""><summary>{filename}"#)?;
             write!(
                 html,
                 r#" <a href="{before_href}">before</a> <a href="{after_href}">after</a></summary><pre class="diff-content">{unified_diff}</pre>"#

--- a/src/gh_range_diff.rs
+++ b/src/gh_range_diff.rs
@@ -9,13 +9,13 @@ use axum::{
     http::HeaderValue,
     response::IntoResponse,
 };
+use gix_imara_diff::{
+    Algorithm, Diff, InternedInput, Interner, Token, UnifiedDiffConfig, UnifiedDiffPrinter,
+};
 use hyper::header::CACHE_CONTROL;
 use hyper::{
     HeaderMap, StatusCode,
     header::{CONTENT_SECURITY_POLICY, CONTENT_TYPE},
-};
-use imara_diff::{
-    Algorithm, Diff, InternedInput, Interner, Token, UnifiedDiffConfig, UnifiedDiffPrinter,
 };
 use pulldown_cmark_escape::FmtWriter;
 use regex::Regex;
@@ -682,7 +682,7 @@ impl UnifiedDiffPrinter for HtmlDiffPrinter<'_> {
 // Simple abstraction over `unicode_segmentation::split_word_bounds` for `imara_diff::TokenSource`
 struct SplitWordBoundaries<'a>(&'a str);
 
-impl<'a> imara_diff::TokenSource for SplitWordBoundaries<'a> {
+impl<'a> gix_imara_diff::TokenSource for SplitWordBoundaries<'a> {
     type Token = &'a str;
     type Tokenizer = unicode_segmentation::UWordBounds<'a>;
 

--- a/src/gh_range_diff.rs
+++ b/src/gh_range_diff.rs
@@ -9,7 +9,7 @@ use axum::{
     http::HeaderValue,
     response::IntoResponse,
 };
-use gix_imara_diff::{Algorithm, Diff, InternedInput, Interner, Token, UnifiedDiffPrinter};
+use gix_imara_diff::{Algorithm, Diff, Hunk, InternedInput, Interner, Token, UnifiedDiffPrinter};
 use hyper::header::CACHE_CONTROL;
 use hyper::{
     HeaderMap, StatusCode,
@@ -371,30 +371,26 @@ fn process_old_new(
         // Run postprocessing to improve hunk boundaries
         diff.postprocess_lines(&input);
 
-        // Determine if there are any differences
-        let has_hunks = diff.hunks().next().is_some();
+        // Collect and filter-out hunks don't contain any diff marker (-, +)
+        // as those are context-only changes, which are not interesting in
+        // a range-diff.
+        //
+        // See <https://github.com/rust-lang/triagebot/issues/2394>
+        let hunks = diff
+            .hunks()
+            .filter(|hunk| contains_diff_marker(&input, hunk.clone()))
+            .collect::<Vec<_>>();
 
-        if has_hunks {
-            let has_content_changes = 'context: {
-                for mut hunk in diff.hunks() {
-                    let contains_diff_marker = |idx: u32, source: &[Token]| {
-                        let line = &input.interner[source[idx as usize]];
-                        line.starts_with('+') || line.starts_with('-')
-                    };
-
-                    if hunk.before.any(|i| contains_diff_marker(i, &input.before))
-                        || hunk.after.any(|i| contains_diff_marker(i, &input.after))
-                    {
-                        break 'context true;
-                    }
-                }
-                false
-            };
+        // Show the changes if there are any hunks to be shown
+        if !hunks.is_empty() {
+            // FIXME: Remove the checkbox as we now filter-out all the context-only hunks
+            // without the possibly to show them after afterwards
+            let has_content_changes = true;
 
             let printer = HtmlDiffPrinter(&input.interner, filename);
             let unified_diff = CustomUnifiedDiff {
                 printer: &printer,
-                diff: &diff,
+                hunks: &hunks,
                 config: config.clone(),
                 before: &input.before,
                 after: &input.after,
@@ -686,7 +682,7 @@ impl UnifiedDiffPrinter for HtmlDiffPrinter<'_> {
 /// Custom imara-diff UnifiedDiff
 struct CustomUnifiedDiff<'a, P: UnifiedDiffPrinter> {
     printer: &'a P,
-    diff: &'a Diff,
+    hunks: &'a [Hunk],
     config: CustomUnifiedDiffConfig,
     before: &'a [Token],
     after: &'a [Token],
@@ -697,10 +693,10 @@ struct CustomUnifiedDiffConfig {
     context_len: u32,
 }
 
-// Copied from https://github.com/GitoxideLabs/gitoxide/blob/8af2691270a72c711bbec8100ce07273de29f52a/gix-imara-diff/src/unified_diff.rs#L218
+// Customized version of <https://github.com/GitoxideLabs/gitoxide/blob/8af2691270a72c711bbec8100ce07273de29f52a/gix-imara-diff/src/unified_diff.rs#L218>
 impl<P: UnifiedDiffPrinter> fmt::Display for CustomUnifiedDiff<'_, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let first_hunk = self.diff.hunks().next().unwrap_or_default();
+        let first_hunk = self.hunks.first().cloned().unwrap_or_default();
         let context_len = self.config.context_len.min(1024 * 1024);
         let mut pos = first_hunk.before.start.saturating_sub(context_len);
         let mut before_context_start = pos;
@@ -708,7 +704,7 @@ impl<P: UnifiedDiffPrinter> fmt::Display for CustomUnifiedDiff<'_, P> {
         let mut before_context_len = 0;
         let mut after_context_len = 0;
         let mut buffer = String::new();
-        for hunk in self.diff.hunks() {
+        for hunk in self.hunks {
             if hunk.before.start - pos > 2 * context_len {
                 if !buffer.is_empty() {
                     let end = (pos + context_len).min(self.before.len() as u32);
@@ -780,6 +776,18 @@ impl<'a> gix_imara_diff::TokenSource for SplitWordBoundaries<'a> {
     }
 }
 
+// Determine if a hunk contains any diff marker (+, -) in the underline inputs
+fn contains_diff_marker(input: &InternedInput<&str>, mut hunk: Hunk) -> bool {
+    let contains_diff_marker = |idx: u32, source: &[Token]| {
+        let line = &input.interner[source[idx as usize]];
+        line.starts_with('+') || line.starts_with('-')
+    };
+
+    hunk.before.any(|i| contains_diff_marker(i, &input.before))
+        || hunk.after.any(|i| contains_diff_marker(i, &input.after))
+}
+
+// function to create a <a> to a GitHub commit
 fn a_github_commit(owner: &str, repo: &str, ref_: &str) -> String {
     format!(
         r#"<a href="https://github.com/{owner}/{repo}/commit/{ref_}" class="commit">{}</a>"#,


### PR DESCRIPTION
This PR filter-out context-only hunks in our range-diff.

We currently only hide-by-default file changes that only have context-only changes, but as described in #2394, a range-diff might have plenty of hunks that only have context changes (ie not a diff line, `+`/`-`).

| Currently (with context-only changes) | Currently | This PR |
|------|---|---|
| <img width="1150" height="5075" alt="image" src="https://github.com/user-attachments/assets/a7cfb0d9-d61b-4eb7-9751-6f03f4dbe7c4" /> | <img width="1150" height="4876" alt="image" src="https://github.com/user-attachments/assets/e42053e0-7b96-4eb1-a616-08c0b6a96930" /> | <img width="1150" height="3716" alt="image" src="https://github.com/user-attachments/assets/9a30a7e0-8b22-4abf-9d1e-e1f721c80e9b" /> |

Implementation wise, I had to copy and lighting edit the `UnifiedDiff` implementation from `imara-diff` in order to be able to filter-out some hunks.

I sadly had to remove the checkbox (not sure it was very useful to begin with) as knowing with lines to show/hide is highly non-trivial for context line as they can be part of the same context for multiple hunks at the same time (each hunk has +- 3 context line).

I also took the opportunity to switch to `gix-imara-diff` since the original crate has had unreleased fixes for several months.

Testing link: http://localhost:8000/gh-range-diff/rust-lang/miri/98cb1d3d48fa7c8e97994050bfd69e8f3da2a1a7..3f8007e19b8cac3d08fb07579bde3217c58807e4/e0b3afbdd5362aa348abc6661ed6417d1a21f58c..d811aaf958594156e2ce38365b835c361aa88de9

Fixes https://github.com/rust-lang/triagebot/issues/2394
cc @RalfJung