### PR TITLE
Also take into account the previous filename when mentioning

### DIFF
--- a/src/github/issue.rs
+++ b/src/github/issue.rs
@@ -158,6 +158,9 @@ pub struct GithubCompare {
 pub struct FileDiff {
     /// The fullname path of the file.
     pub filename: String,
+    /// The previous fullname path of the file.
+    #[serde(default)]
+    pub previous_filename: Option<String>,
     /// The patch/diff for the file.
     ///
     /// Can be empty when there isn't any changes to the content of the file

--- a/src/handlers/assign/tests/tests_from_diff.rs
+++ b/src/handlers/assign/tests/tests_from_diff.rs
@@ -33,6 +33,7 @@ fn make_fake_diff(paths: &[(&str, u32, u32)]) -> Vec<FileDiff> {
             FileDiff {
                 filename: path.to_string(),
                 patch: diff,
+                previous_filename: None,
             }
         })
         .collect()
@@ -63,6 +64,7 @@ fn from_diff_submodule() {
             +Subproject commit b001609960ca33047e5cbc5a231c1e24b6041d4b\n\
         "
         .to_string(),
+        previous_filename: None,
     }];
     test_from_diff(&diff, config, &["user1", "user2"]);
 }
@@ -130,6 +132,7 @@ fn empty_file_still_counts() {
         patch: "new file mode 100644\n\
                 index 0000000..e69de29\n"
             .to_string(),
+        previous_filename: None,
     }];
     test_from_diff(&diff, config, &["parser"]);
 }

--- a/src/handlers/check_commits/modified_submodule.rs
+++ b/src/handlers/check_commits/modified_submodule.rs
@@ -36,6 +36,7 @@ fn no_submodule_update() {
             -let mut my_var = 5;\
             +let mut my_var = \"tmp\";"
             .to_string(),
+        previous_filename: None,
     };
 
     assert_eq!(modifies_submodule(&[filediff]), None)
@@ -50,6 +51,7 @@ fn simple_submodule_update() {
             -Subproject commit c0f3b53c8e5de87714d18a5f42998859302ae03a\n\
             +Subproject commit 8158f78f738715c060d230351623a7f7cc01bf97"
             .to_string(),
+        previous_filename: None,
     };
 
     assert_eq!(
@@ -66,6 +68,7 @@ fn no_submodule_update_tricky_case() {
             -let mut subproject_commit = 5;\
             +let mut subproject_commit = \"+Subproject commit \";"
             .to_string(),
+        previous_filename: None,
     };
 
     assert_eq!(modifies_submodule(&[filediff]), None)

--- a/src/handlers/mentions.rs
+++ b/src/handlers/mentions.rs
@@ -20,6 +20,7 @@ pub(super) struct MentionsInput {
     to_mention: Vec<ToMention>,
 }
 
+#[derive(Debug)]
 struct ToMention {
     entry: String,
     relevant_file_paths: Vec<PathBuf>,
@@ -67,10 +68,18 @@ pub(super) async fn parse_input(
         return Ok(None);
     };
 
-    let modified_paths: Vec<_> = modified_files
+    let mut modified_paths: Vec<_> = modified_files
         .iter()
         .map(|fd| Path::new(&fd.filename))
         .collect();
+
+    // also include the previous filename (in case of renames)
+    modified_paths.extend(
+        modified_files
+            .iter()
+            .filter_map(|fd| fd.previous_filename.as_ref())
+            .map(|filename| Path::new(filename)),
+    );
 
     let to_mention: Vec<_> = config
         .entries


### PR DESCRIPTION
When a file is being renamed the filename is the new location and the previous location is the previous one.

We should take both into account with the `[mention]` handler.

Happened in https://github.com/rust-lang/rust/pull/156975 where I should have been mentioned.

API: https://api.github.com/repos/rust-lang/rust/compare/HEAD...a2b21900b40c2d3d3009b8d9e7ecd143416a6b18