### PR TITLE
Enable `[lock]` handler in the `rust-lang` organization

### DIFF
--- a/rust-lang.triagebot.toml
+++ b/rust-lang.triagebot.toml
@@ -45,6 +45,13 @@ excluded-repos = [
   "rust-lang/team", # no write permissions
 ]
 
+# Allow mods/members to lock/unlock an issue or PR (`@rustbot lock`)
+# Documentation at: https://forge.rust-lang.org/triagebot/lock.html
+[lock]
+excluded-repos = [
+  "rust-lang/team", # no write permissions
+]
+
 # Enable merge conflicts notifications in PRs
 # Documentation at: https://forge.rust-lang.org/triagebot/merge-conflicts.html
 [merge-conflicts]


### PR DESCRIPTION
I've done some extra testing in https://github.com/rust-lang/triagebot/issues/2419, everything worked as expected (both from GitHub and Zulip).

I think we are ready to enable both commands org-wide, so that they can be used on all triagebot-enabled repository by mods and members.

cc @oli-obk 