### PR TITLE
user-info command: username extract DWIM

### DIFF
--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -269,7 +269,7 @@ async fn handle_command<'a>(
             ChatCommand::UserInfo {
                 username,
                 organization,
-            } => user_info_cmd(&ctx, gh_id, username, &organization)
+            } => user_info_cmd(&ctx, gh_id, username, organization)
                 .await
                 .map(Some),
             ChatCommand::TeamStats { name, repo } => {
@@ -664,6 +664,13 @@ async fn user_info_cmd(
 
     let pr_limit = 100;
     let recent_days: u64 = 7;
+
+    // Get username from input string
+    let username = username
+        .trim_end_matches('/')
+        .rsplit_once('/')
+        .map(|(_left, right)| right)
+        .unwrap_or(username);
 
     // Load data concurrently to make the command faster
     let (user, user_prs, org_user_prs, user_repos) = futures::future::try_join4(


### PR DESCRIPTION
I often use the triagebot `user-info` command with a link from GH (f.e. `https://www.github.com/apiraino`) and manually remove everything before the GH handle otherwise I get a "failed to fetch user info" error.

I would like someone else to do this onerous work :) Therefore in this patch I suggest a [DWIM (Do What I Mean)](https://en.wikipedia.org/wiki/DWIM) version of the command.

~~todo: e2e tests~~ tested