### PR TITLE
Restore welcome messages by also checking for the `None` association

### DIFF
--- a/src/github/issue.rs
+++ b/src/github/issue.rs
@@ -1,6 +1,5 @@
 use anyhow::Context;
 use chrono::Utc;
-use octocrab::models::AuthorAssociation;
 use reqwest::StatusCode;
 use std::fmt;
 use std::sync::OnceLock;
@@ -734,6 +733,38 @@ impl Issue {
             .await
             .context("failed to post comment")?;
         Ok(comment)
+    }
+}
+
+// Author association
+
+#[derive(Debug, serde::Deserialize, serde::Serialize, PartialEq)]
+#[serde(transparent)]
+pub struct AuthorAssociation(octocrab::models::AuthorAssociation);
+
+impl AuthorAssociation {
+    pub fn is_probably_first_timer(&self) -> bool {
+        use octocrab::models::AuthorAssociation;
+
+        // See https://github.com/llvm/llvm-project/blob/00062ed982256651a28187e865d6ae14e21d8395/.github/workflows/new-prs.yml#L22-L34
+        // for why we are also checking None
+        matches!(
+            self.0,
+            AuthorAssociation::FirstTimer
+                | AuthorAssociation::FirstTimeContributor
+                | AuthorAssociation::None
+        )
+    }
+
+    pub fn is_org_member(&self) -> bool {
+        use octocrab::models::AuthorAssociation;
+        matches!(self.0, AuthorAssociation::Member | AuthorAssociation::Owner)
+    }
+}
+
+impl From<octocrab::models::AuthorAssociation> for AuthorAssociation {
+    fn from(value: octocrab::models::AuthorAssociation) -> Self {
+        Self(value)
     }
 }
 

--- a/src/handlers/assign.rs
+++ b/src/handlers/assign.rs
@@ -189,8 +189,12 @@ pub(super) async fn handle_input(
             }
         } else if matches!(
             event.issue.author_association,
-            AuthorAssociation::FirstTimer | AuthorAssociation::FirstTimeContributor
+            AuthorAssociation::FirstTimer
+                | AuthorAssociation::FirstTimeContributor
+                | AuthorAssociation::None
         ) {
+            // See https://github.com/llvm/llvm-project/blob/00062ed982256651a28187e865d6ae14e21d8395/.github/workflows/new-prs.yml#L22-L34
+            // for why we are also checking None
             let assignee_text = match &assignee {
                 Some(assignee) => messages::welcome_with_reviewer(&assignee.name),
                 None => messages::WELCOME_WITHOUT_REVIEWER.to_string(),

--- a/src/handlers/assign.rs
+++ b/src/handlers/assign.rs
@@ -33,7 +33,6 @@ use crate::{
     interactions::EditIssueBody,
 };
 use anyhow::{Context as _, bail};
-use octocrab::models::AuthorAssociation;
 use parser::command::assign::AssignCommand;
 use parser::command::{Command, Input};
 use rand::seq::IteratorRandom;
@@ -177,24 +176,14 @@ pub(super) async fn handle_input(
 
                 if let Some(ref mut welcome) = welcome
                     && let Some(contrib) = &config.contributing_url
-                    && matches!(
-                        event.issue.author_association,
-                        AuthorAssociation::FirstTimer | AuthorAssociation::FirstTimeContributor
-                    )
+                    && event.issue.author_association.is_probably_first_timer()
                 {
                     welcome.push_str("\n\n");
                     welcome.push_str(&messages::contribution_message(contrib, &ctx.username));
                 }
                 welcome
             }
-        } else if matches!(
-            event.issue.author_association,
-            AuthorAssociation::FirstTimer
-                | AuthorAssociation::FirstTimeContributor
-                | AuthorAssociation::None
-        ) {
-            // See https://github.com/llvm/llvm-project/blob/00062ed982256651a28187e865d6ae14e21d8395/.github/workflows/new-prs.yml#L22-L34
-            // for why we are also checking None
+        } else if event.issue.author_association.is_probably_first_timer() {
             let assignee_text = match &assignee {
                 Some(assignee) => messages::welcome_with_reviewer(&assignee.name),
                 None => messages::WELCOME_WITHOUT_REVIEWER.to_string(),

--- a/src/handlers/check_commits.rs
+++ b/src/handlers/check_commits.rs
@@ -418,7 +418,7 @@ r#":warning: **Warning** :warning:
                 state: crate::github::IssueState::Open,
                 milestone: None,
                 mergeable: None,
-                author_association: octocrab::models::AuthorAssociation::Contributor,
+                author_association: octocrab::models::AuthorAssociation::Contributor.into(),
             },
             changes: None,
             before: None,

--- a/src/handlers/review_reminder.rs
+++ b/src/handlers/review_reminder.rs
@@ -1,5 +1,3 @@
-use octocrab::models::AuthorAssociation;
-
 use crate::{config::ShortcutConfig, db::issue_data::IssueData, github::Issue, handlers::Context};
 
 /// Key for the state in the database
@@ -22,10 +20,7 @@ pub(crate) async fn remind_author_of_bot_ready(
         return Ok(());
     };
 
-    if matches!(
-        issue.author_association,
-        AuthorAssociation::Member | AuthorAssociation::Owner
-    ) {
+    if issue.author_association.is_org_member() {
         // Don't post the reminder for org members (public-only unfortunately) and owner of the org.
         return Ok(());
     }

--- a/src/tests/github.rs
+++ b/src/tests/github.rs
@@ -74,7 +74,7 @@ pub fn issue(
         state,
         milestone: None,
         mergeable: None,
-        author_association: octocrab::models::AuthorAssociation::None,
+        author_association: octocrab::models::AuthorAssociation::None.into(),
     }
 }
 


### PR DESCRIPTION
Context: [#triagebot > Welcome message isn't being posted](https://rust-lang.zulipchat.com/#narrow/channel/224082-triagebot/topic/Welcome.20message.20isn.27t.20being.20posted/with/598629929)