### PR TITLE
Add specific note to use the `reroll` command instead of bare `r?`

### DIFF
--- a/parser/src/command.rs
+++ b/parser/src/command.rs
@@ -340,7 +340,7 @@ fn review_errors() {
         };
         assert_eq!(
             err.source().unwrap().downcast_ref(),
-            Some(&assign::ParseError::NoUser)
+            Some(&assign::ParseError::NoUserReview)
         );
         assert_eq!(input.next(), None);
     }

--- a/parser/src/command/assign.rs
+++ b/parser/src/command/assign.rs
@@ -30,6 +30,7 @@ pub enum AssignCommand {
 pub enum ParseError {
     ExpectedEnd,
     MentionUser,
+    NoUserReview,
     NoUser,
 }
 
@@ -40,6 +41,10 @@ impl fmt::Display for ParseError {
         match self {
             ParseError::MentionUser => write!(f, "user should start with @"),
             ParseError::ExpectedEnd => write!(f, "expected end of command"),
+            ParseError::NoUserReview => write!(
+                f,
+                "specify user to assign to (if you want to reroll without a specific reviewer in mind, use `@rustbot reroll`)"
+            ),
             ParseError::NoUser => write!(f, "specify user to assign to"),
         }
     }
@@ -104,11 +109,11 @@ impl AssignCommand {
                 let name = strip_circumfix(name, '`', '`').unwrap_or(name);
                 let name = name.strip_prefix('@').unwrap_or(name).to_string();
                 if name.is_empty() {
-                    return Err(input.error(ParseError::NoUser));
+                    return Err(input.error(ParseError::NoUserReview));
                 }
                 Ok(Some(AssignCommand::RequestReview { name }))
             }
-            _ => Err(input.error(ParseError::NoUser)),
+            _ => Err(input.error(ParseError::NoUserReview)),
         }
     }
 }
@@ -194,7 +199,7 @@ mod tests {
                     .source()
                     .unwrap()
                     .downcast_ref(),
-                Some(&ParseError::NoUser),
+                Some(&ParseError::NoUserReview),
                 "failed on {input}"
             )
         }

--- a/parser/src/error.rs
+++ b/parser/src/error.rs
@@ -28,14 +28,20 @@ impl Error<'_> {
 
 impl fmt::Display for Error<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let space = 10;
-        let end = std::cmp::min(self.input.len(), self.position + space);
-        write!(
-            f,
-            "...'{}' | error: {} at >| '{}'...",
-            &self.input[self.position.saturating_sub(space)..self.position],
-            self.source,
-            &self.input[self.position..end],
-        )
+        if self.input.is_empty() {
+            writeln!(f, "{}", self.source)
+        } else {
+            const MARGIN: usize = 10;
+
+            let start = self.position.saturating_sub(MARGIN);
+            let end = std::cmp::min(self.input.len(), self.position + MARGIN);
+            write!(
+                f,
+                "{} when parsing: {}[!]{}",
+                self.source,
+                &self.input[start..self.position],
+                &self.input[self.position..end],
+            )
+        }
     }
 }


### PR DESCRIPTION
This PR adds a specific note to use the `reroll` command instead of bare `r?` and improves the display of the parsing error context (I find the current context display unreadable IMO).

| Currently | This PR (`r?`) | This PR (assign) |
|----|----|----|
| <img width="886" height="195" alt="image" src="https://github.com/user-attachments/assets/3d1090b5-1a6f-4ad2-a3aa-87ee395898f8" /> | <img width="880" height="210" alt="image" src="https://github.com/user-attachments/assets/9e0625c3-c9dc-44e2-905e-66e33b9e760c" /> | <img width="887" height="184" alt="image" src="https://github.com/user-attachments/assets/7a72b607-370a-419e-ac38-48d0defa1119" /> |


Fixes #2402