### PR TITLE
Add the concept of community reviews before PR assignment

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@ use crate::github::{GithubClient, Repository};
 use parser::command::relabel::{Label, LabelDelta, RelabelCommand};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
+use std::num::NonZeroU8;
 use std::sync::{Arc, LazyLock, RwLock};
 use std::time::{Duration, Instant};
 use tracing as log;
@@ -160,6 +161,9 @@ pub(crate) struct AssignConfig {
     pub(crate) warn_non_default_branch: WarnNonDefaultBranchConfig,
     /// A URL to include in the welcome message.
     pub(crate) contributing_url: Option<String>,
+    /// Community reviews before auto-assignement
+    #[serde(default)]
+    pub(crate) community_reviews: Option<AssignCommunityReviewsConfig>,
     /// Ad-hoc groups that can be referred to in `owners`.
     #[serde(default)]
     pub(crate) adhoc_groups: HashMap<String, Vec<String>>,
@@ -192,6 +196,15 @@ impl AssignConfig {
     pub(crate) fn fallback_review_group(&self) -> Option<&[String]> {
         self.adhoc_groups.get("fallback").map(Vec::as_slice)
     }
+}
+
+#[derive(PartialEq, Eq, Debug, Clone, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AssignCommunityReviewsConfig {
+    /// The minimum number of community reviews before automatic assignment is performed
+    pub(crate) minimum_approvals: NonZeroU8,
+    /// Label indicating that community reviews are required
+    pub(crate) label: String,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone, serde::Deserialize)]
@@ -993,6 +1006,7 @@ mod tests {
                     users_on_vacation: HashSet::from(["jyn514".into()]),
                     review_prefs: None,
                     custom_messages: None,
+                    community_reviews: None,
                 }),
                 note: Some(NoteConfig { _empty: () }),
                 ping: Some(PingConfig { teams: ping_teams }),
@@ -1120,6 +1134,7 @@ mod tests {
                     owners: HashMap::new(),
                     users_on_vacation: HashSet::new(),
                     review_prefs: None,
+                    community_reviews: None,
                 }),
                 note: None,
                 ping: None,
@@ -1166,6 +1181,23 @@ mod tests {
             config.assign.and_then(|c| c.review_prefs),
             Some(AssignReviewPrefsConfig {})
         ));
+    }
+
+    #[test]
+    fn assign_review_min_reviews() {
+        let config = r#"
+            [assign.community_reviews]
+            minimum_approvals = 2
+            label = "S-waiting-on-community-reviews"
+        "#;
+        let config = toml::from_str::<Config>(&config).unwrap();
+        assert_eq!(
+            config.assign.and_then(|c| c.community_reviews),
+            Some(AssignCommunityReviewsConfig {
+                minimum_approvals: NonZeroU8::new(2).unwrap(),
+                label: "S-waiting-on-community-reviews".to_string(),
+            })
+        );
     }
 
     #[test]

--- a/src/github/issue.rs
+++ b/src/github/issue.rs
@@ -653,6 +653,19 @@ impl Issue {
             .with_context(|| format!("unable to fetch review comment ({review_comment_id})"))?;
         Ok(review)
     }
+
+    pub async fn get_reviews(&self, client: &GithubClient) -> anyhow::Result<Vec<Comment>> {
+        let review_url = format!(
+            "{}/pulls/{}/reviews",
+            self.repository().url(client),
+            self.number,
+        );
+        let reviews: Vec<Comment> = client
+            .json(client.get(&review_url))
+            .await
+            .with_context(|| format!("unable to fetch reviews for {}", self.number))?;
+        Ok(reviews)
+    }
 }
 
 // Comments

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -97,6 +97,18 @@ pub async fn handle(ctx: &Context, host: &str, event: &Event) -> Vec<HandlerErro
         Ok(())
     };
 
+    let assign_comments = async {
+        if let Some(assign_config) = config.as_ref().ok().and_then(|c| c.assign.as_ref())
+            && let Event::IssueComment(event) = event
+        {
+            assign::handle_comment(ctx, assign_config, event)
+                .await
+                .map_err(|e| HandlerError::Other(e.context("assign (from reviews) handler failed")))
+        } else {
+            Ok(())
+        }
+    };
+
     let check_commits = async {
         if let Ok(check_commits_config) = &config {
             check_commits::handle(ctx, host, event, check_commits_config)
@@ -230,6 +242,7 @@ pub async fn handle(ctx: &Context, host: &str, event: &Event) -> Vec<HandlerErro
 
     let (
         prune_gh_comments,
+        assign_comments,
         check_commits,
         project_goals,
         rustc_commits,
@@ -244,6 +257,7 @@ pub async fn handle(ctx: &Context, host: &str, event: &Event) -> Vec<HandlerErro
         merge_conflicts,
     ) = futures::join!(
         prune_gh_comments,
+        assign_comments,
         check_commits,
         project_goals,
         rustc_commits,
@@ -260,6 +274,7 @@ pub async fn handle(ctx: &Context, host: &str, event: &Event) -> Vec<HandlerErro
 
     for result in [
         prune_gh_comments,
+        assign_comments,
         check_commits,
         project_goals,
         rustc_commits,

--- a/src/handlers/assign.rs
+++ b/src/handlers/assign.rs
@@ -22,14 +22,18 @@
 //! `assign.owners` config, it will auto-select an assignee based on the files
 //! the PR modifies.
 
+use crate::config::AssignCommunityReviewsConfig;
 use crate::db::issue_data::IssueData;
 use crate::db::review_prefs::{RotationMode, get_review_prefs_batch};
 use crate::errors::{self, AssignmentError, user_error};
 use crate::handlers::pr_tracking::ReviewerWorkqueue;
 use crate::{
     config::AssignConfig,
-    github::{self, Event, FileDiff, Issue, IssuesAction, utils::Selection},
-    handlers::{Context, GithubClient, IssuesEvent},
+    github::{
+        self, Comment, Event, FileDiff, Issue, IssueCommentAction, IssueCommentEvent, IssuesAction,
+        PullRequestReviewState, utils::Selection,
+    },
+    handlers::{Context, IssuesEvent},
     interactions::EditIssueBody,
 };
 use anyhow::{Context as _, bail};
@@ -84,6 +88,7 @@ fn get_repo_workqueue(ctx: &Context, repo: &str) -> Arc<RwLock<ReviewerWorkqueue
 pub(super) enum AssignInput {
     Opened { draft: bool },
     ReadyForReview,
+    UnlabeledMinReviews { draft: bool },
 }
 
 /// Prepares the input when a new PR is opened.
@@ -92,15 +97,29 @@ pub(super) async fn parse_input(
     event: &IssuesEvent,
     config: Option<&AssignConfig>,
 ) -> Result<Option<AssignInput>, String> {
-    if config.is_none() || !event.issue.is_pr() {
+    if !event.issue.is_pr() {
         return Ok(None);
     }
 
-    match event.action {
+    let Some(config) = config else {
+        return Ok(None);
+    };
+
+    match &event.action {
         IssuesAction::Opened => Ok(Some(AssignInput::Opened {
             draft: event.issue.draft,
         })),
         IssuesAction::ReadyForReview => Ok(Some(AssignInput::ReadyForReview)),
+        IssuesAction::Unlabeled { label: Some(label) }
+            if config
+                .community_reviews
+                .as_ref()
+                .is_some_and(|community_reviews| community_reviews.label == label.name) =>
+        {
+            Ok(Some(AssignInput::UnlabeledMinReviews {
+                draft: event.issue.draft,
+            }))
+        }
         _ => Ok(None),
     }
 }
@@ -115,20 +134,82 @@ pub(super) async fn handle_input(
 ) -> anyhow::Result<()> {
     let assign_command = find_assign_command(ctx, event);
 
-    // Perform assignment when:
-    // - PR was opened normally
-    // - PR was opened as a draft with an explicit r? (but not r? ghost)
-    // - PR was converted from a draft and there are no current assignees
     let should_assign = match input {
-        AssignInput::Opened { draft: false } => true,
+        AssignInput::Opened { draft: false } => {
+            if let Some(community_reviews) = &config.community_reviews
+                && assign_command.is_none()
+            {
+                // PR was opened normally, but minimum approval configured,
+                // add label and welcome message BUT don't perform assignment
+                event
+                    .issue
+                    .add_labels(
+                        &ctx.github,
+                        vec![github::Label {
+                            name: community_reviews.label.to_string(),
+                        }],
+                    )
+                    .await?;
+                if event.issue.author_association.is_probably_first_timer() {
+                    let mut welcome = messages::new_user_welcome_message_community_reviews(
+                        community_reviews.minimum_approvals.get(),
+                    );
+                    if let Some(contrib) = &config.contributing_url {
+                        welcome.push_str("\n\n");
+                        welcome.push_str(&messages::contribution_message(contrib, &ctx.username));
+                    }
+                    event
+                        .issue
+                        .post_comment(&ctx.github, &welcome)
+                        .await
+                        .context("couldn't post welcome message")?;
+                }
+                false
+            } else {
+                // PR was opened normally, perform assignment if not assignees manually set
+                event.issue.assignees.is_empty()
+            }
+        }
         AssignInput::Opened { draft: true } => {
-            // Even if the PR is opened as a draft, we still want to perform assignment if r?
+            // PR is opened as a draft, we still want to perform assignment if r?
             // was used. However, historically, `r? ghost` was supposed to mean "do not
             // perform assignment". So in that case, we skip the assignment and only perform it once
             // the PR has been marked as being ready for review.
             assign_command.as_ref().is_some_and(|a| a != GHOST_ACCOUNT)
         }
-        AssignInput::ReadyForReview => event.issue.assignees.is_empty(),
+        AssignInput::ReadyForReview => {
+            if let Some(community_reviews) = &config.community_reviews
+                && assign_command.is_none()
+            {
+                if !event.issue.assignees.is_empty()
+                    || event.issue.labels.contains(&github::Label {
+                        name: community_reviews.label.to_string(),
+                    })
+                {
+                    // PR was converted from a draft, but there are current assignees or
+                    // min reviews label is set, don't perform assignment
+                    false
+                } else {
+                    // PR was converted from a draft and there are no current assignees,
+                    // but min reviews configured, perform assignment if enough reviews
+                    update_community_review_label(ctx, &community_reviews, &event.issue).await?
+                }
+            } else {
+                // PR was converted from a draft, perform assignment if there are
+                // no current assignees
+                event.issue.assignees.is_empty()
+            }
+        }
+        AssignInput::UnlabeledMinReviews { draft: false } => {
+            // Minimum reviews label was removed and the PR is not in a draft state
+            // perform assignement if no current assignees
+            event.issue.assignees.is_empty()
+        }
+        AssignInput::UnlabeledMinReviews { draft: true } => {
+            // Minimum reviews label was removed, but PR is still in a draft state (should
+            // only happened if someone manually edited the label), don't perform assignement
+            false
+        }
     };
 
     if !should_assign {
@@ -183,7 +264,9 @@ pub(super) async fn handle_input(
                 }
                 welcome
             }
-        } else if event.issue.author_association.is_probably_first_timer() {
+        } else if event.issue.author_association.is_probably_first_timer()
+            && config.community_reviews.is_none()
+        {
             let assignee_text = match &assignee {
                 Some(assignee) => Some(messages::welcome_with_reviewer(&assignee.name)),
                 None => {
@@ -208,17 +291,27 @@ pub(super) async fn handle_input(
             }
         } else if !from_comment {
             match &assignee {
-                Some(assignee) => Some(messages::returning_user_welcome_message(
-                    &assignee.name,
-                    &ctx.username,
-                )),
+                Some(assignee) => Some(if config.community_reviews.is_some() {
+                    messages::returning_user_welcome_message_community_reviews(
+                        &assignee.name,
+                        &ctx.username,
+                    )
+                } else {
+                    messages::returning_user_welcome_message(&assignee.name, &ctx.username)
+                }),
                 None => {
                     // If the assign fallback group is empty, then we don't expect any automatic
                     // assignment, and this message would just be spam.
                     if config.fallback_review_group().is_some() {
-                        Some(messages::returning_user_welcome_message_no_reviewer(
-                            &event.issue.user.login,
-                        ))
+                        Some(if config.community_reviews.is_some() {
+                            messages::returning_user_welcome_message_no_reviewer_community_reviews(
+                                &event.issue.user.login,
+                            )
+                        } else {
+                            messages::returning_user_welcome_message_no_reviewer(
+                                &event.issue.user.login,
+                            )
+                        })
                     } else {
                         None
                     }
@@ -229,7 +322,7 @@ pub(super) async fn handle_input(
             None
         };
         if let Some(assignee) = &assignee {
-            set_assignee(ctx, &event.issue, &ctx.github, assignee).await?;
+            set_assignee(ctx, config, &event.issue, assignee).await?;
         }
 
         if let Some(mut welcome) = welcome {
@@ -321,11 +414,67 @@ fn is_self_assign(assignee: &str, pr_author: &str) -> bool {
     assignee.to_lowercase() == pr_author.to_lowercase()
 }
 
+/// Determine if the issue has enough community (review) approvals
+async fn has_enough_community_approvals(
+    ctx: &Context,
+    config: &AssignCommunityReviewsConfig,
+    issue: &Issue,
+) -> anyhow::Result<bool> {
+    let reviews = issue
+        .get_reviews(&ctx.github)
+        .await
+        .context("unable to fetch reviews for determining assignement")?;
+
+    let mut approval_reviews: HashSet<_> = reviews
+        .iter()
+        .filter(|c| c.pr_review_state == Some(PullRequestReviewState::Approved))
+        .map(|c| c.user.id)
+        .collect::<HashSet<_>>();
+
+    // GitHub doesn't allow PR authors to approve a PR them-selves but just
+    // in case let's remove the PR author.
+    approval_reviews.remove(&issue.user.id);
+
+    Ok(approval_reviews.len() >= config.minimum_approvals.get().into())
+}
+
+/// Update the min community reviews label on the PR.
+/// Returns true if the PR already has enough community approvals.
+async fn update_community_review_label(
+    ctx: &Context,
+    config: &AssignCommunityReviewsConfig,
+    issue: &Issue,
+) -> anyhow::Result<bool> {
+    let enough_reviews = has_enough_community_approvals(ctx, config, issue).await?;
+
+    if enough_reviews {
+        issue
+            .remove_labels(
+                &ctx.github,
+                vec![github::Label {
+                    name: config.label.to_string(),
+                }],
+            )
+            .await?;
+    } else {
+        issue
+            .add_labels(
+                &ctx.github,
+                vec![github::Label {
+                    name: config.label.to_string(),
+                }],
+            )
+            .await?;
+    }
+
+    Ok(enough_reviews)
+}
+
 /// Sets the assignee of a PR, alerting any errors.
 async fn set_assignee(
     ctx: &Context,
+    config: &AssignConfig,
     issue: &Issue,
-    github: &GithubClient,
     reviewer: &ReviewerSelection,
 ) -> anyhow::Result<()> {
     let mut db = ctx.db.get().await;
@@ -341,7 +490,7 @@ async fn set_assignee(
         );
         return Ok(());
     }
-    if let Err(err) = issue.set_assignee(github, &reviewer.name).await {
+    if let Err(err) = issue.set_assignee(&ctx.github, &reviewer.name).await {
         log::warn!(
             "failed to set assignee of PR {} to {}: {err:?}",
             issue.global_id(),
@@ -349,7 +498,7 @@ async fn set_assignee(
         );
         if let Err(e) = issue
             .post_comment(
-                github,
+                &ctx.github,
                 &format!(
                     "Failed to set assignee to `{}`: {err}\n\
                      \n\
@@ -386,6 +535,19 @@ They may take a while to respond."
                 log::warn!("failed to post reviewer warning comment: {err}");
             }
         }
+    }
+
+    // Since we are assigning someone we cannot be waiting on community reviews
+    // remove the label if it's still present
+    if let Some(min_reviews) = &config.community_reviews {
+        issue
+            .remove_labels(
+                &ctx.github,
+                vec![github::Label {
+                    name: min_reviews.label.to_string(),
+                }],
+            )
+            .await?;
     }
 
     // Record the reviewer in the database
@@ -680,7 +842,7 @@ pub(super) async fn handle_command(
                         .await
                         .context("Cannot determine assignee when rerolling")?;
                 if let Some(assignee) = assignee {
-                    set_assignee(ctx, issue, &ctx.github, &assignee)
+                    set_assignee(ctx, config, issue, &assignee)
                         .await
                         .context("Cannot set assignee when rerolling")?;
                 } else {
@@ -727,7 +889,7 @@ pub(super) async fn handle_command(
             }
         };
 
-        set_assignee(ctx, issue, &ctx.github, &assignee).await?;
+        set_assignee(ctx, config, issue, &assignee).await?;
     } else {
         let mut client = ctx.db.get().await;
         let mut e: EditIssueBody<'_, AssignData> =
@@ -792,6 +954,48 @@ pub(super) async fn handle_command(
             }
             Err(e) => return Err(e.into()),
         }
+    }
+
+    Ok(())
+}
+
+/// Process a comment/review/review comment
+pub(super) async fn handle_comment(
+    ctx: &Context,
+    config: &AssignConfig,
+    event: &IssueCommentEvent,
+) -> anyhow::Result<()> {
+    // If not a new review on a PR, bail out
+    if !matches!(
+        event,
+        IssueCommentEvent {
+            action: IssueCommentAction::Created,
+            issue: Issue {
+                pull_request: Some(_),
+                merged: false,
+                draft: false,
+                ..
+            },
+            comment: Comment {
+                in_reply_to_id: None,
+                pr_review_state: Some(PullRequestReviewState::Approved),
+                ..
+            },
+            ..
+        }
+    ) {
+        return Ok(());
+    }
+
+    let Some(min_reviews) = &config.community_reviews else {
+        return Ok(());
+    };
+
+    if event.issue.labels.contains(&github::Label {
+        name: min_reviews.label.to_string(),
+    }) {
+        // Let's update the status, but only if the label wasn't already removed.
+        update_community_review_label(ctx, min_reviews, &event.issue).await?;
     }
 
     Ok(())

--- a/src/handlers/assign/messages.rs
+++ b/src/handlers/assign/messages.rs
@@ -6,8 +6,15 @@
 pub fn new_user_welcome_message(reviewer: &str) -> String {
     format!(
         "Thanks for the pull request, and welcome! \
-The Rust team is excited to review your changes, and you should hear from {reviewer} \
+The Rust Project is excited to review your changes, and you should hear from {reviewer} \
 some time within the next two weeks."
+    )
+}
+
+pub fn new_user_welcome_message_community_reviews(min_reviews: u8) -> String {
+    format!(
+        "Thanks for the pull request, and welcome!\
+You should hear from one of our reviewers after this PR is reviewed by at least {min_reviews} reviewers from the community"
     )
 }
 
@@ -42,6 +49,24 @@ Use `r?` to explicitly pick a reviewer"
 
 pub fn returning_user_welcome_message_no_reviewer(pr_author: &str) -> String {
     format!("@{pr_author}: no appropriate reviewer found, use `r?` to override")
+}
+
+pub fn returning_user_welcome_message_community_reviews(assignee: &str, bot: &str) -> String {
+    format!(
+        "r? @{assignee}
+
+{bot} has assigned @{assignee} for the project review.
+They will have a look at your PR within the next two weeks and either review your PR or \
+reassign to another reviewer.
+
+Use `r?` to explicitly pick a reviewer"
+    )
+}
+
+pub fn returning_user_welcome_message_no_reviewer_community_reviews(pr_author: &str) -> String {
+    format!(
+        "@{pr_author}: no appropriate reviewer found for the project review, use `r?` to override"
+    )
 }
 
 pub fn reviewer_off_rotation_message(username: &str) -> String {


### PR DESCRIPTION
This PR adds the concept of community reviews before PR assignment.

It's enabled in the `[assign]` handler with a new config:
```toml
[assign.community_reviews]
minimum_approvals = 2
label = "S-waiting-on-community-reviews"
```

The normal workflow for community reviews is like this:
1. PR is being opened *(non-draft, otherwise ignore until ready)*
    * Add the label
    * Post the welcome message if new user, with small explanation of community reviews
        * No message for recurring users 
3. Min approval reviews is reached (or label is manually removed)
    * Normal PR assignment
    * Assignment message

If someone is being assigned with our commands (`r?`, reroll), we remove the label after the assignment, thus preventing further auto-assign.

I tested what I could on my private repo, the core logic seems to work, although I couldn't test everything since I'm alone.

cc @samueltardieu 