### PR TITLE
Highlight the whole line when too many individual words changed

### DIFF
--- a/src/gh_range_diff.rs
+++ b/src/gh_range_diff.rs
@@ -599,17 +599,41 @@ impl UnifiedDiffPrinter for HtmlDiffPrinter<'_> {
                     // Compute the (word) diff
                     let diff = Diff::compute(Algorithm::Histogram, &input);
 
-                    (diff, input)
+                    // Calculate if the line is too different to highlight individual words
+                    // We check the ratio of changed tokens against the total tokens
+                    let total_tokens = input.before.len() + input.after.len();
+
+                    let removed_count = (0..input.before.len())
+                        .filter(|&i| diff.is_removed(i as u32))
+                        .count();
+                    let added_count = (0..input.after.len())
+                        .filter(|&i| diff.is_added(i as u32))
+                        .count();
+
+                    let changed_tokens = removed_count + added_count;
+
+                    // If more than 60% of the combined unique positions changed
+                    // force word highlighting on all tokens
+                    let force_highlight = if total_tokens > 0 {
+                        (changed_tokens as f32 / total_tokens as f32) >= 0.6
+                    } else {
+                        true
+                    };
+
+                    (diff, input, force_highlight)
                 })
                 .collect();
 
             // Process all before lines first
-            for (diff, input) in &diffs_and_inputs {
+            for (diff, input, force_highlight) in &diffs_and_inputs {
                 self.handle_hunk_line(
                     &mut f,
                     HunkTokenStatus::Removed,
                     input.before.iter().enumerate().map(|(b_pos, b_token)| {
-                        (input.interner[*b_token], diff.is_removed(b_pos as u32))
+                        (
+                            input.interner[*b_token],
+                            *force_highlight || diff.is_removed(b_pos as u32),
+                        )
                     }),
                 )?;
             }
@@ -622,12 +646,15 @@ impl UnifiedDiffPrinter for HtmlDiffPrinter<'_> {
             }
 
             // Then process all after lines
-            for (diff, input) in &diffs_and_inputs {
+            for (diff, input, force_hightlight) in &diffs_and_inputs {
                 self.handle_hunk_line(
                     &mut f,
                     HunkTokenStatus::Added,
                     input.after.iter().enumerate().map(|(a_pos, a_token)| {
-                        (input.interner[*a_token], diff.is_added(a_pos as u32))
+                        (
+                            input.interner[*a_token],
+                            *force_hightlight || diff.is_added(a_pos as u32),
+                        )
                     }),
                 )?;
             }


### PR DESCRIPTION
This PR update our words highlighting logic to highlight the whole line when more than 60% of the individual words changed.

| Currently | This PR |
|----|----|
| <img width="925" height="640" alt="image" src="https://github.com/user-attachments/assets/a1594010-c467-43b1-a11c-bb76941d028f" /> | <img width="946" height="639" alt="image" src="https://github.com/user-attachments/assets/6e228bdb-1f26-44ec-8de4-694ebe27e615" /> |

Testing:
 - https://triagebot.infra.rust-lang.org/gh-range-diff/rust-lang/rust/d1961bebe091816d8ce9771f29ad471dda398f5d..730f7b808d09dbdffe64fac82935e8bf007e3a3a/eab3d9776409dfb564130c3cd5f6ecacef3d3279..02e8e3ed2d03576a26a9b30d46168de2abadf910
 - http://localhost:8000/gh-range-diff/rust-lang/rust/d1961bebe091816d8ce9771f29ad471dda398f5d..730f7b808d09dbdffe64fac82935e8bf007e3a3a/eab3d9776409dfb564130c3cd5f6ecacef3d3279..02e8e3ed2d03576a26a9b30d46168de2abadf910