### PR TITLE
Add automatic release of inactive claimed assignments

### DIFF
--- a/src/db/issue_data.rs
+++ b/src/db/issue_data.rs
@@ -37,6 +37,15 @@ where
     ) -> Result<IssueData<'db, T>> {
         let repo = issue.repository().to_string();
         let issue_number = issue.number as i32;
+        Self::load_raw(db, repo, issue_number, key).await
+    }
+
+    pub async fn load_raw(
+        db: &'db mut DbClient,
+        repo: String,
+        issue_number: i32,
+        key: &str,
+    ) -> Result<IssueData<'db, T>> {
         let transaction = db.transaction().await?;
         transaction
             .execute("LOCK TABLE issue_data", &[])

--- a/src/github.rs
+++ b/src/github.rs
@@ -13,4 +13,5 @@ pub use webhook::event::*;
 pub use webhook::webhook;
 
 pub type UserId = u64;
+pub type IssueNumber = u64;
 pub type PullRequestNumber = u64;

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -7,6 +7,7 @@ use reqwest::Body;
 use reqwest::header::{AUTHORIZATION, USER_AGENT};
 use reqwest::{Client, Request, RequestBuilder, Response, StatusCode};
 use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Deserializer};
 use std::time::{Duration, SystemTime};
 use tracing as log;
 
@@ -380,10 +381,31 @@ pub struct GraphQlErrors {
 pub struct GraphQlError {
     #[serde(default)]
     pub message: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_path")]
     pub path: Vec<String>,
     #[serde(default, rename = "type")]
     pub type_: String,
+}
+
+fn deserialize_path<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // Deserialize the field into a vector of generic JSON Values first
+    let raw_vector: Vec<serde_json::Value> = Vec::deserialize(deserializer)?;
+
+    // Map each JSON Value cleanly into a String
+    let string_vector = raw_vector
+        .into_iter()
+        .map(|value| match value {
+            serde_json::Value::String(s) => s,
+            serde_json::Value::Number(n) => n.to_string(),
+            serde_json::Value::Bool(b) => b.to_string(),
+            _ => value.to_string(),
+        })
+        .collect();
+
+    Ok(string_vector)
 }
 
 impl std::fmt::Display for GraphQlErrors {

--- a/src/github/queries/closing_issues_references.rs
+++ b/src/github/queries/closing_issues_references.rs
@@ -1,0 +1,95 @@
+use anyhow::Context as _;
+use chrono::{DateTime, Utc};
+
+use crate::github::{GithubClient, IssueNumber, PullRequestNumber};
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PullRequestWithClosingIssuesReferences {
+    pub number: PullRequestNumber,
+    pub updated_at: DateTime<Utc>,
+    pub closing_issues_references: Vec<ClosingIssueReference>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClosingIssueReference {
+    pub number: IssueNumber,
+}
+
+impl GithubClient {
+    pub async fn closing_issues_references(
+        &self,
+        owner: &str,
+        repo: &str,
+    ) -> anyhow::Result<Vec<PullRequestWithClosingIssuesReferences>> {
+        fn page_info(data: &serde_json::Value) -> (bool, Option<String>) {
+            let has_next = data["pageInfo"]["hasNextPage"].as_bool().unwrap_or(false);
+            let end_cursor = data["pageInfo"]["endCursor"]
+                .as_str()
+                .map(|s| s.to_string());
+            (has_next, end_cursor)
+        }
+
+        let mut prs_cursor: Option<String> = None;
+        let mut prs = Vec::<PullRequestWithClosingIssuesReferences>::new();
+
+        loop {
+            let mut data = self
+                .graphql_query(
+                    r##"
+query ($owner: String!, $repo: String!, $after: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequests(first: 100, after: $after, states: OPEN) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        number
+        updatedAt
+        closingIssuesReferences(first: 10) {
+          nodes {
+            number
+          }
+        }  
+      }
+    }
+  }
+}
+            "##,
+                    serde_json::json!({
+                        "owner": owner,
+                        "repo": repo,
+                        "after": prs_cursor.as_deref(),
+                    }),
+                )
+                .await
+                .context("failed to fetch opened issues")?;
+
+            let mut value = data["data"]["repository"]["pullRequests"].take();
+
+            for val in value["nodes"].as_array_mut().context("no issues nodes")? {
+                prs.push(PullRequestWithClosingIssuesReferences {
+                    number: val["number"].as_u64().context("no issue number")?,
+                    updated_at: serde_json::from_value(val["updatedAt"].take())?,
+                    closing_issues_references: serde_json::from_value(
+                        val["closingIssuesReferences"]["nodes"].take(),
+                    )?,
+                });
+            }
+
+            let (has_next, new_end_cursor) = page_info(&value);
+
+            if new_end_cursor.is_some() {
+                prs_cursor = new_end_cursor;
+            }
+
+            if !has_next {
+                break;
+            }
+        }
+
+        Ok(prs)
+    }
+}

--- a/src/github/queries/issues_assigned.rs
+++ b/src/github/queries/issues_assigned.rs
@@ -1,0 +1,107 @@
+use anyhow::Context as _;
+use chrono::{DateTime, Utc};
+
+use crate::github::{GithubClient, IssueNumber};
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitHubIssueAssigned {
+    pub number: IssueNumber,
+    pub updated_at: DateTime<Utc>,
+    pub assignees: Vec<GitHubAssignee>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitHubAssignee {
+    pub login: String,
+    #[serde(alias = "databaseId")]
+    pub id: u64,
+}
+
+impl GithubClient {
+    pub async fn issues_assigned(
+        &self,
+        owner: &str,
+        repo: &str,
+    ) -> anyhow::Result<Vec<GitHubIssueAssigned>> {
+        fn page_info(data: &serde_json::Value) -> (bool, Option<String>) {
+            let has_next = data["pageInfo"]["hasNextPage"].as_bool().unwrap_or(false);
+            let end_cursor = data["pageInfo"]["endCursor"]
+                .as_str()
+                .map(|s| s.to_string());
+            (has_next, end_cursor)
+        }
+
+        let mut issues_cursor: Option<String> = None;
+        let mut issues = Vec::<GitHubIssueAssigned>::new();
+
+        loop {
+            let mut data = self
+                .graphql_query(
+                    r##"
+query(
+  $owner: String!, 
+  $repo: String!, 
+  $after: String
+) {
+  repository(owner: $owner, name: $repo) {
+    issues(
+      first: 100,
+      after: $after,
+      filterBy: { 
+        states: [OPEN], 
+        assignee: "*" 
+      }
+    ) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        number
+        updatedAt
+        assignees(first: 5) {
+          nodes {
+            login
+            databaseId
+          }
+        }
+      }
+    }
+  }
+}
+            "##,
+                    serde_json::json!({
+                        "owner": owner,
+                        "repo": repo,
+                        "after": issues_cursor.as_deref(),
+                    }),
+                )
+                .await
+                .context("failed to fetch opened issues")?;
+
+            let mut value = data["data"]["repository"]["issues"].take();
+
+            for val in value["nodes"].as_array_mut().context("no issues nodes")? {
+                issues.push(GitHubIssueAssigned {
+                    number: val["number"].as_u64().context("no issue number")?,
+                    updated_at: serde_json::from_value(val["updatedAt"].take())?,
+                    assignees: serde_json::from_value(val["assignees"]["nodes"].take())?,
+                });
+            }
+
+            let (has_next, new_end_cursor) = page_info(&value);
+
+            if new_end_cursor.is_some() {
+                issues_cursor = new_end_cursor;
+            }
+
+            if !has_next {
+                break;
+            }
+        }
+
+        Ok(issues)
+    }
+}

--- a/src/github/queries/mod.rs
+++ b/src/github/queries/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod issue_with_comments;
+pub(crate) mod issues_assigned;
 pub(crate) mod user_comments_in_org;
 pub(crate) mod user_contributions;
 pub(crate) mod user_info;

--- a/src/github/queries/mod.rs
+++ b/src/github/queries/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod closing_issues_references;
 pub(crate) mod issue_with_comments;
 pub(crate) mod issues_assigned;
 pub(crate) mod user_comments_in_org;

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -11,7 +11,7 @@ use std::fmt;
 use std::sync::Arc;
 use tracing as log;
 
-mod assign;
+pub(crate) mod assign;
 mod autolabel;
 mod backport;
 mod bot_pull_requests;

--- a/src/handlers/assign.rs
+++ b/src/handlers/assign.rs
@@ -49,6 +49,7 @@ use tokio_postgres::Client as DbClient;
 use tracing as log;
 
 mod messages;
+pub(crate) mod release_inactive_assignments;
 
 #[cfg(test)]
 mod tests {

--- a/src/handlers/assign.rs
+++ b/src/handlers/assign.rs
@@ -60,6 +60,9 @@ mod tests {
 const GHOST_ACCOUNT: &str = "ghost";
 
 /// Key for the state in the database
+const ASSIGN_KEY: &str = "ASSIGN";
+
+/// Key for the state in the database
 const PREVIOUS_REVIEWERS_KEY: &str = "previous-reviewers";
 
 /// State stored in the database
@@ -893,7 +896,7 @@ pub(super) async fn handle_command(
     } else {
         let mut client = ctx.db.get().await;
         let mut e: EditIssueBody<'_, AssignData> =
-            EditIssueBody::load(&mut client, issue, "ASSIGN").await?;
+            EditIssueBody::load(&mut client, issue, ASSIGN_KEY).await?;
         let d = e.data_mut();
 
         let to_assign = match cmd {

--- a/src/handlers/assign/release_inactive_assignments.rs
+++ b/src/handlers/assign/release_inactive_assignments.rs
@@ -1,0 +1,247 @@
+//! This module defines the logic for releasing inactive issue assignments
+
+use std::collections::HashMap;
+
+use anyhow::Context as _;
+use async_trait::async_trait;
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+
+const INACTIVITY_REMINDER_DAYS: i64 = 49; // 7 weeks
+const INACTIVITY_LIMIT_DAYS: i64 = 56; // 8 weeks
+const INACTIVITY_GRACE_PERIOD_DAYS: i64 = INACTIVITY_LIMIT_DAYS - INACTIVITY_REMINDER_DAYS;
+
+use crate::{
+    db::issue_data::IssueData,
+    github::{IssueNumber, IssueRepository, ReportedContentClassifiers, utils::Selection},
+    handlers::Context,
+    jobs::Job,
+};
+
+pub(crate) const RELEASE_INACTIVE_ASSIGNMENTS_JOB_NAME: &str = "release_inactive_assignments";
+
+pub(crate) struct ReleaseInactiveAssignmentsJob;
+
+#[async_trait]
+impl Job for ReleaseInactiveAssignmentsJob {
+    fn name(&self) -> &'static str {
+        RELEASE_INACTIVE_ASSIGNMENTS_JOB_NAME
+    }
+
+    async fn run(&self, ctx: &Context, _metadata: &serde_json::Value) -> anyhow::Result<()> {
+        tracing::info!("Starting job to release inactive assignments");
+
+        for (owner, repo) in [("rust-lang", "rust-clippy")] {
+            tracing::info!("Starting checking {owner}/{repo}");
+            match update_assignments(ctx, owner, repo).await {
+                Ok(()) => {
+                    tracing::info!("Checking of {owner}/{repo} succesful");
+                }
+                Err(err) => {
+                    tracing::error!("Failed to check {owner}/{repo}: {err}");
+                }
+            }
+        }
+
+        tracing::info!("Job finished to release inactive assignments");
+        Ok(())
+    }
+}
+
+async fn update_assignments(ctx: &Context, owner: &str, repo: &str) -> anyhow::Result<()> {
+    let issues_assigned = ctx
+        .github
+        .issues_assigned(owner, repo)
+        .await
+        .context("unable to load the assigned issues")?;
+
+    let prs_with_closing_issues_references = ctx
+        .github
+        .closing_issues_references(owner, repo)
+        .await
+        .context("unable to load the closing issues references")?;
+
+    tracing::info!("Loaded {} assigned issues", issues_assigned.len());
+    tracing::info!(
+        "Loaded {} PRs (with their closing issues references)",
+        prs_with_closing_issues_references.len()
+    );
+
+    let references: HashMap<IssueNumber, Vec<&_>> = prs_with_closing_issues_references
+        .iter()
+        .flat_map(|pr| {
+            pr.closing_issues_references
+                .iter()
+                .map(move |i| (i.number, pr))
+        })
+        .fold(HashMap::new(), |mut map, (issue_num, pr)| {
+            map.entry(issue_num).or_default().push(pr);
+            map
+        });
+
+    let now = Utc::now();
+    let owner_repo = format!("{owner}/{repo}");
+
+    for issue_assigned in issues_assigned {
+        let [assignee] = &issue_assigned.assignees[..] else {
+            continue;
+        };
+
+        let last_update_time = references
+            .get(&issue_assigned.number)
+            .iter()
+            .flat_map(|references| references.iter().map(|r| r.updated_at))
+            .max()
+            .unwrap_or(DateTime::<Utc>::MIN_UTC)
+            .max(issue_assigned.updated_at);
+
+        if last_update_time + Duration::days(INACTIVITY_GRACE_PERIOD_DAYS) > now {
+            continue;
+        }
+
+        let mut db = ctx.db.get().await;
+
+        {
+            let issue_assignee = IssueData::<super::AssignData>::load_raw(
+                &mut db,
+                owner_repo.to_string(),
+                issue_assigned.number as i32,
+                super::ASSIGN_KEY,
+            )
+            .await
+            .context("couldn't load issue data")?;
+
+            if Some(assignee.login.as_str()) != issue_assignee.data.user.as_deref() {
+                // Assigned user is different from `claim` command, skipping
+                continue;
+            }
+        }
+
+        let mut issue_reminder = IssueData::<IssueReminderDetails>::load_raw(
+            &mut db,
+            owner_repo.to_string(),
+            issue_assigned.number as i32,
+            ISSUE_REMINDER_DETAILS_KEY,
+        )
+        .await
+        .context("couldn't load issue data")?;
+
+        if issue_reminder.data.login_id == assignee.id {
+            let issue = ctx
+                .github
+                .issue(
+                    &IssueRepository {
+                        organization: owner.to_string(),
+                        repository: repo.to_string(),
+                    },
+                    issue_assigned.number,
+                )
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to load issue {owner_repo}#{}",
+                        issue_assigned.number
+                    )
+                })?;
+
+            if last_update_time <= issue_reminder.data.posted_at {
+                tracing::info!(
+                    "[] inactivity warning was posted but assignee ({assignee:?}) is still inactive, removing the assignement, and posting warning"
+                );
+                issue
+                    .remove_assignees(&ctx.github, Selection::One(&assignee.login))
+                    .await?;
+                issue
+                    .post_comment(
+                        &ctx.github,
+                        &release_message(&assignee.login, INACTIVITY_LIMIT_DAYS),
+                    )
+                    .await
+                    .context("couldn't post release message")?;
+
+                issue_reminder.data = IssueReminderDetails::default();
+                issue_reminder.save().await?;
+            } else {
+                tracing::info!(
+                    "[] new activity detected, hidding previous warning comment and scheduling new inactivity check"
+                );
+                issue
+                    .hide_comment(
+                        &ctx.github,
+                        &issue_reminder.data.node_id,
+                        ReportedContentClassifiers::Resolved,
+                    )
+                    .await?;
+
+                issue_reminder.data = IssueReminderDetails::default();
+                issue_reminder.save().await?;
+            }
+        } else if last_update_time + Duration::days(INACTIVITY_REMINDER_DAYS) <= now {
+            tracing::info!(
+                "inactivity detected (last_update_time: {last_update_time}), posting warning comment and scheduling new inactivity check"
+            );
+
+            let issue = ctx
+                .github
+                .issue(
+                    &IssueRepository {
+                        organization: owner.to_string(),
+                        repository: repo.to_string(),
+                    },
+                    issue_assigned.number,
+                )
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to load issue {owner_repo}#{}",
+                        issue_assigned.number
+                    )
+                })?;
+
+            let comment = issue
+                .post_comment(
+                    &ctx.github,
+                    &inactivity_message(
+                        &assignee.login,
+                        INACTIVITY_REMINDER_DAYS,
+                        INACTIVITY_GRACE_PERIOD_DAYS,
+                        &ctx.username,
+                    ),
+                )
+                .await
+                .context("failed to post inactivity comment")?;
+
+            issue_reminder.data = IssueReminderDetails {
+                posted_at: comment.created_at.context("no created_at for a comment")?,
+                login_id: assignee.id,
+                node_id: comment.node_id,
+            };
+            issue_reminder.save().await?;
+        }
+    }
+
+    Ok(())
+}
+
+const ISSUE_REMINDER_DETAILS_KEY: &str = "ISSUE_REMINDER_DETAILS";
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, Eq)]
+pub(super) struct IssueReminderDetails {
+    posted_at: DateTime<Utc>,
+    login_id: u64,
+    node_id: String,
+}
+
+fn inactivity_message(assignee: &str, remind: i64, grace_period: i64, username: &str) -> String {
+    format!("Hey @{assignee}, just checking in! It's been {remind} days since the last update on this issue or linked PRs.
+
+No worries if you're busy! If you still want to tackle this, just drop a quick comment below. If you've run out of time or interest, you can release it by commenting `@{username} release-assignment` so another contributor can jump in.
+
+If we don't hear from you in {grace_period} days, you will be automatically unassigned.")
+}
+
+fn release_message(assignee: &str, total: i64) -> String {
+    format!(
+        "Hey @{assignee}, just letting you know we've freed up this issue since we haven't seen any updates for {total} days. If you find the time later on, feel free to reclaim it and pick up where you left off."
+    )
+}

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -55,7 +55,8 @@ use crate::{
     db::jobs::JobSchedule,
     github::client::GithubRateLimitLoggingJob,
     handlers::{
-        Context, docs_update::DocsUpdateJob, major_change::MajorChangeAcceptanceJob,
+        Context, assign::release_inactive_assignments::ReleaseInactiveAssignmentsJob,
+        docs_update::DocsUpdateJob, major_change::MajorChangeAcceptanceJob,
         review_changes_since::AddReviewChangesSinceLinkJob, rustc_commits::RustcCommitsJob,
     },
 };
@@ -77,6 +78,7 @@ pub fn jobs() -> Vec<Box<dyn Job + Send + Sync>> {
         Box::new(MajorChangeAcceptanceJob),
         Box::new(GithubRateLimitLoggingJob),
         Box::new(AddReviewChangesSinceLinkJob),
+        Box::new(ReleaseInactiveAssignmentsJob),
     ]
 }
 
@@ -105,6 +107,12 @@ pub fn default_jobs() -> Vec<JobSchedule> {
             name: GithubRateLimitLoggingJob.name(),
             // Every 15 minutes
             schedule: Schedule::from_str("* */15 * * * * *").unwrap(),
+            metadata: serde_json::Value::Null,
+        },
+        JobSchedule {
+            name: ReleaseInactiveAssignmentsJob.name(),
+            // Every day at 5am
+            schedule: Schedule::from_str("0 5 * * * * *").unwrap(),
             metadata: serde_json::Value::Null,
         },
     ]


### PR DESCRIPTION
This PR adds a system to automatically release inactive claimed (`claim` and `assign <username>` commands) assignments.

The logic is loosely inspired by [Zulip's bot](https://github.com/zulip/zulipbot/blob/7a83a0ab804169a328860cbb1d0fa6acd68e85c9/src/events/activity.ts#L111). We check after `inactivity_reminder` days the last update on the issue and linked PRs (via the cross-references), we post the reminder message and if nothing moves `inactivity_limit - inactivity_reminder` days later we remove the assignment and post a comment.

It's configured like this:
```toml
[assign.check_activity]
inactivity_reminder = 6 #days
inactivity_limit = 7 #days
```

Output for the reminder:
> Hey @Urgau, just checking in! It's been 6 days since the last update on this issue or linked PRs.
> 
> No worries if you're busy! If you still want to tackle this, just drop a quick comment below. If you've run out of time or interest, you can release it by commenting `@rustbot release-assignment` so another contributor can jump in.
> 
> If we don't hear from you in 1 days, you will be automatically unassigned.

Output for the release assignment:
> Hey @Urgau, just letting you know we've freed up this issue since we haven't seen any updates for 7 days. If you find the time later on, feel free to reclaim it and pick up where you left off.

Context: [#triagebot > Releasing lingering assignments](https://rust-lang.zulipchat.com/#narrow/channel/224082-triagebot/topic/Releasing.20lingering.20assignments/with/597163574)
cc @samueltardieu