### PR TITLE
Enable `[lock]` handler in this repo for testing

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -5,6 +5,8 @@ allow-unauthenticated = ["bug", "invalid", "question", "enhancement"]
 
 [note]
 
+[lock]
+
 [concern]
 labels = ["has-concerns"]
 


### PR DESCRIPTION
Let's enable the `[lock]` handler in this repo so we can validate it's well working in here before enabling org-wide. 