### PR TITLE
Allow text after claim/unclaim/reroll commands

### DIFF
--- a/parser/src/command.rs
+++ b/parser/src/command.rs
@@ -268,6 +268,27 @@ fn resumes_after_code() {
 }
 
 #[test]
+fn text_after_claim() {
+    let input = "@bot claim I'd like to work on this";
+    let mut input = Input::new(input, vec!["bot"]);
+    assert!(matches!(input.next(), Some(Command::Assign(Ok(_)))));
+}
+
+#[test]
+fn text_after_unclaim() {
+    let input = "@bot unclaim (I don't have time).";
+    let mut input = Input::new(input, vec!["bot"]);
+    assert!(matches!(input.next(), Some(Command::Assign(Ok(_)))));
+}
+
+#[test]
+fn text_after_reroll() {
+    let input = "@bot reroll blahblah";
+    let mut input = Input::new(input, vec!["bot"]);
+    assert!(matches!(input.next(), Some(Command::Assign(Ok(_)))));
+}
+
+#[test]
 fn edit_1() {
     let input_old = "@bot modify labels: +bug.";
     let mut input_old = Input::new(input_old, vec!["bot"]);

--- a/parser/src/command/assign.rs
+++ b/parser/src/command/assign.rs
@@ -57,11 +57,9 @@ impl AssignCommand {
             toks.next_token()?;
             if let Some(Token::Dot | Token::EndOfLine) = toks.peek_token()? {
                 toks.next_token()?;
-                *input = toks;
-                Ok(Some(AssignCommand::Claim))
-            } else {
-                Err(toks.error(ParseError::ExpectedEnd))
             }
+            *input = toks;
+            Ok(Some(AssignCommand::Claim))
         } else if let Some(Token::Word("assign")) = toks.peek_token()? {
             toks.next_token()?;
             if let Some(Token::Word(user)) = toks.next_token()? {
@@ -79,20 +77,16 @@ impl AssignCommand {
             toks.next_token()?;
             if let Some(Token::Dot | Token::EndOfLine) = toks.peek_token()? {
                 toks.next_token()?;
-                *input = toks;
-                Ok(Some(AssignCommand::ReleaseAssignment))
-            } else {
-                Err(toks.error(ParseError::ExpectedEnd))
             }
+            *input = toks;
+            Ok(Some(AssignCommand::ReleaseAssignment))
         } else if let Some(Token::Word("reroll")) = toks.peek_token()? {
             toks.next_token()?;
             if let Some(Token::Dot | Token::EndOfLine) = toks.peek_token()? {
                 toks.next_token()?;
-                *input = toks;
-                Ok(Some(AssignCommand::Reroll))
-            } else {
-                Err(toks.error(ParseError::ExpectedEnd))
             }
+            *input = toks;
+            Ok(Some(AssignCommand::Reroll))
         } else {
             Ok(None)
         }


### PR DESCRIPTION
I don't think it's necessary to require a newline at the end of a command. Do you agree?

close: https://github.com/rust-lang/triagebot/issues/284