### PR TITLE
Make the word highlighting colors follow the hunk rather than the line

### DIFF
--- a/src/gh_range_diff.rs
+++ b/src/gh_range_diff.rs
@@ -266,8 +266,8 @@ fn process_old_new(
       color: rgb(220, 0, 0)
     }}
     .line-removed-after .word-added {{
-      color: white;
-      background-color: #C85000;
+      color: black;
+      background-color: #FFA500;
     }}
     .line-added-after {{
       color: rgb(0, 221, 0)
@@ -323,7 +323,7 @@ fn process_old_new(
       }}
       .line-removed-after .word-added {{
         color: black;
-        background-color: #C85000;
+        background-color: #D48B04;
       }}
       .line-added-after {{
         color: rgba(0, 255, 0, 1);

--- a/src/gh_range_diff.rs
+++ b/src/gh_range_diff.rs
@@ -520,6 +520,13 @@ impl HtmlDiffPrinter<'_> {
 
             for (word, changed) in words {
                 if changed {
+                    let prefix_class = match (hunk_token_status, is_add) {
+                        (HunkTokenStatus::Removed, true) => "removed-after",
+                        (HunkTokenStatus::Removed, false) => "removed-before",
+                        (HunkTokenStatus::Added, true) => "added-after",
+                        (HunkTokenStatus::Added, false) => "added-before",
+                    };
+
                     write!(f, r#"<span class="word-{prefix_class}">"#)?;
                     pulldown_cmark_escape::escape_html(FmtWriter(&mut f), word)?;
                     write!(f, "</span>")?;

--- a/src/gh_range_diff.rs
+++ b/src/gh_range_diff.rs
@@ -265,30 +265,30 @@ fn process_old_new(
     .line-removed-after {{
       color: rgb(220, 0, 0)
     }}
+    .line-removed-after .word-added {{
+      color: white;
+      background-color: rgb(63, 128, 94);
+    }}
     .line-added-after {{
       color: rgb(0, 221, 0)
+    }}
+    .line-added-after .word-added {{
+      color: white;
+      background-color: rgb(0, 73, 0);
     }}
     .line-removed-before {{
       color: rgb(192, 78, 76)
     }}
-    .line-added-before {{
-      color: rgb(63, 128, 94)
-    }}
-    .word-removed-after {{
-      color: white;
-      background-color: rgb(220, 0, 0);
-    }}
-    .word-added-after {{
-      color: white;
-      background-color: rgb(0, 73, 0);
-    }}
-    .word-removed-before {{
+    .line-removed-before .word-removed {{
       color: white;
       background-color: rgb(192, 78, 76);
     }}
-    .word-added-before {{
+    .line-added-before {{
+      color: rgb(63, 128, 94)
+    }}
+    .line-added-before .word-removed {{
       color: white;
-      background-color: rgb(63, 128, 94);
+      background-color: rgb(220, 0, 0);
     }}
     .spacer {{
       margin-bottom: 1rem;
@@ -321,30 +321,30 @@ fn process_old_new(
       .line-removed-after {{
         color: rgba(255, 0, 0, 1);
       }}
+      .line-removed-after .word-added {{
+        color: black;
+        background-color: rgb(0, 100, 0);
+      }}
       .line-added-after {{
         color: rgba(0, 255, 0, 1);
+      }}
+      .line-added-after .word-added {{
+        color: black;
+        background-color: rgb(0, 255, 0);
       }}
       .line-removed-before {{
         color: rgb(255, 159, 131);
       }}
+      .line-removed-before .word-removed {{
+        color: black;
+        background-color: rgb(100, 0, 0);
+      }}
       .line-added-before {{
         color: rgba(11, 142, 0, 1);
       }}
-      .word-removed-after {{
+      .line-added-before .word-removed {{
         color: black;
-        background-color: rgba(255, 0, 0, 1);
-      }}
-      .word-added-after {{
-        color: black;
-        background-color: rgba(0, 255, 0, 1);
-      }}
-      .word-removed-before {{
-        color: black;
-        background-color: rgba(100, 0, 0, 1);
-      }}
-      .word-added-before {{
-        color: black;
-        background-color: rgba(0, 100, 0, 1);
+        background-color: rgb(255, 0, 0);
       }}
     }}
     </style>
@@ -510,24 +510,22 @@ impl HtmlDiffPrinter<'_> {
         // diff lines though, since then the coloring distracts from what is
         // relevant.)
         if is_add || is_remove {
-            let prefix_class = match (hunk_token_status, is_add) {
-                (HunkTokenStatus::Removed, true) => "added-before",
-                (HunkTokenStatus::Removed, false) => "removed-before",
-                (HunkTokenStatus::Added, true) => "added-after",
-                (HunkTokenStatus::Added, false) => "removed-after",
+            let line_class = match (is_add, hunk_token_status) {
+                (true, HunkTokenStatus::Removed) => "line-added-before",
+                (false, HunkTokenStatus::Removed) => "line-removed-before",
+                (true, HunkTokenStatus::Added) => "line-added-after",
+                (false, HunkTokenStatus::Added) => "line-removed-after",
             };
-            write!(f, r#"<span class="line-{prefix_class}">"#)?;
+            write!(f, r#"<span class="{line_class}">"#)?;
 
             for (word, changed) in words {
                 if changed {
-                    let prefix_class = match (hunk_token_status, is_add) {
-                        (HunkTokenStatus::Removed, true) => "removed-after",
-                        (HunkTokenStatus::Removed, false) => "removed-before",
-                        (HunkTokenStatus::Added, true) => "added-after",
-                        (HunkTokenStatus::Added, false) => "added-before",
+                    let word_class = match hunk_token_status {
+                        HunkTokenStatus::Removed => "word-removed",
+                        HunkTokenStatus::Added => "word-added",
                     };
 
-                    write!(f, r#"<span class="word-{prefix_class}">"#)?;
+                    write!(f, r#"<span class="{word_class}">"#)?;
                     pulldown_cmark_escape::escape_html(FmtWriter(&mut f), word)?;
                     write!(f, "</span>")?;
                 } else {

--- a/src/gh_range_diff.rs
+++ b/src/gh_range_diff.rs
@@ -267,7 +267,7 @@ fn process_old_new(
     }}
     .line-removed-after .word-added {{
       color: white;
-      background-color: rgb(63, 128, 94);
+      background-color: #C85000;
     }}
     .line-added-after {{
       color: rgb(0, 221, 0)
@@ -323,7 +323,7 @@ fn process_old_new(
       }}
       .line-removed-after .word-added {{
         color: black;
-        background-color: rgb(0, 100, 0);
+        background-color: #C85000;
       }}
       .line-added-after {{
         color: rgba(0, 255, 0, 1);


### PR DESCRIPTION
While looking at [one of the example](https://github.com/rust-lang/triagebot/issues/2394#issuecomment-4374094982) from #2394, I found my-self a bit perplex at the word highlighting we do.

In particular regarding the color we use which currently follows the color of the line, but that doesn't really make sense, as we want to show what was removed/added between the two part of the hunk, and for that red/green are the standard colors.

This PR therefor changes the word highlighting to always show removed words in red, and added words in green (EDIT: except in a removed line where we use orange, see below). An attempt is made to dim the color for a removed line, where knowing exactly what changed is less relevant.

Light theme:

| Currently | This PR |
|----|----|
| <img width="895" height="326" alt="image" src="https://github.com/user-attachments/assets/459f77b5-e02e-4330-b999-4f401c0c3930" /> | <img width="925" height="330" alt="image" src="https://github.com/user-attachments/assets/eb2598e9-45aa-4145-a77b-57b6a7226115" /><details><summary>V1 & V2</summary><img width="881" height="323" alt="image" src="https://github.com/user-attachments/assets/ada0231e-754e-44c3-8ec0-8e7ca8170d1c" /><img width="927" height="329" alt="image" src="https://github.com/user-attachments/assets/67fd927b-fbfc-4f82-9d6b-580d30990bbf" /></details> |

Dark theme:

| Currently | This PR |
|----|----|
| <img width="902" height="332" alt="image" src="https://github.com/user-attachments/assets/dc3502df-b87e-443d-af0e-9c7f4454cfbb" /> | <img width="901" height="337" alt="image" src="https://github.com/user-attachments/assets/b21f5a29-3cda-4ae2-a8c5-c8ad971d7e96" /><details><summary>V1 & V2</summary><img width="912" height="324" alt="image" src="https://github.com/user-attachments/assets/2b7749b2-7344-441a-a43f-68ea64071da9" /><img width="894" height="331" alt="image" src="https://github.com/user-attachments/assets/43385175-8e38-4816-9d33-3a34a5e2d5c9" /></details> | 

First commit is the actual change, second commit is a refactor/simplification and the other are the orange change.

Testing: http://localhost:8000/gh-range-diff/rust-lang/miri/98cb1d3d48fa7c8e97994050bfd69e8f3da2a1a7..3f8007e19b8cac3d08fb07579bde3217c58807e4/e0b3afbdd5362aa348abc6661ed6417d1a21f58c..d811aaf958594156e2ce38365b835c361aa88de9

@RalfJung does the new colors make sense to you? 