### PR TITLE
Add `lock`/`unlock` commands for GitHub issues and pull-requests

### DIFF
--- a/parser/src/command.rs
+++ b/parser/src/command.rs
@@ -6,6 +6,7 @@ use regex::Regex;
 pub mod assign;
 pub mod close;
 pub mod concern;
+pub mod lock;
 pub mod nominate;
 pub mod note;
 pub mod ping;
@@ -24,6 +25,7 @@ pub enum Command<'a> {
     Prioritize(Result<prioritize::PrioritizeCommand, Error<'a>>),
     Second(Result<second::SecondCommand, Error<'a>>),
     Shortcut(Result<shortcut::ShortcutCommand, Error<'a>>),
+    Lock(Result<lock::LockCommand, Error<'a>>),
     Close(Result<close::CloseCommand, Error<'a>>),
     Note(Result<note::NoteCommand, Error<'a>>),
     Concern(Result<concern::ConcernCommand, Error<'a>>),
@@ -130,6 +132,11 @@ impl<'a> Input<'a> {
             &original_tokenizer,
         ));
         success.extend(parse_single_command(
+            lock::LockCommand::parse,
+            Command::Lock,
+            &original_tokenizer,
+        ));
+        success.extend(parse_single_command(
             close::CloseCommand::parse,
             Command::Close,
             &original_tokenizer,
@@ -210,6 +217,7 @@ impl Command<'_> {
             Command::Prioritize(r) => r.is_ok(),
             Command::Second(r) => r.is_ok(),
             Command::Shortcut(r) => r.is_ok(),
+            Command::Lock(r) => r.is_ok(),
             Command::Close(r) => r.is_ok(),
             Command::Note(r) => r.is_ok(),
             Command::Concern(r) => r.is_ok(),
@@ -359,6 +367,26 @@ fn review_ignored() {
         let mut input = Input::new(input, vec!["bot"]);
         assert_eq!(input.next(), None);
     }
+}
+
+#[test]
+fn lock() {
+    let input = "@bot lock";
+    let mut input = Input::new(input, vec!["bot"]);
+    assert_eq!(
+        input.next(),
+        Some(Command::Lock(Ok(lock::LockCommand::Lock)))
+    );
+}
+
+#[test]
+fn unlock() {
+    let input = "@bot unlock";
+    let mut input = Input::new(input, vec!["bot"]);
+    assert_eq!(
+        input.next(),
+        Some(Command::Lock(Ok(lock::LockCommand::Unlock)))
+    );
 }
 
 #[test]

--- a/parser/src/command/lock.rs
+++ b/parser/src/command/lock.rs
@@ -1,0 +1,20 @@
+use crate::error::Error;
+use crate::token::{Token, Tokenizer};
+
+#[derive(PartialEq, Eq, Debug)]
+pub enum LockCommand {
+    Lock,
+    Unlock,
+}
+
+impl LockCommand {
+    pub fn parse<'a>(input: &mut Tokenizer<'a>) -> Result<Option<Self>, Error<'a>> {
+        if let Some(Token::Word("lock")) = input.peek_token()? {
+            Ok(Some(LockCommand::Lock))
+        } else if let Some(Token::Word("unlock")) = input.peek_token()? {
+            Ok(Some(LockCommand::Unlock))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,6 +69,7 @@ define_config! {
     nominate: NominateConfig,
     prioritize: PrioritizeConfig,
     major_change: MajorChangeConfig,
+    lock: LockConfig,
     close: CloseConfig,
     autolabel: AutolabelConfig,
     notify_zulip: NotifyZulipConfig,
@@ -549,6 +550,10 @@ pub(crate) struct MajorChangeTrackingIssueTemplateConfig {
 
 #[derive(PartialEq, Eq, Debug, Clone, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
+pub(crate) struct LockConfig {}
+
+#[derive(PartialEq, Eq, Debug, Clone, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct CloseConfig {}
 
 #[derive(PartialEq, Eq, Debug, Clone, serde::Deserialize)]
@@ -881,6 +886,10 @@ mod tests {
 
             [note]
 
+            [close]
+
+            [lock]
+
             [concern]
             labels = ["has-concerns"]
 
@@ -993,7 +1002,8 @@ mod tests {
                 shortcut: Some(ShortcutConfig { _empty: () }),
                 prioritize: None,
                 major_change: None,
-                close: None,
+                lock: Some(LockConfig {}),
+                close: Some(CloseConfig {}),
                 autolabel: None,
                 notify_zulip: None,
                 github_releases: None,
@@ -1118,6 +1128,7 @@ mod tests {
                 shortcut: None,
                 prioritize: None,
                 major_change: None,
+                lock: None,
                 close: None,
                 autolabel: None,
                 notify_zulip: None,

--- a/src/github/issue.rs
+++ b/src/github/issue.rs
@@ -818,6 +818,20 @@ impl Issue {
             .context("failed to lock issue")?;
         Ok(())
     }
+
+    /// Unlock an issue.
+    pub async fn unlock(&self, client: &GithubClient) -> anyhow::Result<()> {
+        let lock_url = format!(
+            "{}/issues/{}/lock",
+            self.repository().url(client),
+            self.number
+        );
+        client
+            .send_req(client.delete(&lock_url))
+            .await
+            .context("failed to unlock issue")?;
+        Ok(())
+    }
 }
 
 // Pull-request files

--- a/src/github/repos.rs
+++ b/src/github/repos.rs
@@ -208,6 +208,13 @@ impl GithubClient {
             .context("failed to retrive the compare")
     }
 
+    pub async fn issue(&self, repo: &IssueRepository, issue_num: u64) -> anyhow::Result<Issue> {
+        let url = format!("{}/issues/{issue_num}", repo.url(self));
+        self.json(self.get(&url))
+            .await
+            .with_context(|| format!("{repo} failed to get issue {issue_num}"))
+    }
+
     pub async fn pull_request(&self, repo: &IssueRepository, pr_num: u64) -> anyhow::Result<Issue> {
         let url = format!("{}/pulls/{pr_num}", repo.url(self));
         let mut pr: Issue = self
@@ -869,11 +876,15 @@ impl Repository {
     }
 
     pub async fn get_issue(&self, client: &GithubClient, issue_num: u64) -> anyhow::Result<Issue> {
-        let url = format!("{}/issues/{issue_num}", self.url(client));
         client
-            .json(client.get(&url))
+            .issue(
+                &IssueRepository {
+                    organization: self.owner().to_string(),
+                    repository: self.name().to_string(),
+                },
+                issue_num,
+            )
             .await
-            .with_context(|| format!("{} failed to get issue {issue_num}", self.full_name))
     }
 
     pub async fn get_pr(&self, client: &GithubClient, pr_num: u64) -> anyhow::Result<Issue> {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -21,6 +21,7 @@ mod concern;
 pub mod docs_update;
 mod github_releases;
 mod issue_links;
+mod lock;
 pub(crate) mod major_change;
 mod mentions;
 mod merge_conflicts;
@@ -497,6 +498,7 @@ command_handlers! {
     relabel: Relabel,
     major_change: Second,
     shortcut: Shortcut,
+    lock: Lock,
     close: Close,
     note: Note,
     concern: Concern,

--- a/src/handlers/lock.rs
+++ b/src/handlers/lock.rs
@@ -1,0 +1,36 @@
+//! Allows to lock/unlock an issue or a PR
+
+use crate::{config::LockConfig, errors::user_error, github::Event, handlers::Context};
+use parser::command::lock::LockCommand;
+
+pub(super) async fn handle_command(
+    ctx: &Context,
+    _config: &LockConfig,
+    event: &Event,
+    cmd: LockCommand,
+) -> anyhow::Result<()> {
+    let Some(issue) = event.issue() else {
+        return user_error!("Can only lock/unlock issues and pull-request.");
+    };
+
+    let is_team_member = ctx
+        .team
+        .is_team_member(&event.user().login)
+        .await
+        .unwrap_or(false);
+
+    if !is_team_member {
+        return user_error!("Only team members can lock/unlock issues and pull-request.");
+    }
+
+    match cmd {
+        LockCommand::Lock => {
+            issue.lock(&ctx.github, None).await?;
+        }
+        LockCommand::Unlock => {
+            issue.unlock(&ctx.github).await?;
+        }
+    }
+
+    Ok(())
+}

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -10,7 +10,7 @@ use crate::db::users::DbUser;
 use crate::github::queries::user_comments_in_org::UserComment;
 use crate::github::queries::user_prs::PullRequestState;
 use crate::github::queries::user_prs::UserPullRequest;
-use crate::github::{self, Repository};
+use crate::github::{self, PullRequestNumber, Repository};
 use crate::handlers::Context;
 use crate::handlers::docs_update::docs_update;
 use crate::handlers::pr_tracking::{ReviewerWorkqueue, get_assigned_prs};
@@ -261,6 +261,11 @@ async fn handle_command<'a>(
         let output = match &cmd {
             ChatCommand::Whoami => whoami_cmd(&ctx, gh_id).await,
             ChatCommand::Lookup(cmd) => lookup_cmd(&ctx, cmd).await,
+            ChatCommand::Unlock {
+                organization,
+                repo,
+                id,
+            } => unlock_cmd(&ctx, gh_id, organization, repo, *id).await,
             ChatCommand::Work(cmd) => workqueue_commands(&ctx, gh_id, cmd).await,
             ChatCommand::PingGoals(args) => {
                 ping_goals_cmd(ctx.clone(), gh_id, message_data, args).await
@@ -390,6 +395,11 @@ async fn handle_command<'a>(
                     };
                     Ok(None)
                 }
+                StreamCommand::Unlock {
+                    organization,
+                    repo,
+                    id,
+                } => unlock_cmd(&ctx, gh_id, &organization, &repo, id).await,
             };
         }
 
@@ -634,6 +644,51 @@ async fn ping_goals_cmd(
             "That command is only permitted for those running the project-goal program.",
         ))
     }
+}
+
+/// Unlock a specific issue in our managed repos.
+/// This command can only be used by team members.
+async fn unlock_cmd(
+    ctx: &Context,
+    gh_id: u64,
+    org: &str,
+    repo: &str,
+    issue_id: PullRequestNumber,
+) -> anyhow::Result<Option<String>> {
+    let gh_login = ctx
+        .team
+        .username_from_gh_id(gh_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("Username for GitHub user {gh_id} not found"))?;
+
+    if !ctx.team.is_team_member(&gh_login).await? {
+        return Err(anyhow::anyhow!(
+            "This command is only available to team members."
+        ));
+    }
+
+    if ctx.team.repos().await?.repos.get(org).is_none() {
+        return Err(anyhow::anyhow!(
+            "Organization `{org}` is not managed by the team database."
+        ));
+    }
+
+    let issue_repo = github::IssueRepository {
+        organization: org.to_string(),
+        repository: repo.to_string(),
+    };
+
+    let issue = ctx
+        .github
+        .issue(&issue_repo, issue_id)
+        .await
+        .context(format!("Could not get {issue_repo}#{issue_id} details"))?;
+
+    issue.unlock(&ctx.github).await?;
+
+    Ok(Some(format!(
+        "Successfully unlocked {issue_repo}#{issue_id}!"
+    )))
 }
 
 /// Output recent GitHub activity made by a given user (both globally and in a given organization).
@@ -1108,6 +1163,7 @@ fn get_cmd_impersonation_mode(cmd: &ChatCommand) -> ImpersonationMode {
         | ChatCommand::PingGoals(_)
         | ChatCommand::UserInfo { .. }
         | ChatCommand::TeamStats { .. }
+        | ChatCommand::Unlock { .. }
         | ChatCommand::Lookup(_) => ImpersonationMode::Disabled,
         ChatCommand::Whoami => ImpersonationMode::Silent,
         ChatCommand::Work(cmd) => match cmd {

--- a/src/zulip/commands.rs
+++ b/src/zulip/commands.rs
@@ -17,6 +17,16 @@ pub enum ChatCommand {
     /// Inspect or modify your reviewer workqueue.
     #[clap(subcommand)]
     Work(WorkqueueCmd),
+    /// Unlock a specific GitHub issue or pull-request.
+    Unlock {
+        /// Orgnization that is specifically being queried.
+        #[arg(long = "org", default_value = "rust-lang")]
+        organization: String,
+        /// Repository where the issue or pull-request is.
+        repo: String,
+        /// Issue or pull-request number to unlock.
+        id: PullRequestNumber,
+    },
     /// Ping project goal owners.
     PingGoals(PingGoalsArgs),
     /// Update docs
@@ -155,6 +165,16 @@ pub enum StreamCommand {
     },
     /// Label assignment: add one of `P-{low,medium,high,critical}` and remove `I-prioritize`
     AssignPriority(AssignPrioArgs),
+    /// Unlock a specific GitHub issue or pull-request.
+    Unlock {
+        /// Orgnization that is specifically being queried.
+        #[arg(long = "org", default_value = "rust-lang")]
+        organization: String,
+        /// Repository where the issue or pull-request is.
+        repo: String,
+        /// Issue or pull-request number to unlock.
+        id: PullRequestNumber,
+    },
 }
 
 #[derive(clap::Parser, Debug, PartialEq, Clone)]

--- a/src/zulip/commands.rs
+++ b/src/zulip/commands.rs
@@ -20,7 +20,7 @@ pub enum ChatCommand {
     /// Unlock a specific GitHub issue or pull-request.
     Unlock {
         /// Orgnization that is specifically being queried.
-        #[arg(long = "org", default_value = "rust-lang")]
+        #[arg(long = "org", default_value_t = get_default_org())]
         organization: String,
         /// Repository where the issue or pull-request is.
         repo: String,
@@ -38,7 +38,7 @@ pub enum ChatCommand {
         /// GitHub username to look up.
         username: String,
         /// Organization where to find the user's activity.
-        #[arg(long = "org", default_value = "rust-lang")]
+        #[arg(long = "org", default_value_t = get_default_org())]
         organization: String,
     },
     /// Shows review queue statistics of members of the given Rust team.
@@ -47,7 +47,7 @@ pub enum ChatCommand {
         name: String,
         /// Repository that is specifically being queried.
         /// Defaults to `rust` (if you do not specify an org, it will be filled to `rust-lang/`).
-        #[arg(long, default_value = "rust-lang/rust")]
+        #[arg(long, default_value_t = get_default_org_repo())]
         repo: String,
     },
 }
@@ -74,7 +74,7 @@ pub enum WorkqueueCmd {
     Show {
         /// Repository for which to show the statistics.
         /// Defaults to `rust` (if you do not specify an org, it will be filled to `rust-lang/`).
-        #[arg(long, default_value = "rust-lang/rust")]
+        #[arg(long, default_value_t = get_default_org_repo())]
         repo: String,
     },
     /// Set the maximum capacity limit of your workqueue for a specific repository.
@@ -83,7 +83,7 @@ pub enum WorkqueueCmd {
         limit: WorkqueueLimit,
         /// Repository on which to set the limit.
         /// Defaults to `rust` (if you do not specify an org, it will be filled to `rust-lang/`).
-        #[arg(long, default_value = "rust-lang/rust")]
+        #[arg(long, default_value_t = get_default_org_repo())]
         repo: String,
     },
     /// Set your rotation mode (`on` rotation or `off` rotation).
@@ -160,7 +160,7 @@ pub enum StreamCommand {
         /// GitHub username to look up.
         username: String,
         /// Organization where to find the activity.
-        #[arg(long = "org", default_value = "rust-lang")]
+        #[arg(long = "org", default_value_t = get_default_org())]
         organization: String,
     },
     /// Label assignment: add one of `P-{low,medium,high,critical}` and remove `I-prioritize`
@@ -168,7 +168,7 @@ pub enum StreamCommand {
     /// Unlock a specific GitHub issue or pull-request.
     Unlock {
         /// Orgnization that is specifically being queried.
-        #[arg(long = "org", default_value = "rust-lang")]
+        #[arg(long = "org", default_value_t = get_default_org())]
         organization: String,
         /// Repository where the issue or pull-request is.
         repo: String,
@@ -285,6 +285,17 @@ pub fn parse_cli<'a, T: Parser, I: Iterator<Item = &'a str>>(input: I) -> anyhow
         .try_get_matches_from(input)?;
     let value = T::from_arg_matches(&matches)?;
     Ok(value)
+}
+
+fn get_default_org() -> String {
+    std::env::var("MAIN_GH_REPO_OWNER").unwrap_or_else(|_| "rust-lang".to_string())
+}
+
+fn get_default_org_repo() -> String {
+    let repo_owner = std::env::var("MAIN_GH_REPO_OWNER").unwrap_or("rust-lang".to_string());
+    let repo_name = std::env::var("MAIN_GH_REPO_NAME").unwrap_or("rust".to_string());
+
+    format!("{}/{}", repo_owner, repo_name)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
While talking with the moderation team @oli-obk expressed the desired to have triagebot commands to lock and unlock issues and pull-requests on repos they don't have write access.

This PR therefore adds the following commands:
 - On GitHub:
   - `lock`
   - `unlock`
 - On Zulip (stream and DM):
   - `unlock [--org <org>] <repo> <id>` *(to be able to unlock after locking, otherwise can't post a comment)*

I didn't add a `lock` command on Zulip as it seems preferable to do it in the open, let me @oli-obk if you also want a `lock` command on Zulip.

All the commands are restricted to team members and the GitHub commands are also behind the `[lock]` config (which we should enable org-wide after some basic testing).

I've tested the GitHub commands on my repo without an issue. I couldn't test the Zulip command unfortunately.