### PR TITLE
Add basic `merge` command for merge queues

### DIFF
--- a/parser/src/command.rs
+++ b/parser/src/command.rs
@@ -7,6 +7,7 @@ pub mod assign;
 pub mod close;
 pub mod concern;
 pub mod lock;
+pub mod merge;
 pub mod nominate;
 pub mod note;
 pub mod ping;
@@ -30,6 +31,7 @@ pub enum Command<'a> {
     Note(Result<note::NoteCommand, Error<'a>>),
     Concern(Result<concern::ConcernCommand, Error<'a>>),
     Transfer(Result<transfer::TransferCommand, Error<'a>>),
+    Merge(Result<merge::MergeCommand, Error<'a>>),
 }
 
 #[derive(Debug)]
@@ -146,6 +148,11 @@ impl<'a> Input<'a> {
             Command::Transfer,
             &original_tokenizer,
         ));
+        success.extend(parse_single_command(
+            merge::MergeCommand::parse,
+            Command::Merge,
+            &original_tokenizer,
+        ));
 
         assert!(
             success.len() <= 1,
@@ -222,6 +229,7 @@ impl Command<'_> {
             Command::Note(r) => r.is_ok(),
             Command::Concern(r) => r.is_ok(),
             Command::Transfer(r) => r.is_ok(),
+            Command::Merge(r) => r.is_ok(),
         }
     }
 
@@ -423,4 +431,11 @@ fn resolve() {
             title: "this is my concern".to_string()
         })))
     );
+}
+
+#[test]
+fn merge() {
+    let input = "@bot merge";
+    let mut input = Input::new(input, vec!["bot"]);
+    assert_eq!(input.next(), Some(Command::Merge(Ok(merge::MergeCommand))));
 }

--- a/parser/src/command/merge.rs
+++ b/parser/src/command/merge.rs
@@ -1,0 +1,15 @@
+use crate::error::Error;
+use crate::token::{Token, Tokenizer};
+
+#[derive(PartialEq, Eq, Debug)]
+pub struct MergeCommand;
+
+impl MergeCommand {
+    pub fn parse<'a>(input: &mut Tokenizer<'a>) -> Result<Option<Self>, Error<'a>> {
+        if let Some(Token::Word("merge")) = input.peek_token()? {
+            Ok(Some(Self))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,6 +83,7 @@ define_config! {
     no_merges: NoMergesConfig,
     pr_tracking: ReviewPrefsConfig,
     transfer: TransferConfig,
+    merge: MergeConfig,
     merge_conflicts: MergeConflictConfig,
     bot_pull_requests: BotPullRequests,
     rendered_link: RenderedLinkConfig,
@@ -594,6 +595,21 @@ pub(crate) struct TransferConfig {}
 #[derive(PartialEq, Eq, Debug, Clone, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
+pub(crate) struct MergeConfig {
+    #[serde(rename = "type")]
+    pub(crate) type_: MergeType,
+}
+
+#[derive(PartialEq, Eq, Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum MergeType {
+    /// Github Merge queue
+    MergeQueue,
+}
+
+#[derive(PartialEq, Eq, Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields)]
 pub(crate) struct MergeConflictConfig {
     #[serde(default)]
     pub remove: HashSet<String>,
@@ -940,6 +956,9 @@ mod tests {
             [range-diff]
 
             [review-changes-since]
+
+            [merge]
+            type = "merge-queue"
         "##;
         let config = toml::from_str::<Config>(&config).unwrap();
         let mut ping_teams = HashMap::new();
@@ -1061,6 +1080,9 @@ mod tests {
                 }),
                 review_changes_since: Some(ReviewChangesSinceConfig {}),
                 view_all_comments_link: None,
+                merge: Some(MergeConfig {
+                    type_: MergeType::MergeQueue
+                }),
             }
         );
     }
@@ -1152,6 +1174,7 @@ mod tests {
                 range_diff: None,
                 review_changes_since: None,
                 view_all_comments_link: None,
+                merge: None,
             }
         );
     }

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -3,7 +3,6 @@ use async_trait::async_trait;
 use futures::{FutureExt, future::BoxFuture};
 use http_body_util::BodyExt;
 use http_body_util::Limited;
-use itertools::Itertools;
 use reqwest::Body;
 use reqwest::header::{AUTHORIZATION, USER_AGENT};
 use reqwest::{Client, Request, RequestBuilder, Response, StatusCode};
@@ -359,15 +358,43 @@ impl GithubClient {
         query: &str,
         vars: serde_json::Value,
     ) -> anyhow::Result<serde_json::Value> {
-        let result: serde_json::Value = self.graphql_query_with_errors(query, vars).await?;
-        if let Some(errors) = result["errors"].as_array() {
-            let messages = errors
-                .iter()
-                .map(|err| err["message"].as_str().unwrap_or_default())
-                .format("\n");
-            anyhow::bail!("error: {messages}");
+        let mut result: serde_json::Value = self.graphql_query_with_errors(query, vars).await?;
+        if let Some(errors) = result["errors"].take().as_array_mut() {
+            anyhow::bail!(GraphQlErrors {
+                errors: std::mem::take(errors)
+                    .into_iter()
+                    .map(|err| serde_json::from_value(err).unwrap_or_default())
+                    .collect(),
+            })
         }
         Ok(result)
+    }
+}
+
+#[derive(Debug)]
+pub struct GraphQlErrors {
+    pub errors: Vec<GraphQlError>,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+pub struct GraphQlError {
+    #[serde(default)]
+    pub message: String,
+    #[serde(default)]
+    pub path: Vec<String>,
+    #[serde(default, rename = "type")]
+    pub type_: String,
+}
+
+impl std::fmt::Display for GraphQlErrors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (i, err) in self.errors.iter().enumerate() {
+            if i > 0 {
+                f.write_str("\n")?;
+            }
+            f.write_str(&err.message)?;
+        }
+        Ok(())
     }
 }
 

--- a/src/github/issue.rs
+++ b/src/github/issue.rs
@@ -987,7 +987,17 @@ impl IssueRepository {
 
 #[derive(Debug, serde::Deserialize)]
 pub struct CollaboratorPermission {
-    pub permission: String,
+    pub permission: GitHubPermission,
+}
+
+// https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2026-03-10#get-repository-permissions-for-a-user
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GitHubPermission {
+    Admin,
+    Write,
+    Read,
+    None,
 }
 
 impl IssueRepository {
@@ -999,5 +1009,14 @@ impl IssueRepository {
         let url = format!("{}/collaborators/{username}/permission", self.url(client));
         let permission = client.json(client.get(&url)).await?;
         Ok(permission)
+    }
+}
+
+impl GitHubPermission {
+    pub fn has_write_permissions(&self) -> bool {
+        match self {
+            GitHubPermission::Admin | GitHubPermission::Write => true,
+            GitHubPermission::Read | GitHubPermission::None => false,
+        }
     }
 }

--- a/src/github/issue.rs
+++ b/src/github/issue.rs
@@ -565,15 +565,20 @@ impl Issue {
         Ok(commits)
     }
 
-    /// Returns the GraphQL ID of this issue.
+    /// Returns the GraphQL ID of this issue or pull-request.
     async fn graphql_issue_id(&self, client: &GithubClient) -> anyhow::Result<String> {
         let repo = self.repository();
         let mut issue_id = client
             .graphql_query(
                 "query($owner:String!, $repo:String!, $issueNum:Int!) {
                     repository(owner: $owner, name: $repo) {
-                        issue(number: $issueNum) {
-                            id
+                        issueOrPullRequest(number: $issueNum) {
+                            ... on Issue {
+                                id
+                            }
+                            ... on PullRequest {
+                                id
+                            }
                         }
                     }
                 }
@@ -586,7 +591,7 @@ impl Issue {
             )
             .await?;
         let serde_json::Value::String(issue_id) =
-            issue_id["data"]["repository"]["issue"]["id"].take()
+            issue_id["data"]["repository"]["issueOrPullRequest"]["id"].take()
         else {
             anyhow::bail!("expected issue id, got {issue_id}");
         };
@@ -619,6 +624,26 @@ impl Issue {
                 }),
             )
             .await?;
+        Ok(())
+    }
+
+    /// Enqueues this pull request into the repository's merge queue.
+    pub async fn enqueue_to_merge_queue(&self, client: &GithubClient) -> anyhow::Result<()> {
+        let pr_id = self.graphql_issue_id(client).await?;
+
+        client
+            .graphql_query(
+                "mutation ($pullRequestId: ID!) {
+                  enqueuePullRequest(input: { pullRequestId: $pullRequestId }) {
+                    clientMutationId
+                  }
+                }",
+                serde_json::json!({
+                    "pullRequestId": pr_id,
+                }),
+            )
+            .await?;
+
         Ok(())
     }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -24,6 +24,7 @@ mod issue_links;
 mod lock;
 pub(crate) mod major_change;
 mod mentions;
+mod merge;
 mod merge_conflicts;
 mod milestone_prs;
 mod nominate;
@@ -503,6 +504,7 @@ command_handlers! {
     note: Note,
     concern: Concern,
     transfer: Transfer,
+    merge: Merge,
 }
 
 #[derive(Debug)]

--- a/src/handlers/merge.rs
+++ b/src/handlers/merge.rs
@@ -31,7 +31,7 @@ pub(super) async fn handle_command(
             .await
             .context("failed to get the user repository permission")?;
 
-        perm.permission == "write" || perm.permission == "admin"
+        perm.permission.has_write_permissions()
     };
 
     if !has_perm {

--- a/src/handlers/merge.rs
+++ b/src/handlers/merge.rs
@@ -1,0 +1,64 @@
+use anyhow::Context as _;
+use parser::command::merge::MergeCommand;
+
+use crate::{
+    config::MergeConfig,
+    errors::user_error,
+    github::{Event, client::GraphQlErrors},
+    handlers::Context,
+};
+
+pub(super) async fn handle_command(
+    ctx: &Context,
+    config: &MergeConfig,
+    event: &Event,
+    _cmd: MergeCommand,
+) -> anyhow::Result<()> {
+    let Event::IssueComment(issue_comment) = event else {
+        return user_error!(
+            "`merge` command can only be issued from a pull-request comment/review"
+        );
+    };
+    if issue_comment.issue.pull_request.is_none() {
+        return user_error!("`merge` command can only be issued on an pull-request");
+    };
+
+    let has_perm = {
+        let perm = issue_comment
+            .issue
+            .repository()
+            .collaborator_permission(&ctx.github, &issue_comment.comment.user.login)
+            .await
+            .context("failed to get the user repository permission")?;
+
+        perm.permission == "write" || perm.permission == "admin"
+    };
+
+    if !has_perm {
+        return user_error!(
+            "Unauthorized, only user with `write` permissions on this repository can merge PRs."
+        );
+    };
+
+    match config.type_ {
+        crate::config::MergeType::MergeQueue => {
+            if let Err(err) = issue_comment
+                .issue
+                .enqueue_to_merge_queue(&ctx.github)
+                .await
+            {
+                if let Some(graphql_errors) = err.downcast_ref::<GraphQlErrors>()
+                    && let [error] = &*graphql_errors.errors
+                    && error.path == &["enqueuePullRequest"]
+                    && error.type_ == "UNPROCESSABLE"
+                {
+                    return user_error!(error.message.to_string());
+                }
+
+                anyhow::bail!(err);
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/handlers/review_submitted.rs
+++ b/src/handlers/review_submitted.rs
@@ -36,7 +36,7 @@ pub(crate) async fn handle(
                 .await
                 .context("failed to get the user repository permission")?;
 
-            perm.permission == "write" || perm.permission == "admin"
+            perm.permission.has_write_permissions()
         } {
             // Remove review labels
             event


### PR DESCRIPTION
This pull-request adds a basic `merge` to triagebot, it's currently only intended to work with native GitHub merge queues (so no `bors` support, or normal merge/squash/rebase support).

It's short termm goal is to be able to delegate the merging to the author (or some arbitrary person? tbd), like it's currently possible in `bors`, where a reviewer often ask for a change and than `r=me`. Probably with some `@bot delegate+` like bors.

Technically we don't much, we check the user GitHub permissions on the repo (at least write) and if it's okay we enqueue the PR in the merge queue. Nothing else.

I was unable to fully test it, since I need a public org with a public repo to be able to setup a merge queue, but the error handling works well. I'm planning on testing it in this repo.

<img width="886" height="191" alt="image" src="https://github.com/user-attachments/assets/079623f8-52c6-4077-901a-6c97f085c492" />

This was requested by Clippy (cc @samueltardieu).