### PR TITLE
Add commit message diff in our range-diff implementation

### DIFF
--- a/src/gh_range_diff.rs
+++ b/src/gh_range_diff.rs
@@ -385,7 +385,11 @@ fn process_old_new(
 
         // Show the changes if there are any hunks to be shown
         if !hunks.is_empty() {
-            let printer = HtmlDiffPrinter(&input.interner, filename);
+            let printer = HtmlDiffPrinter {
+                interner: &input.interner,
+                filename: Some(filename),
+                mode: HtmlDiffPrinterMode::DoubleDiff,
+            };
             let unified_diff = CustomUnifiedDiff {
                 printer: &printer,
                 hunks: &hunks,
@@ -475,13 +479,23 @@ fn process_old_new(
 const REMOVED_BLOCK_SIGN: &str = r#"<span class="removed-block"> - </span>"#;
 const ADDED_BLOCK_SIGN: &str = r#"<span class="added-block"> + </span>"#;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 enum HunkTokenStatus {
     Added,
     Removed,
 }
 
-struct HtmlDiffPrinter<'a>(pub &'a Interner<&'a str>, pub &'a str);
+struct HtmlDiffPrinter<'a> {
+    pub interner: &'a Interner<&'a str>,
+    pub filename: Option<&'a str>,
+    pub mode: HtmlDiffPrinterMode,
+}
+
+#[derive(PartialEq)]
+enum HtmlDiffPrinterMode {
+    DoubleDiff,
+    NormalDiff,
+}
 
 impl HtmlDiffPrinter<'_> {
     #[expect(clippy::unused_self, reason = "might use it later")]
@@ -500,8 +514,14 @@ impl HtmlDiffPrinter<'_> {
         let mut words = words.peekable();
 
         let first_word = words.peek();
-        let is_add = first_word.is_some_and(|w| w.0.starts_with('+'));
-        let is_remove = first_word.is_some_and(|w| w.0.starts_with('-'));
+        let is_add = match self.mode {
+            HtmlDiffPrinterMode::DoubleDiff => first_word.is_some_and(|w| w.0.starts_with('+')),
+            HtmlDiffPrinterMode::NormalDiff => hunk_token_status == HunkTokenStatus::Added,
+        };
+        let is_remove = match self.mode {
+            HtmlDiffPrinterMode::DoubleDiff => first_word.is_some_and(|w| w.0.starts_with('-')),
+            HtmlDiffPrinterMode::NormalDiff => hunk_token_status == HunkTokenStatus::Removed,
+        };
 
         // Highlight in the same was as `git range-diff` does for diff-lines
         // that changed. In addition we also do word highlighting.
@@ -555,16 +575,17 @@ impl UnifiedDiffPrinter for HtmlDiffPrinter<'_> {
     ) -> fmt::Result {
         const NEW_LINE: &str = "\n";
 
-        write!(
-            f,
-            r#"<span class="filename-line"> <span class="filename-block">@@</span> <b>{}</b>{NEW_LINE}</span>"#,
-            self.1
-        )?;
+        if let Some(filename) = &self.filename {
+            write!(
+                f,
+                r#"<span class="filename-line"> <span class="filename-block">@@</span> <b>{filename}</b>{NEW_LINE}</span>"#,
+            )?;
+        }
         Ok(())
     }
 
     fn display_context_token(&self, mut f: impl fmt::Write, token: Token) -> fmt::Result {
-        let token = self.0[token];
+        let token = self.interner[token];
         write!(f, "    ")?;
         pulldown_cmark_escape::escape_html(FmtWriter(&mut f), token)?;
         if !token.ends_with('\n') {
@@ -592,8 +613,8 @@ impl UnifiedDiffPrinter for HtmlDiffPrinter<'_> {
                 .map(|(b_token, a_token)| {
                     // Split both lines by words and intern them.
                     let input: InternedInput<&str> = InternedInput::new(
-                        SplitWordBoundaries(self.0[*b_token]),
-                        SplitWordBoundaries(self.0[*a_token]),
+                        SplitWordBoundaries(self.interner[*b_token]),
+                        SplitWordBoundaries(self.interner[*a_token]),
                     );
 
                     // Compute the (word) diff
@@ -640,7 +661,7 @@ impl UnifiedDiffPrinter for HtmlDiffPrinter<'_> {
 
             // Add potentially missing new-line after the last before diff line
             if let Some(&last) = before.last() {
-                if !self.0[last].ends_with('\n') {
+                if !self.interner[last].ends_with('\n') {
                     writeln!(f)?;
                 }
             }
@@ -661,7 +682,7 @@ impl UnifiedDiffPrinter for HtmlDiffPrinter<'_> {
 
             // Add potentially missing new-line after the last after diff line
             if let Some(&last) = after.last() {
-                if !self.0[last].ends_with('\n') {
+                if !self.interner[last].ends_with('\n') {
                     writeln!(f)?;
                 }
             }
@@ -670,28 +691,28 @@ impl UnifiedDiffPrinter for HtmlDiffPrinter<'_> {
 
             if let Some(&last) = before.last() {
                 for &token in before {
-                    let token = self.0[token];
+                    let token = self.interner[token];
                     self.handle_hunk_line(
                         &mut f,
                         HunkTokenStatus::Removed,
                         std::iter::once((token, false)),
                     )?;
                 }
-                if !self.0[last].ends_with('\n') {
+                if !self.interner[last].ends_with('\n') {
                     writeln!(f)?;
                 }
             }
 
             if let Some(&last) = after.last() {
                 for &token in after {
-                    let token = self.0[token];
+                    let token = self.interner[token];
                     self.handle_hunk_line(
                         &mut f,
                         HunkTokenStatus::Added,
                         std::iter::once((token, false)),
                     )?;
                 }
-                if !self.0[last].ends_with('\n') {
+                if !self.interner[last].ends_with('\n') {
                     writeln!(f)?;
                 }
             }

--- a/src/gh_range_diff.rs
+++ b/src/gh_range_diff.rs
@@ -19,7 +19,7 @@ use pulldown_cmark_escape::FmtWriter;
 use regex::Regex;
 use unicode_segmentation::UnicodeSegmentation;
 
-use crate::github::GithubCompare;
+use crate::github::{GithubCommit, GithubCompare};
 use crate::utils::is_known_and_public_repo;
 use crate::{errors::AppError, github, handlers::Context};
 
@@ -353,6 +353,7 @@ fn process_old_new(
 <h3>range-diff of {a_compare_before} {a_compare_after} in {owner}/{repo}</h3>
 <span>Legend: {REMOVED_BLOCK_SIGN}&nbsp;Removed from previous diff | {ADDED_BLOCK_SIGN}&nbsp;Added in new diff</span>
 <div class="spacer"></div>
+<h3>Changes</h3>
 "#
     )?;
 
@@ -447,6 +448,98 @@ fn process_old_new(
     // Print message when there aren't any differences
     if diff_displayed == 0 {
         writeln!(html, "<p>No differences</p>")?;
+    }
+
+    writeln!(html, "<h3>Commits</h3>")?;
+
+    let mut old_commits_it = old.commits.iter();
+    let mut new_commits_it = new.commits.iter();
+    let mut commit_number = 0;
+
+    loop {
+        let old_commit = old_commits_it.next();
+        let new_commit = new_commits_it.next();
+        commit_number += 1;
+
+        if let None = old_commit
+            && let None = new_commit
+        {
+            break;
+        }
+
+        fn commit_content_as_txt(commit: &GithubCommit) -> String {
+            let mut content = String::new();
+
+            if let Some(author_name) = &commit.commit.author.name {
+                let _ = write!(content, "Author: {author_name}");
+
+                if let Some(author_email) = &commit.commit.author.email {
+                    let _ = write!(content, " <{author_email}>");
+                }
+                content.push_str("\n\n");
+            }
+
+            content.push_str(&commit.commit.message);
+            content
+        }
+
+        // Prepare the inputs
+        let old_content = old_commit
+            .map(commit_content_as_txt)
+            .unwrap_or_else(|| "".to_string());
+        let new_content = new_commit
+            .map(commit_content_as_txt)
+            .unwrap_or_else(|| "".to_string());
+
+        // Prepare the
+        let old_sha = old_commit
+            .map(|c| a_github_commit("", owner, repo, &c.sha))
+            .unwrap_or_else(|| ".......".to_string());
+
+        let new_sha = new_commit
+            .map(|c| a_github_commit("", owner, repo, &c.sha))
+            .unwrap_or_else(|| ".......".to_string());
+
+        let first_line_message = new_commit
+            .or(old_commit)
+            .map(|c| c.commit.message.lines().next())
+            .flatten()
+            .unwrap_or("");
+
+        // Compute the diff
+        let input: InternedInput<&str> = InternedInput::new(&*old_content, &*new_content);
+        let mut diff = Diff::compute(Algorithm::Histogram, &input);
+        diff.postprocess_lines(&input);
+
+        // Collect all the hunks
+        let hunks = diff.hunks().collect::<Vec<_>>();
+
+        // Show the diff if there are any changes
+        if !hunks.is_empty() {
+            let printer = HtmlDiffPrinter {
+                interner: &input.interner,
+                filename: None,
+                mode: HtmlDiffPrinterMode::NormalDiff,
+            };
+
+            let unified_diff = CustomUnifiedDiff {
+                printer: &printer,
+                hunks: &hunks,
+                config: CustomUnifiedDiffConfig { context_len: 1000 },
+                before: &input.before,
+                after: &input.after,
+            };
+
+            writeln!(
+                html,
+                "<details open><summary><span>{commit_number}: {old_sha} -- {new_sha} {first_line_message}</span></summary><pre>{unified_diff}</pre></details>",
+            )?;
+        } else {
+            writeln!(
+                html,
+                r#"<details><summary><span>{commit_number}: {old_sha} -- {new_sha} {first_line_message}</span></summary><pre style="margin-left: 4ch">{new_content}</pre></details>"#,
+            )?;
+        }
     }
 
     writeln!(
@@ -835,5 +928,13 @@ fn a_github_compare(class: &str, owner: &str, repo: &str, base: &str, head: &str
         r#"<a href="https://github.com/{owner}/{repo}/compare/{base}..{head}" class="compare {class}">{base_6}..{head_6}</a>"#,
         base_6 = &base[..base.len().min(7)],
         head_6 = &head[..head.len().min(7)]
+    )
+}
+
+// Function to create an <a> link to a GitHub
+fn a_github_commit(class: &str, owner: &str, repo: &str, sha: &str) -> String {
+    format!(
+        r#"<a href="https://github.com/{owner}/{repo}/commit/{sha}" class="{class}">{sha_6}</a>"#,
+        sha_6 = &sha[..sha.len().min(7)],
     )
 }

--- a/src/github/repos.rs
+++ b/src/github/repos.rs
@@ -1108,6 +1108,8 @@ pub struct GitTreeObject {
 #[derive(Debug, serde::Deserialize)]
 pub struct GitUser {
     pub date: DateTime<FixedOffset>,
+    pub name: Option<String>,
+    pub email: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize)]

--- a/src/handlers/check_commits.rs
+++ b/src/handlers/check_commits.rs
@@ -326,6 +326,8 @@ fn dummy_commit_from_body(sha: &str, body: &str) -> GithubCommit {
         commit: crate::github::GithubCommitCommitField {
             author: crate::github::GitUser {
                 date: DateTime::<FixedOffset>::MIN_UTC.into(),
+                name: Some("octocrab".to_string()),
+                email: Some("example@example.com".to_string()),
             },
             message: body.to_string(),
             tree: crate::github::GitCommitTree {


### PR DESCRIPTION
It has been mentioned to me by multiple people that they would like to see the different commit messages in our range-diff, like is done in the official `git range-diff`.

This PR therefore adds such feature. It's not exactly the same, as we show the changes across the full range, and not per commit as is done by `git range-diff`.

As such I added a new section called "Commits" which list all the commits and the diff if there is a change in the message.

| New commits | Changed message |
|--------|-----------|
| <img width="786" height="688" alt="image" src="https://github.com/user-attachments/assets/e8ae9cac-4829-4a80-9344-97716de947f1" />| <img width="904" height="328" alt="image" src="https://github.com/user-attachments/assets/79f6ed19-d9e2-4bd9-9ddd-ac9f9084ed9b" /> |

Testing links:
 - http://localhost:8000/gh-range-diff/rust-lang/rust/6769f690f947f12e36db6b6503bab265b7b2cced..87d009021e6e5aa59fd17fe91751de91e084db27/1a70f8d36e818b45829a5c065fd6004c9047e8d1..57e3c83223818777372d156134c56ee31af0b1a6
 - http://localhost:8000/gh-range-diff/rust-lang/rust/3bf5c6d99bc8a0c0d5b2f69826ed4f6d256a0a21..b3687efe9eaed1c1de123100ece0e54d9e59787f/3bf5c6d99bc8a0c0d5b2f69826ed4f6d256a0a21..c24ec53db05b64c5a9817160aae04029da58dd24

Best reviewed commit by commit.

cc @camelid