### PR TITLE
Keep the GraphQl end cursor to avoid getting the data twice

### DIFF
--- a/src/github/queries/issue_with_comments.rs
+++ b/src/github/queries/issue_with_comments.rs
@@ -416,9 +416,15 @@ query ($owner: String!, $repo: String!, $issueNumber: Int!, $commentsCursor: Str
             let reviews_cursor_changed = reviews_end_cursor != reviews_cursor;
 
             // Update cursors for next iteration
-            comments_cursor = comments_end_cursor;
-            review_threads_cursor = review_threads_end_cursor;
-            reviews_cursor = reviews_end_cursor;
+            if comments_end_cursor.is_some() {
+                comments_cursor = comments_end_cursor;
+            }
+            if review_threads_end_cursor.is_some() {
+                review_threads_cursor = review_threads_end_cursor;
+            }
+            if reviews_end_cursor.is_some() {
+                reviews_cursor = reviews_end_cursor;
+            }
 
             // Early return if first page has no more pages for any field (1 API call)
             if all_comments.is_empty()


### PR DESCRIPTION
For some reason GitHub GraphQl api doesn't seems to send anymore a response object at all when we pass the last cursor.

This trigger a bug where we though we had new data (actually the old one) and so everything was duplicated.

This PR fixes it by making sure we never lose a cursor, even if the GraphQl doesn't send one anymore.

| Currently | This PR |
|----|----|
| <img width="959" height="108" alt="image" src="https://github.com/user-attachments/assets/5460d9fc-0bed-4851-8dd5-79a32f60f495" /> | <img width="988" height="157" alt="image" src="https://github.com/user-attachments/assets/36066f30-4013-4730-aeac-9afd5654738b" /> |

Testing: http://localhost:8000/gh-comments/rust-lang/rust-forge/pull/1040