### PR TITLE
Add backport approve Zulip shortcuts

### DIFF
--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -436,13 +436,13 @@ async fn accept_decline_backport(
 
     // Parse the stream subjetc if the channel or the pr num are not provided
     if pr_num.is_none() || channel.is_none() {
-        let (_pr_num, _channel) = subject
+        let (maybe_pr_num, maybe_channel) = subject
             .rsplit_once(':')
             .context("Could not parse a valid PR num")?;
 
         if pr_num.is_none() {
             pr_num = Some(
-                _pr_num
+                maybe_pr_num
                     .strip_prefix('#')
                     .context("Could not parse a valid PR num")?
                     .parse::<u64>()
@@ -452,7 +452,7 @@ async fn accept_decline_backport(
 
         if channel.is_none() {
             channel = Some(
-                _channel
+                maybe_channel
                     .rsplit_once('-')
                     .map(|s| s.0.trim().try_into())
                     .expect("Could not parse a valid release channel")
@@ -462,7 +462,7 @@ async fn accept_decline_backport(
     };
 
     let pr_num = pr_num.context("No PR number to apply to")?;
-    let channel = channel.context("No PR number to apply to")?;
+    let channel = channel.context("No channel to apply to")?;
 
     // Repository owner and name are hardcoded
     // This command is only used in this repository

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -363,18 +363,18 @@ async fn handle_command<'a>(
                 }
                 StreamCommand::DocsUpdate => trigger_docs_update(&ctx.zulip, message_data),
                 StreamCommand::Backport {
-                    channel,
                     verb,
+                    channel,
                     pr_num,
                 } => {
                     let _ =
-                        match accept_decline_backport(&ctx, message_data, &channel, &verb, pr_num)
+                        match accept_decline_backport(&ctx, message_data, &verb, channel, pr_num)
                             .await
                         {
                             // give user feedback
                             Ok(_) => ctx.zulip.add_reaction(message_data.id, "check").await,
                             Err(err) => {
-                                log::error!("Could not handle backport #{}: {:?}", pr_num, err);
+                                log::error!("Could not handle backport #{:?}: {:?}", pr_num, err);
                                 ctx.zulip.add_reaction(message_data.id, "scream").await
                             }
                         };
@@ -410,16 +410,16 @@ async fn handle_command<'a>(
     }
 }
 
-// TODO: shorter variant of this command (f.e. `backport accept` or even `accept`) that infers everything from the Message payload
 async fn accept_decline_backport(
     ctx: &Context,
     message_data: &Message,
-    channel: &BackportChannelArgs,
     verb: &BackportVerbArgs,
-    pr_num: PullRequestNumber,
+    channel: Option<BackportChannelArgs>,
+    pr_num: Option<PullRequestNumber>,
 ) -> anyhow::Result<Option<String>> {
     let message = message_data.clone();
     let stream_id = message.stream_id.unwrap();
+    // expected something like "#123456: beta-nominated"
     let subject = message.subject.unwrap();
     let zulip_client = &ctx.zulip;
     let zulip_stream = zulip_client.get_zulip_channel_by_id(stream_id).await?;
@@ -430,6 +430,39 @@ async fn accept_decline_backport(
         .map_or(&*zulip_stream.name, |s| s.0)
         .strip_prefix("t-")
         .unwrap_or_default();
+
+    let mut pr_num = pr_num;
+    let mut channel = channel.clone();
+
+    // Parse the stream subjetc if the channel or the pr num are not provided
+    if pr_num.is_none() || channel.is_none() {
+        let (_pr_num, _channel) = subject
+            .rsplit_once(':')
+            .context("Could not parse a valid PR num")?;
+
+        if pr_num.is_none() {
+            pr_num = Some(
+                _pr_num
+                    .strip_prefix('#')
+                    .context("Could not parse a valid PR num")?
+                    .parse::<u64>()
+                    .context("Could not parse a valid PR num")?,
+            );
+        }
+
+        if channel.is_none() {
+            channel = Some(
+                _channel
+                    .rsplit_once('-')
+                    .map(|s| s.0.trim().try_into())
+                    .expect("Could not parse a valid release channel")
+                    .unwrap(),
+            );
+        }
+    };
+
+    let pr_num = pr_num.context("No PR number to apply to")?;
+    let channel = channel.context("No PR number to apply to")?;
 
     // Repository owner and name are hardcoded
     // This command is only used in this repository

--- a/src/zulip/commands.rs
+++ b/src/zulip/commands.rs
@@ -155,12 +155,12 @@ pub enum StreamCommand {
     DocsUpdate,
     /// Accept or decline a backport.
     Backport {
-        /// Release channel this backport is pointing to. Allowed: "beta" or "stable".
-        channel: BackportChannelArgs,
         /// Accept or decline this backport? Allowed: "accept", "accepted", "approve", "approved", "decline", "declined".
         verb: BackportVerbArgs,
+        /// Release channel for this backport. Allowed: "beta" or "stable".
+        channel: Option<BackportChannelArgs>,
         /// PR to be backported
-        pr_num: PullRequestNumber,
+        pr_num: Option<PullRequestNumber>,
     },
     /// Show recent GitHub activity of a user.
     UserInfo {
@@ -209,6 +209,28 @@ impl std::fmt::Display for BackportChannelArgs {
         match &self {
             BackportChannelArgs::Beta => write!(f, "beta"),
             BackportChannelArgs::Stable => write!(f, "stable"),
+        }
+    }
+}
+
+impl TryFrom<&str> for &BackportChannelArgs {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "stable" => Ok(&BackportChannelArgs::Stable),
+            "beta" => Ok(&BackportChannelArgs::Beta),
+            _ => Err("unsupported `{value}` backport channel"),
+        }
+    }
+}
+
+impl TryFrom<&str> for BackportChannelArgs {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "stable" => Ok(BackportChannelArgs::Stable),
+            "beta" => Ok(BackportChannelArgs::Beta),
+            _ => Err("unsupported `{value}` backport channel"),
         }
     }
 }
@@ -389,19 +411,37 @@ mod tests {
     #[test]
     fn backports_command() {
         assert_eq!(
-            parse_stream(&["backport", "beta", "accept", "123456"]),
+            parse_stream(&["backport", "accept", "beta", "123456"]),
             StreamCommand::Backport {
-                channel: BackportChannelArgs::Beta,
                 verb: BackportVerbArgs::Accept,
-                pr_num: 123456
+                channel: Some(BackportChannelArgs::Beta),
+                pr_num: Some(123456)
             }
         );
         assert_eq!(
-            parse_stream(&["backport", "stable", "decline", "123456"]),
+            parse_stream(&["backport", "decline", "stable", "123456"]),
             StreamCommand::Backport {
-                channel: BackportChannelArgs::Stable,
                 verb: BackportVerbArgs::Decline,
-                pr_num: 123456
+                channel: Some(BackportChannelArgs::Stable),
+                pr_num: Some(123456)
+            }
+        );
+
+        assert_eq!(
+            parse_stream(&["backport", "decline", "stable"]),
+            StreamCommand::Backport {
+                verb: BackportVerbArgs::Decline,
+                channel: Some(BackportChannelArgs::Stable),
+                pr_num: None
+            }
+        );
+
+        assert_eq!(
+            parse_stream(&["backport", "decline"]),
+            StreamCommand::Backport {
+                verb: BackportVerbArgs::Decline,
+                channel: None,
+                pr_num: None
             }
         );
     }


### PR DESCRIPTION
follow-up to #2407, closes #2407 

To make things easier when approving a backport on Zulip, I've made some parameters optional and added some logic to infer them by parsing the Zulip thread name. If the parsing for the missing parameters fail, we will emit en error.

After this patch, we support these variants of the `backport` command:
- `@**triagebot** backport accept beta 123456`
- `@**triagebot** backport accept beta`
- `@**triagebot** backport accept`

I will update the docs with the new syntax

r? @Urgau 


Thanks for a review!