### PR TITLE
Show which users reacted in our GitHub comments viewer

### DIFF
--- a/src/gh_comments.rs
+++ b/src/gh_comments.rs
@@ -888,33 +888,54 @@ fn write_reaction_groups_as_html(
     buffer: &mut String,
     reaction_groups: &[GitHubGraphQlReactionGroup],
 ) -> anyhow::Result<()> {
-    let any_reactions = reaction_groups.iter().any(|rg| rg.users.total_count > 0);
+    let any_reactions = reaction_groups.iter().any(|rg| rg.reactors.total_count > 0);
 
     if any_reactions {
         writeln!(buffer, r##"<div class="reactions">"##)?;
 
         for reaction_group in reaction_groups {
-            let total_count = reaction_group.users.total_count;
+            let total_count = reaction_group.reactors.total_count;
 
             if total_count == 0 {
                 continue;
             }
 
             use crate::github::queries::issue_with_comments::GitHubGraphQlReactionContent::*;
-            let emoji = match reaction_group.content {
-                ThumbsUp => "👍",
-                ThumbsDown => "👎",
-                Laugh => "😄",
-                Hooray => "🎉",
-                Confused => "😕",
-                Heart => "❤️",
-                Rocket => "🚀",
-                Eyes => "👀",
+            let (emoji, emoji_desc) = match reaction_group.content {
+                ThumbsUp => ("👍", "thumbs up"),
+                ThumbsDown => ("👎", "thumbs down"),
+                Laugh => ("😄", "laugh"),
+                Hooray => ("🎉", "hooray"),
+                Confused => ("😕", "confused"),
+                Heart => ("❤️", "heart"),
+                Rocket => ("🚀", "rocket"),
+                Eyes => ("👀", "eyes"),
+            };
+
+            let title = {
+                let users = reaction_group
+                    .reactors
+                    .nodes
+                    .iter()
+                    .filter_map(|r| r.login.as_deref())
+                    .collect::<Vec<_>>();
+                let left = total_count.saturating_sub(users.len() as u32);
+
+                let users = users.join(", ");
+                let reacted = if left == 0 {
+                    format!("{users} reacted with {emoji_desc} emoji")
+                } else {
+                    format!("{users} and {left} users reacted with {emoji_desc} emoji")
+                };
+
+                let mut title = String::new();
+                pulldown_cmark_escape::escape_html(&mut title, &reacted)?;
+                title
             };
 
             write!(
                 buffer,
-                r##"<button class="reaction" disabled="disabled">{emoji}<span class="reaction-number">{total_count}</span></button>"##
+                r##"<button class="reaction" disabled="disabled" title="{title}">{emoji}<span class="reaction-number">{total_count}</span></button>"##
             )?;
         }
 

--- a/src/github/queries/issue_with_comments.rs
+++ b/src/github/queries/issue_with_comments.rs
@@ -147,13 +147,20 @@ pub struct GitHubGraphQlReview {
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct GitHubGraphQlReactionGroup {
     pub content: GitHubGraphQlReactionContent,
-    pub users: GitHubGraphQlReactionGroupUsers,
+    pub reactors: GitHubGraphQlReactionGroupReactors,
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
-pub struct GitHubGraphQlReactionGroupUsers {
+pub struct GitHubGraphQlReactionGroupReactors {
     #[serde(rename = "totalCount")]
     pub total_count: u32,
+    pub nodes: Vec<GitHubGraphQlReactionGroupReactor>,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct GitHubGraphQlReactionGroupReactor {
+    #[serde(default)]
+    pub login: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize, Clone, Copy, PartialEq, Eq)]
@@ -250,8 +257,13 @@ query ($owner: String!, $repo: String!, $issueNumber: Int!, $commentsCursor: Str
         }
         reactionGroups {
           content
-          users {
+          reactors(first: 10) {
             totalCount
+            nodes {
+              ... on User {
+                login
+              }
+            }
           }
         }
         comments(first: 100, after: $commentsCursor) {
@@ -268,8 +280,13 @@ query ($owner: String!, $repo: String!, $issueNumber: Int!, $commentsCursor: Str
             url
             reactionGroups {
               content
-              users {
+              reactors(first: 10) {
                 totalCount
+                nodes {
+                  ... on User {
+                    login
+                  }
+                }
               }
             }
           }
@@ -293,8 +310,13 @@ query ($owner: String!, $repo: String!, $issueNumber: Int!, $commentsCursor: Str
         }
         reactionGroups {
           content
-          users {
+          reactors(first: 10) {
             totalCount
+            nodes {
+              ... on User {
+                login
+              }
+            }
           }
         }
         comments(first: 100, after: $commentsCursor) {
@@ -311,8 +333,13 @@ query ($owner: String!, $repo: String!, $issueNumber: Int!, $commentsCursor: Str
             url
             reactionGroups {
               content
-              users {
+              reactors(first: 10) {
                 totalCount
+                nodes {
+                  ... on User {
+                    login
+                  }
+                }
               }
             }
           }
@@ -344,8 +371,13 @@ query ($owner: String!, $repo: String!, $issueNumber: Int!, $commentsCursor: Str
                 url
                 reactionGroups {
                   content
-                  users {
+                  reactors(first: 10) {
                     totalCount
+                    nodes {
+                      ... on User {
+                        login
+                      }
+                    }
                   }
                 }
                 pullRequestReview {
@@ -375,8 +407,13 @@ query ($owner: String!, $repo: String!, $issueNumber: Int!, $commentsCursor: Str
             url
             reactionGroups {
               content
-              users {
+              reactors(first: 10) {
                 totalCount
+                nodes {
+                  ... on User {
+                    login
+                  }
+                }
               }
             }
           }


### PR DESCRIPTION
People have been asking since the beginning (and even at the All-Hands) about seeing who reacted on a issue body, comments, ... and I always though it wasn't possible.

Turns out we can actually fetch the users who reacted to each individual reaction. (I'm just really bad at reading GraphQl)

<img width="1005" height="726" alt="Capture d’écran du 2026-05-28 20-01-59" src="https://github.com/user-attachments/assets/f3326ed3-ef02-4391-8b47-e71d0da59221" />
