### PR TITLE
Add T-compiler P-high issues triage module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,6 +524,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "compiler-p-high"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "http",
+ "http-body-util",
+ "itertools",
+ "octocrab",
+ "regex",
+ "reqwest",
+ "rust_team_data",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "tera",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
 name = "comrak"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Mark Rousskov <mark.simulacrum@gmail.com>"]
 edition = "2024"
 
 [workspace]
+resolver = "3"
+members = ["agendas/compiler-p-high"]
 
 [dependencies]
 serde_json = "1"

--- a/agendas/compiler-p-high/Cargo.toml
+++ b/agendas/compiler-p-high/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "compiler-p-high"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anyhow = "1.0.98"
+async-trait = "0.1.31"
+chrono = { version = "0.4.38", default-features = false, features = ["serde"] }
+octocrab = { version = "0.44" }
+tera = { version = "1.3.1", default-features = false, features = ["builtins"] }
+tokio = { version = "1", default-features = false, features = ["macros", "time", "rt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
+
+# Rust team data and its deps
+rust_team_data = { git = "https://github.com/rust-lang/team" }
+reqwest = { version = "0.12", features = ["json", "blocking"] }
+serde = { version = "1", default-features = false, features = ["derive"] }
+tracing = "0.1"
+
+# github.rs and its deps
+serde_json = "1"
+regex = "1"
+bytes = "1.10.1"
+itertools = "0.14.0"
+secrecy = { version = "0.10", default-features = false, features = ["serde"] }
+http = "1.4.0"
+http-body-util = "0.1.3"
+futures = { version = "0.3", default-features = false, features = ["std"] }
+url = "2.1.0"

--- a/agendas/compiler-p-high/src/actions.rs
+++ b/agendas/compiler-p-high/src/actions.rs
@@ -1,0 +1,149 @@
+use chrono::{DateTime, Utc};
+use octocrab::Octocrab;
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock};
+
+use async_trait::async_trait;
+use tera::{Context, Tera};
+
+// TODO: can this crate be replaced with octocrab?
+use crate::github::{self, GithubClient, Repository};
+use crate::team_data::TeamClient;
+
+#[async_trait]
+pub trait Action {
+    async fn call(&self, octocrab: &Octocrab) -> anyhow::Result<String>;
+}
+
+pub struct Step<'a> {
+    pub name: &'a str,
+    pub actions: Vec<Query<'a>>,
+}
+
+pub struct Query<'a> {
+    /// Vec of (owner, name)
+    pub repos: Vec<(&'a str, &'a str)>,
+    pub queries: Vec<QueryMap<'a>>,
+}
+
+#[derive(Copy, Clone)]
+pub enum QueryKind {
+    List,
+    Count,
+}
+
+pub struct QueryMap<'a> {
+    pub name: &'a str,
+    pub kind: QueryKind,
+    pub query: Arc<dyn github::issue_query::IssuesQuery + Send + Sync>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct IssueDecorator {
+    pub number: u64,
+    pub title: String,
+    pub html_url: String,
+    pub repo_name: String,
+    pub labels: String,
+    pub author: String,
+    pub team: String,
+    pub assignees: String,
+    // Human (readable) timestamps
+    pub created_at_hts: String,
+    pub updated_at_hts: String,
+    pub is_blocked: bool,
+}
+
+// TODO: embed templates in binary
+// (so the compiled binary can run from everywhere)
+pub static TEMPLATES: LazyLock<Tera> = LazyLock::new(|| match Tera::new("templates/*") {
+    Ok(t) => t,
+    Err(e) => {
+        println!("Parsing error(s): {e}");
+        ::std::process::exit(1);
+    }
+});
+
+pub fn to_human(d: DateTime<Utc>) -> String {
+    let d1 = chrono::Utc::now() - d;
+    let days = d1.num_days();
+    if days > 60 {
+        format!("{} months ago", days / 30)
+    } else {
+        format!("about {days} days ago")
+    }
+}
+
+// TODO: try using the octocrab client
+#[async_trait]
+impl Action for Step<'_> {
+    async fn call(&self, _octocrab: &Octocrab) -> anyhow::Result<String> {
+        let mut gh = GithubClient::new_from_env();
+        gh.set_retry_rate_limit(true);
+        let team_api = TeamClient::new_from_env();
+
+        let mut context = Context::new();
+        let mut results = HashMap::new();
+
+        let mut handles: Vec<tokio::task::JoinHandle<anyhow::Result<(String, QueryKind, Vec<_>)>>> =
+            Vec::new();
+        let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(5));
+
+        for Query { repos, queries } in &self.actions {
+            for repo in repos {
+                let repository = Repository {
+                    full_name: format!("{}/{}", repo.0, repo.1),
+                    // These are unused for query.
+                    default_branch: "main".to_string(),
+                    fork: false,
+                    parent: None,
+                };
+
+                for QueryMap { name, kind, query } in queries {
+                    let semaphore = semaphore.clone();
+                    let name = String::from(*name);
+                    let kind = *kind;
+                    let repository = repository.clone();
+                    let gh = gh.clone();
+                    let team_api = team_api.clone();
+                    let query = query.clone();
+                    handles.push(tokio::task::spawn(async move {
+                        let _permit = semaphore.acquire().await?;
+                        let issues = query.query(&repository, &gh, &team_api).await?;
+                        Ok((name, kind, issues))
+                    }));
+                }
+            }
+        }
+
+        for handle in handles {
+            let (name, kind, issues) = handle.await.unwrap()?;
+            match kind {
+                QueryKind::List => {
+                    results.entry(name).or_insert(Vec::new()).extend(issues);
+                }
+                QueryKind::Count => {
+                    let count = issues.len();
+                    let result = if let Some(value) = context.get(&name) {
+                        value.as_u64().unwrap() + count as u64
+                    } else {
+                        count as u64
+                    };
+
+                    context.insert(name, &result);
+                }
+            }
+        }
+
+        for (name, issues) in &results {
+            context.insert(name, issues);
+        }
+
+        let date = chrono::Utc::now().date_naive();
+        context.insert("CURRENT_DATE", &date);
+
+        Ok(TEMPLATES
+            .render(&format!("{}.tt", self.name), &context)
+            .unwrap())
+    }
+}

--- a/agendas/compiler-p-high/src/github.rs
+++ b/agendas/compiler-p-high/src/github.rs
@@ -1,0 +1,9 @@
+mod client;
+mod issue;
+pub mod issue_query;
+mod repos;
+mod utils;
+
+pub use client::{GithubClient, default_token_from_env};
+pub use issue::*;
+pub use repos::*;

--- a/agendas/compiler-p-high/src/github/client.rs
+++ b/agendas/compiler-p-high/src/github/client.rs
@@ -1,0 +1,326 @@
+use anyhow::Context;
+use bytes::Bytes;
+use futures::{FutureExt, future::BoxFuture};
+use http_body_util::{BodyExt, Limited};
+use reqwest::header::{AUTHORIZATION, USER_AGENT};
+use reqwest::{Body, Client, Request, RequestBuilder, Response, StatusCode};
+use secrecy::{ExposeSecret, SecretString};
+use std::time::{Duration, SystemTime};
+use tracing as log;
+
+use crate::GITHUB_API_VERSION;
+
+/// Finds the token in the user's environment, panicking if no suitable token
+/// can be found.
+pub fn default_token_from_env() -> SecretString {
+    std::env::var("GITHUB_TOKEN")
+        .or_else(|_| get_token_from_git_config())
+        .expect("could not find token in GITHUB_TOKEN, GITHUB_API_TOKEN or .gitconfig/github.oath-token")
+        .into()
+}
+
+fn get_token_from_git_config() -> anyhow::Result<String> {
+    let output = std::process::Command::new("git")
+        .arg("config")
+        .arg("--get")
+        .arg("github.oauth-token")
+        .output()?;
+    if !output.status.success() {
+        anyhow::bail!("error received executing `git`: {:?}", output.status);
+    }
+    let git_token = String::from_utf8(output.stdout)?.trim().to_string();
+    Ok(git_token)
+}
+
+#[derive(Clone)]
+pub struct GithubClient {
+    token: SecretString,
+    client: Client,
+    pub(in crate::github) api_url: String,
+    /// If `true`, requests will sleep if it hits GitHub's rate limit.
+    retry_rate_limit: bool,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct RateLimitResources {
+    pub core: RateLimit,
+    pub search: RateLimit,
+    pub graphql: RateLimit,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct RateLimit {
+    pub limit: u64,
+    pub remaining: u64,
+    pub reset: u64,
+}
+
+impl GithubClient {
+    pub fn new(token: SecretString, api_url: String) -> Self {
+        GithubClient {
+            client: Client::new(),
+            token,
+            api_url,
+            retry_rate_limit: false,
+        }
+    }
+
+    pub fn new_from_env() -> Self {
+        Self::new(
+            default_token_from_env(),
+            std::env::var("GITHUB_API_URL")
+                .unwrap_or_else(|_| "https://api.github.com".to_string()),
+        )
+    }
+
+    /// Sets whether or not this client will retry when it hits GitHub's rate limit.
+    ///
+    /// Just beware that the retry may take a long time (like 30 minutes,
+    /// depending on various factors).
+    pub fn set_retry_rate_limit(&mut self, retry: bool) {
+        self.retry_rate_limit = retry;
+    }
+
+    pub fn raw(&self) -> &Client {
+        &self.client
+    }
+
+    pub async fn send_req(&self, req: RequestBuilder) -> anyhow::Result<(Bytes, String)> {
+        const MAX_DEFAULT_RESPONSE_SIZE: usize = 8 * 1024 * 1024; // 8 Mib
+
+        self.send_req_with_limit(req, MAX_DEFAULT_RESPONSE_SIZE)
+            .await
+    }
+
+    pub async fn send_req_with_limit(
+        &self,
+        req: RequestBuilder,
+        max_response_size: usize,
+    ) -> anyhow::Result<(Bytes, String)> {
+        const MAX_ATTEMPTS: u32 = 2;
+
+        log::debug!("send_req with {:?}", req);
+
+        let req_dbg = format!("{req:?}");
+
+        let req = req
+            .build()
+            .with_context(|| format!("building reqwest {req_dbg}"))?;
+
+        let req_url = req.url().to_string();
+
+        let mut resp = self.client.execute(req.try_clone().unwrap()).await?;
+        if self.retry_rate_limit
+            && let Some(sleep) = Self::needs_retry(&resp).await
+        {
+            resp = self.retry(req, sleep, MAX_ATTEMPTS).await?;
+        }
+
+        let maybe_err = resp.error_for_status_ref().err();
+        let github_request_id = resp.headers().get("x-github-request-id").cloned();
+
+        let resp: http::Response<Body> = resp.into();
+        let limited = Limited::new(resp, max_response_size);
+
+        let body = match limited.collect().await {
+            Ok(body) => body.to_bytes(),
+            Err(e) => match e.downcast::<http_body_util::LengthLimitError>() {
+                Ok(e) => {
+                    return Err(anyhow::Error::new(*e)).with_context(|| {
+                            format!(
+                                "req={req_url} (x-github-request-id: {}): max response size exceeded (over {max_response_size} bytes)",
+                                github_request_id
+                                    .as_ref()
+                                    .and_then(|v| v.to_str().ok())
+                                    .unwrap_or("unknown")
+                            )
+                        });
+                }
+                Err(e) => {
+                    return Err(anyhow::Error::from_boxed(e)).with_context(|| {
+                            format!(
+                                "req={req_url} (x-github-request-id: {}): unable to complete the request",
+                                github_request_id
+                                    .as_ref()
+                                    .and_then(|v| v.to_str().ok())
+                                    .unwrap_or("unknown")
+                            )
+                        });
+                }
+            },
+        };
+
+        if let Some(e) = maybe_err {
+            return Err(anyhow::Error::new(e)).with_context(|| {
+                format!(
+                    "req={req_url} (x-github-request-id: {}): {:.500}",
+                    github_request_id
+                        .as_ref()
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or("unknown"),
+                    String::from_utf8_lossy(&body),
+                )
+            });
+        }
+
+        Ok((body, req_dbg))
+    }
+
+    async fn needs_retry(resp: &Response) -> Option<Duration> {
+        const REMAINING: &str = "X-RateLimit-Remaining";
+        const RESET: &str = "X-RateLimit-Reset";
+
+        if !matches!(
+            resp.status(),
+            StatusCode::FORBIDDEN | StatusCode::TOO_MANY_REQUESTS
+        ) {
+            return None;
+        }
+
+        let headers = resp.headers();
+        if !(headers.contains_key(REMAINING) && headers.contains_key(RESET)) {
+            return None;
+        }
+
+        let reset_time = headers[RESET].to_str().unwrap().parse::<u64>().unwrap();
+        Some(Duration::from_secs(Self::calc_sleep(reset_time) + 10))
+    }
+
+    fn calc_sleep(reset_time: u64) -> u64 {
+        let epoch_time = SystemTime::UNIX_EPOCH.elapsed().unwrap().as_secs();
+        reset_time.saturating_sub(epoch_time)
+    }
+
+    fn retry(
+        &self,
+        req: Request,
+        sleep: Duration,
+        remaining_attempts: u32,
+    ) -> BoxFuture<'_, Result<Response, reqwest::Error>> {
+        #[derive(Debug, serde::Deserialize)]
+        struct RateLimitResponse {
+            resources: RateLimitResources,
+        }
+
+        log::warn!(
+            "Retrying after {} seconds, remaining attepts {}",
+            sleep.as_secs(),
+            remaining_attempts,
+        );
+
+        async move {
+            tokio::time::sleep(sleep).await;
+
+            // check rate limit
+            let rate_resp = self
+                .client
+                .execute(
+                    self.client
+                        .get(format!("{}/rate_limit", self.api_url))
+                        .configure(self)
+                        .build()
+                        .unwrap(),
+                )
+                .await?;
+            rate_resp.error_for_status_ref()?;
+            let rate_limit_response = rate_resp.json::<RateLimitResponse>().await?;
+
+            // Check url for search path because github has different rate limits for the search api
+            let rate_limit = if req
+                .url()
+                .path_segments()
+                .is_some_and(|mut segments| segments.next() == Some("search"))
+            {
+                rate_limit_response.resources.search
+            } else {
+                rate_limit_response.resources.core
+            };
+
+            // If we still don't have any more remaining attempts, try sleeping for the remaining
+            // period of time
+            if rate_limit.remaining == 0 {
+                let sleep = Self::calc_sleep(rate_limit.reset);
+                if sleep > 0 {
+                    tokio::time::sleep(Duration::from_secs(sleep)).await;
+                }
+            }
+
+            let resp = self.client.execute(req.try_clone().unwrap()).await?;
+            if let Some(sleep) = Self::needs_retry(&resp).await
+                && remaining_attempts > 0
+            {
+                return self.retry(req, sleep, remaining_attempts - 1).await;
+            }
+
+            Ok(resp)
+        }
+        .boxed()
+    }
+
+    pub async fn json<T>(&self, req: RequestBuilder) -> anyhow::Result<T>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        let (body, _req_dbg) = self.send_req(req).await?;
+        Ok(serde_json::from_slice(&body)?)
+    }
+
+    pub fn get(&self, url: &str) -> RequestBuilder {
+        log::trace!("get {:?}", url);
+        self.client.get(url).configure(self)
+    }
+
+    pub fn patch(&self, url: &str) -> RequestBuilder {
+        log::trace!("patch {:?}", url);
+        self.client.patch(url).configure(self)
+    }
+
+    pub fn delete(&self, url: &str) -> RequestBuilder {
+        log::trace!("delete {:?}", url);
+        self.client.delete(url).configure(self)
+    }
+
+    pub fn post(&self, url: &str) -> RequestBuilder {
+        log::trace!("post {:?}", url);
+        self.client.post(url).configure(self)
+    }
+
+    pub fn put(&self, url: &str) -> RequestBuilder {
+        log::trace!("put {:?}", url);
+        self.client.put(url).configure(self)
+    }
+
+    /// Fetch current rate limit, remaining and used
+    pub async fn rate_limit(&self) -> anyhow::Result<RateLimitResources> {
+        #[derive(Debug, serde::Deserialize)]
+        struct RateLimitResponse {
+            resources: RateLimitResources,
+        }
+
+        let url = format!("{}/rate_limit", self.api_url);
+        let response = self
+            .json::<RateLimitResponse>(self.get(&url))
+            .await
+            .context("failed to fetch GitHub /rate_limit endpoint")?;
+
+        Ok(response.resources)
+    }
+}
+
+trait RequestSend: Sized {
+    fn configure(self, g: &GithubClient) -> Self;
+}
+
+impl RequestSend for RequestBuilder {
+    fn configure(self, g: &GithubClient) -> RequestBuilder {
+        let mut auth = reqwest::header::HeaderValue::from_maybe_shared(format!(
+            "token {}",
+            g.token.expose_secret()
+        ))
+        .unwrap();
+        auth.set_sensitive(true);
+        self.header(USER_AGENT, "rust-lang-triagebot")
+            .header(AUTHORIZATION, &auth)
+            .header("X-GitHub-Api-Version", GITHUB_API_VERSION)
+    }
+}

--- a/agendas/compiler-p-high/src/github/issue.rs
+++ b/agendas/compiler-p-high/src/github/issue.rs
@@ -1,0 +1,200 @@
+use chrono::Utc;
+use std::fmt;
+use std::sync::OnceLock;
+use tracing as log;
+
+use super::client::GithubClient;
+use super::repos::{GitHubUser, Repository};
+use super::utils::opt_string;
+
+/// An issue or pull request.
+///
+/// For convenience, since issues and pull requests share most of their
+/// fields, this struct is used for both. The `pull_request` field can be used
+/// to determine which it is. Some fields are only available on pull requests
+/// (but not always, check the GitHub API for details).
+#[derive(Debug, serde::Deserialize)]
+pub struct Issue {
+    pub number: u64,
+    #[serde(deserialize_with = "opt_string")]
+    pub body: String,
+    pub created_at: chrono::DateTime<Utc>,
+    pub updated_at: chrono::DateTime<Utc>,
+    pub title: String,
+    /// The common URL for viewing this issue or PR.
+    ///
+    /// Example: `https://github.com/octocat/Hello-World/pull/1347`
+    pub html_url: String,
+    // User performing an `action` (or PR/issue author)
+    pub user: GitHubUser,
+    pub labels: Vec<Label>,
+    // Users assigned to the issue/pr after `action` has been performed issue
+    // (PR reviewers or issue assignees)
+    // These are NOT the same as `IssueEvent.assignee`
+    pub assignees: Vec<GitHubUser>,
+
+    #[serde(default)]
+    pub merged: bool,
+    #[serde(default)]
+    pub draft: bool,
+
+    /// Number of comments
+    pub comments: Option<u32>,
+
+    /// The API URL for discussion comments.
+    ///
+    /// Example: `https://api.github.com/repos/octocat/Hello-World/issues/1347/comments`
+    comments_url: String,
+    /// The repository for this issue.
+    ///
+    /// Note that this is constructed via the [`Issue::repository`] method.
+    /// It is not deserialized from the GitHub API.
+    #[serde(skip)]
+    pub repository: OnceLock<IssueRepository>,
+
+    /// Whether it is open or closed.
+    pub state: IssueState,
+}
+
+#[derive(PartialEq, Eq, Debug, Clone, Ord, PartialOrd, serde::Deserialize)]
+pub struct Label {
+    pub name: String,
+}
+
+#[derive(Debug, serde::Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum IssueState {
+    Open,
+    Closed,
+}
+
+#[derive(Clone, Debug, serde::Deserialize)]
+pub struct CommitBase {
+    pub sha: String,
+    #[serde(rename = "ref")]
+    pub git_ref: String,
+    pub repo: Option<Repository>,
+}
+
+impl Issue {
+    pub fn repository(&self) -> &IssueRepository {
+        self.repository.get_or_init(|| {
+            // https://api.github.com/repos/rust-lang/rust/issues/69257/comments
+            log::trace!("get repository for {}", self.comments_url);
+            let url = url::Url::parse(&self.comments_url).unwrap();
+            let mut segments = url.path_segments().unwrap();
+            let _comments = segments.next_back().unwrap();
+            let _number = segments.next_back().unwrap();
+            let _issues_or_prs = segments.next_back().unwrap();
+            let repository = segments.next_back().unwrap();
+            let organization = segments.next_back().unwrap();
+            IssueRepository {
+                organization: organization.into(),
+                repository: repository.into(),
+            }
+        })
+    }
+
+    pub fn global_id(&self) -> String {
+        format!("{}#{}", self.repository(), self.number)
+    }
+
+    pub fn is_open(&self) -> bool {
+        self.state == IssueState::Open
+    }
+
+    pub fn labels(&self) -> &[Label] {
+        &self.labels
+    }
+
+    pub fn contains_label(&self, label: &Label) -> bool {
+        self.labels
+            .iter()
+            .any(|l| l.name.to_lowercase() == label.name.to_lowercase())
+    }
+
+    pub fn contain_assignee(&self, user: &str) -> bool {
+        self.assignees
+            .iter()
+            .any(|a| a.login.to_lowercase() == user.to_lowercase())
+    }
+}
+
+// Comments
+
+#[derive(Debug, serde::Deserialize)]
+pub struct Comment {
+    pub id: u64,
+    pub node_id: String,
+    #[serde(default)]
+    pub in_reply_to_id: Option<u64>,
+    #[serde(default)]
+    pub pull_request_review_id: Option<u64>,
+    #[serde(deserialize_with = "opt_string")]
+    pub body: String,
+    pub html_url: String,
+    pub user: GitHubUser,
+    #[serde(default, alias = "submitted_at")] // for pull-request review comments
+    pub created_at: Option<chrono::DateTime<Utc>>,
+    #[serde(default)]
+    pub updated_at: Option<chrono::DateTime<Utc>>,
+}
+
+// Zulip <-> GitHub
+
+/// Contains only the parts of `Issue` that are needed for turning the issue title into a Zulip
+/// topic.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ZulipGitHubReference {
+    pub number: u64,
+    pub title: String,
+    pub repository: IssueRepository,
+}
+
+impl ZulipGitHubReference {
+    pub fn zulip_topic_reference(&self) -> String {
+        let repo = &self.repository;
+        if repo.organization == "rust-lang" {
+            if repo.repository == "rust" {
+                format!("#{}", self.number)
+            } else {
+                format!("{}#{}", repo.repository, self.number)
+            }
+        } else {
+            format!("{}/{}#{}", repo.organization, repo.repository, self.number)
+        }
+    }
+}
+
+impl Issue {
+    pub fn to_zulip_github_reference(&self) -> ZulipGitHubReference {
+        ZulipGitHubReference {
+            number: self.number,
+            title: self.title.clone(),
+            repository: self.repository().clone(),
+        }
+    }
+}
+
+// Issue repository
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IssueRepository {
+    pub organization: String,
+    pub repository: String,
+}
+
+impl fmt::Display for IssueRepository {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}/{}", self.organization, self.repository)
+    }
+}
+
+impl IssueRepository {
+    pub(crate) fn url(&self, client: &GithubClient) -> String {
+        format!(
+            "{}/repos/{}/{}",
+            client.api_url, self.organization, self.repository
+        )
+    }
+}

--- a/agendas/compiler-p-high/src/github/issue_query.rs
+++ b/agendas/compiler-p-high/src/github/issue_query.rs
@@ -1,0 +1,75 @@
+use anyhow::Context;
+use async_trait::async_trait;
+
+use super::GithubClient;
+use super::Repository;
+use crate::team_data::TeamClient;
+
+#[async_trait]
+pub trait IssuesQuery {
+    async fn query<'a>(
+        &'a self,
+        repo: &'a Repository,
+        gh_client: &'a GithubClient,
+        team_client: &'a TeamClient,
+    ) -> anyhow::Result<Vec<crate::actions::IssueDecorator>>;
+}
+
+pub struct Query<'a> {
+    // key/value filter
+    pub filters: Vec<(&'a str, &'a str)>,
+    pub include_labels: Vec<&'a str>,
+    pub exclude_labels: Vec<&'a str>,
+}
+
+#[async_trait]
+impl IssuesQuery for Query<'_> {
+    async fn query<'a>(
+        &'a self,
+        repo: &'a Repository,
+        gh_client: &'a GithubClient,
+        _team_client: &'a TeamClient,
+    ) -> anyhow::Result<Vec<crate::actions::IssueDecorator>> {
+        let issues = repo
+            .get_issues(gh_client, self)
+            .await
+            .with_context(|| "Unable to get issues.")?;
+
+        let mut issues_decorator = Vec::new();
+        for issue in issues {
+            let labels = issue
+                .labels
+                .iter()
+                .map(|l| l.name.as_ref())
+                .collect::<Vec<&str>>();
+
+            // guess the team this issue belongs to:
+            // get the first T-* label associated with it
+            let t_label = labels
+                .iter()
+                .find(|s| s.starts_with("T-"))
+                .map_or("", |v| v);
+
+            issues_decorator.push(crate::actions::IssueDecorator {
+                title: issue.title.clone(),
+                number: issue.number,
+                html_url: issue.html_url.clone(),
+                repo_name: repo.name().to_owned(),
+                labels: labels.join(","),
+                assignees: issue
+                    .assignees
+                    .iter()
+                    .map(|u| u.login.as_ref())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                author: issue.user.login,
+                team: t_label.to_string(),
+                updated_at_hts: crate::actions::to_human(issue.updated_at),
+                created_at_hts: crate::actions::to_human(issue.created_at),
+                is_blocked: false,
+            });
+        }
+
+        Ok(issues_decorator)
+    }
+}

--- a/agendas/compiler-p-high/src/github/repos.rs
+++ b/agendas/compiler-p-high/src/github/repos.rs
@@ -1,0 +1,380 @@
+use super::issue_query::Query;
+use super::{GithubClient, Issue, IssueRepository};
+use anyhow::Context;
+use chrono::{DateTime, FixedOffset};
+use itertools::Itertools;
+use octocrab::models::Author;
+
+type UserId = u64;
+
+// User
+
+#[derive(Debug, PartialEq, Eq, Hash, serde::Deserialize, Clone)]
+pub struct GitHubUser {
+    pub login: String,
+    #[serde(alias = "databaseId")]
+    pub id: UserId,
+    #[serde(alias = "__typename")]
+    pub r#type: GitHubUserType,
+}
+
+impl From<&Author> for GitHubUser {
+    fn from(author: &Author) -> Self {
+        Self {
+            id: author.id.0,
+            login: author.login.clone(),
+            r#type: match author.r#type.as_str() {
+                "User" => GitHubUserType::User,
+                "Bot" => GitHubUserType::Bot,
+                _ => GitHubUserType::Custom(author.r#type.clone()),
+            },
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, serde::Deserialize, Clone)]
+#[serde(rename_all = "PascalCase")]
+pub enum GitHubUserType {
+    User,
+    Bot,
+    #[serde(untagged)]
+    Custom(String),
+}
+
+// https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content
+#[derive(serde::Deserialize, serde::Serialize)]
+pub struct RepoContent {
+    pub name: String,
+    pub download_url: String,
+}
+
+// Others
+
+impl GithubClient {
+    pub async fn issue(&self, repo: &IssueRepository, issue_num: u64) -> anyhow::Result<Issue> {
+        let url = format!("{}/issues/{issue_num}", repo.url(self));
+        self.json(self.get(&url))
+            .await
+            .with_context(|| format!("{repo} failed to get issue {issue_num}"))
+    }
+
+    /// Returns information about a repository.
+    ///
+    /// The `full_name` should be something like `rust-lang/rust`.
+    async fn repository(&self, full_name: &str) -> anyhow::Result<Repository> {
+        let req = self.get(&format!("{}/repos/{full_name}", self.api_url));
+        self.json(req)
+            .await
+            .with_context(|| format!("{full_name} failed to get repo"))
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize)]
+#[cfg_attr(test, derive(Default))]
+pub struct Repository {
+    pub full_name: String,
+    pub default_branch: String,
+    #[serde(default)]
+    pub fork: bool,
+    pub parent: Option<Box<Repository>>,
+}
+
+impl Repository {
+    fn url(&self, client: &GithubClient) -> String {
+        format!("{}/repos/{}", client.api_url, self.full_name)
+    }
+
+    pub fn owner(&self) -> &str {
+        self.full_name.split_once('/').unwrap().0
+    }
+
+    pub fn name(&self) -> &str {
+        self.full_name.split_once('/').unwrap().1
+    }
+
+    pub async fn get_issues<'a>(
+        &self,
+        client: &GithubClient,
+        query: &Query<'a>,
+    ) -> anyhow::Result<Vec<Issue>> {
+        #[derive(Debug, serde::Deserialize)]
+        struct IssueSearchResult {
+            total_count: u64,
+            items: Vec<Issue>,
+        }
+
+        let Query {
+            filters,
+            include_labels,
+            exclude_labels,
+        } = query;
+
+        let mut ordering = Ordering {
+            sort: "created",
+            direction: "asc",
+            per_page: "100",
+            page: 1,
+        };
+        let filters: Vec<_> = filters
+            .clone()
+            .into_iter()
+            .filter(|(key, val)| {
+                match *key {
+                    "sort" => ordering.sort = val,
+                    "direction" => ordering.direction = val,
+                    "per_page" => ordering.per_page = val,
+                    _ => return true,
+                }
+                false
+            })
+            .collect();
+
+        // `is: pull-request` indicates the query to retrieve PRs only
+        let is_pr = filters.contains(&("is", "pull-request"));
+
+        // There are some cases that can only be handled by the search API:
+        // 1. When using negating label filters (exclude_labels)
+        // 2. When there's a key parameter key=no
+        // 3. When the query is to retrieve PRs only and there are label filters
+        //
+        // Check https://docs.github.com/en/rest/reference/search#search-issues-and-pull-requests
+        // for more information
+        let use_search_api = !exclude_labels.is_empty()
+            || filters.iter().any(|&(key, _)| key == "no")
+            || is_pr && !include_labels.is_empty();
+
+        // If there are more than `per_page` of issues, we need to paginate
+        let mut issues = vec![];
+        loop {
+            let url = if use_search_api {
+                self.build_search_issues_url(
+                    client,
+                    &filters,
+                    include_labels,
+                    exclude_labels,
+                    ordering,
+                )
+            } else if is_pr {
+                self.build_pulls_url(client, &filters, include_labels, ordering)
+            } else {
+                self.build_issues_url(client, &filters, include_labels, ordering)
+            };
+
+            let result = client.get(&url);
+            if use_search_api {
+                let result = client
+                    .json::<IssueSearchResult>(result)
+                    .await
+                    .with_context(|| format!("failed to list issues from {url}"))?;
+                issues.extend(result.items);
+                if (issues.len() as u64) < result.total_count {
+                    ordering.page += 1;
+                    continue;
+                }
+            } else {
+                // FIXME: paginate with non-search
+                issues = client
+                    .json(result)
+                    .await
+                    .with_context(|| format!("failed to list issues from {url}"))?;
+            }
+
+            break;
+        }
+        Ok(issues)
+    }
+
+    fn build_issues_url(
+        &self,
+        client: &GithubClient,
+        filters: &[(&str, &str)],
+        include_labels: &[&str],
+        ordering: Ordering<'_>,
+    ) -> String {
+        self.build_endpoint_url(client, "issues", filters, include_labels, ordering)
+    }
+
+    fn build_pulls_url(
+        &self,
+        client: &GithubClient,
+        filters: &[(&str, &str)],
+        include_labels: &[&str],
+        ordering: Ordering<'_>,
+    ) -> String {
+        self.build_endpoint_url(client, "pulls", filters, include_labels, ordering)
+    }
+
+    fn build_endpoint_url(
+        &self,
+        client: &GithubClient,
+        endpoint: &str,
+        filters: &[(&str, &str)],
+        include_labels: &[&str],
+        ordering: Ordering<'_>,
+    ) -> String {
+        let filters = filters
+            .iter()
+            .map(|(key, val)| format!("{key}={val}"))
+            .chain([format!("labels={}", include_labels.join(","))])
+            .chain(["filter=all".to_owned()])
+            .chain([format!("sort={}", ordering.sort)])
+            .chain([format!("direction={}", ordering.direction)])
+            .chain([format!("per_page={}", ordering.per_page)])
+            .format("&");
+        format!(
+            "{}/repos/{}/{}?{}",
+            client.api_url, self.full_name, endpoint, filters
+        )
+    }
+
+    fn build_search_issues_url(
+        &self,
+        client: &GithubClient,
+        filters: &[(&str, &str)],
+        include_labels: &[&str],
+        exclude_labels: &[&str],
+        ordering: Ordering<'_>,
+    ) -> String {
+        let filters = filters
+            .iter()
+            .filter(|filter| **filter != ("state", "all"))
+            .map(|(key, val)| format!("{key}:{val}"))
+            .chain(include_labels.iter().map(|label| format!("label:{label}")))
+            .chain(exclude_labels.iter().map(|label| format!("-label:{label}")))
+            .chain([format!("repo:{}", self.full_name)])
+            .format("+");
+        format!(
+            "{}/search/issues?q={}&sort={}&order={}&per_page={}&page={}",
+            client.api_url,
+            filters,
+            ordering.sort,
+            ordering.direction,
+            ordering.per_page,
+            ordering.page,
+        )
+    }
+
+    pub async fn get_issue(&self, client: &GithubClient, issue_num: u64) -> anyhow::Result<Issue> {
+        client
+            .issue(
+                &IssueRepository {
+                    organization: self.owner().to_string(),
+                    repository: self.name().to_string(),
+                },
+                issue_num,
+            )
+            .await
+    }
+}
+
+// Commits
+
+#[derive(Debug, serde::Deserialize)]
+pub struct GithubCommit {
+    pub sha: String,
+    pub commit: GithubCommitCommitField,
+    pub parents: Vec<Parent>,
+    pub html_url: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct GithubCommitCommitField {
+    pub author: GitUser,
+    pub message: String,
+    pub tree: GitCommitTree,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct GitCommit {
+    pub sha: String,
+    pub author: GitUser,
+    pub message: String,
+    pub tree: GitCommitTree,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct GitCommitTree {
+    pub sha: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct GitTreeObject {
+    pub sha: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct GitUser {
+    pub date: DateTime<FixedOffset>,
+    pub name: Option<String>,
+    pub email: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct Parent {
+    pub sha: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct Submodule {
+    pub name: String,
+    pub path: String,
+    pub sha: String,
+    pub submodule_git_url: String,
+}
+
+impl Submodule {
+    /// Returns the `Repository` this submodule points to.
+    ///
+    /// This assumes that the submodule is on GitHub.
+    pub async fn repository(&self, client: &GithubClient) -> anyhow::Result<Repository> {
+        let fullname = self
+            .submodule_git_url
+            .strip_prefix("https://github.com/")
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "only github submodules supported, got {}",
+                    self.submodule_git_url
+                )
+            })?
+            .strip_suffix(".git")
+            .ok_or_else(|| {
+                anyhow::anyhow!("expected .git suffix, got {}", self.submodule_git_url)
+            })?;
+        client.repository(fullname).await
+    }
+}
+
+impl Repository {
+    /// Returns information about the git submodule at the given path.
+    ///
+    /// `refname` is the ref to use for fetching information. If `None`, will
+    /// use the latest version on the default branch.
+    pub async fn submodule(
+        &self,
+        client: &GithubClient,
+        path: &str,
+        refname: Option<&str>,
+    ) -> anyhow::Result<Submodule> {
+        let mut url = format!("{}/contents/{}", self.url(client), path);
+        if let Some(refname) = refname {
+            url.push_str("?ref=");
+            url.push_str(refname);
+        }
+        client.json(client.get(&url)).await.with_context(|| {
+            format!(
+                "{} failed to get submodule path={path} refname={refname:?}",
+                self.full_name
+            )
+        })
+    }
+}
+
+// Ordering
+
+#[derive(Copy, Clone)]
+struct Ordering<'a> {
+    sort: &'a str,
+    direction: &'a str,
+    per_page: &'a str,
+    page: u64,
+}

--- a/agendas/compiler-p-high/src/github/utils.rs
+++ b/agendas/compiler-p-high/src/github/utils.rs
@@ -1,0 +1,11 @@
+/// Deserialize as an optional string
+pub(crate) fn opt_string<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    use serde::de::Deserialize;
+    match <Option<String>>::deserialize(deserializer) {
+        Ok(v) => Ok(v.unwrap_or_default()),
+        Err(e) => Err(e),
+    }
+}

--- a/agendas/compiler-p-high/src/lib.rs
+++ b/agendas/compiler-p-high/src/lib.rs
@@ -1,0 +1,6 @@
+// https://docs.github.com/de/rest/about-the-rest-api/api-versions?apiVersion=2026-03-10
+pub const GITHUB_API_VERSION: &str = "2026-03-10";
+
+pub mod actions;
+pub mod github;
+pub mod team_data;

--- a/agendas/compiler-p-high/src/main.rs
+++ b/agendas/compiler-p-high/src/main.rs
@@ -1,0 +1,109 @@
+use std::sync::{Arc, LazyLock};
+
+use compiler_p_high::actions::{Action, Query, QueryKind, QueryMap, Step};
+use compiler_p_high::github::default_token_from_env;
+use compiler_p_high::github::issue_query::Query as IssueQuery;
+use octocrab::Octocrab;
+use tera::Tera;
+
+pub static TEMPLATES: LazyLock<Tera> = LazyLock::new(|| match Tera::new("templates/*") {
+    Ok(t) => t,
+    Err(e) => {
+        println!("Parsing error(s): {e}");
+        ::std::process::exit(1);
+    }
+});
+
+pub fn p_high_issues() -> Box<dyn Action> {
+    let all_tlabels = vec![
+        "T-bootstrap",
+        "T-cargo",
+        "T-clippy",
+        "T-community",
+        "T-compiler",
+        "T-core",
+        "T-crates-io",
+        "T-dev-tools",
+        "T-docs-rs",
+        "T-edition",
+        "T-fls",
+        "T-infra",
+        "T-infra-italians",
+        "T-lang",
+        "T-lang-docs",
+        "T-leadership-council",
+        "T-libs",
+        "T-libs-api",
+        "T-opsem",
+        "T-release",
+        "T-rust-analyzer",
+        "T-rustdoc",
+        "T-rustdoc-frontend",
+        "T-rustdoc-internals",
+        "T-rustdoc-json-backend",
+        "T-rustfmt",
+        "T-rustup",
+        "T-spec",
+        "T-style",
+        "T-testing-devex",
+        "T-triagebot",
+        "T-types",
+    ];
+
+    let mut other_teams_tlabels = all_tlabels.clone();
+    other_teams_tlabels.retain(|&x| x != "T-compiler");
+
+    Box::new(Step {
+        name: "p_high_issues",
+        actions: vec![
+            Query {
+                repos: vec![("rust-lang", "rust")],
+                queries: vec![QueryMap {
+                    name: "p_high_tcompiler_unassigned",
+                    kind: QueryKind::List,
+                    query: Arc::new(IssueQuery {
+                        filters: vec![("state", "open"), ("no", "assignee")],
+                        include_labels: vec!["P-high", "T-compiler"],
+                        exclude_labels: vec![],
+                    }),
+                }],
+            },
+            Query {
+                repos: vec![("rust-lang", "rust")],
+                queries: vec![QueryMap {
+                    name: "p_high_tcompiler_assigned",
+                    kind: QueryKind::List,
+                    query: Arc::new(IssueQuery {
+                        filters: vec![("state", "open"), ("has", "assignee")],
+                        include_labels: vec!["P-high", "T-compiler"],
+                        exclude_labels: other_teams_tlabels,
+                    }),
+                }],
+            },
+            Query {
+                repos: vec![("rust-lang", "rust")],
+                queries: vec![QueryMap {
+                    name: "p_high_without_tlabel",
+                    kind: QueryKind::List,
+                    query: Arc::new(IssueQuery {
+                        filters: vec![("state", "open")],
+                        include_labels: vec!["P-high"],
+                        exclude_labels: all_tlabels,
+                    }),
+                }],
+            },
+        ],
+    })
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+    let octo_client = Octocrab::builder()
+        .user_access_token(default_token_from_env())
+        .build()
+        .unwrap();
+    let query = p_high_issues();
+    print!("{}", query.call(&octo_client).await?);
+    Ok(())
+}

--- a/agendas/compiler-p-high/src/team_data.rs
+++ b/agendas/compiler-p-high/src/team_data.rs
@@ -1,0 +1,198 @@
+use reqwest::Client;
+use rust_team_data::v1::{BASE_URL, People, Repos, Teams, ZulipMapping};
+use serde::de::DeserializeOwned;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::RwLock;
+
+#[derive(Clone)]
+pub struct TeamClient {
+    base_url: String,
+    client: Client,
+    teams: CachedTeamItem<Teams>,
+    repos: CachedTeamItem<Repos>,
+    people: CachedTeamItem<People>,
+    zulip_mapping: CachedTeamItem<ZulipMapping>,
+}
+
+impl TeamClient {
+    pub fn new_from_env() -> Self {
+        let base_url = std::env::var("TEAMS_API_URL").unwrap_or(BASE_URL.to_string());
+        Self::new(base_url)
+    }
+
+    pub fn new(base_url: String) -> Self {
+        Self {
+            base_url,
+            client: Client::new(),
+            teams: CachedTeamItem::new("/teams.json"),
+            repos: CachedTeamItem::new("/repos.json"),
+            people: CachedTeamItem::new("/people.json"),
+            zulip_mapping: CachedTeamItem::new("/zulip-map.json"),
+        }
+    }
+
+    pub async fn is_team_member(&self, gh_login: &str) -> anyhow::Result<bool> {
+        tracing::trace!("Getting team membership for {:?}", gh_login);
+        let permission = self.teams().await?;
+        let map = permission.teams;
+        let is_triager = map
+            .get("wg-triage")
+            .is_some_and(|w| w.members.iter().any(|g| g.github == gh_login));
+        let is_async_member = map
+            .get("wg-async")
+            .is_some_and(|w| w.members.iter().any(|g| g.github == gh_login));
+        let in_all = map["all"].members.iter().any(|g| g.github == gh_login);
+        tracing::trace!(
+            "{:?} is all?={:?}, triager?={:?}, async?={:?}",
+            gh_login,
+            in_all,
+            is_triager,
+            is_async_member,
+        );
+        Ok(in_all || is_triager || is_async_member)
+    }
+
+    pub async fn zulip_to_github_id(&self, zulip_id: u64) -> anyhow::Result<Option<u64>> {
+        let map = self.zulip_map().await?;
+        Ok(map.users.get(&zulip_id).copied())
+    }
+
+    pub async fn username_from_gh_id(&self, github_id: u64) -> anyhow::Result<Option<String>> {
+        let people_map = self.people().await?;
+        Ok(people_map
+            .people
+            .into_iter()
+            .filter(|(_, p)| p.github_id == github_id)
+            .map(|p| p.0)
+            .next())
+    }
+
+    // Returns the ID of the given user, if they are in the `team` database.
+    pub async fn get_gh_id_from_username(&self, login: &str) -> anyhow::Result<Option<u64>> {
+        let people = self.people().await?;
+        let login = login.to_lowercase();
+        Ok(people
+            .people
+            .iter()
+            .find(|(github_login, _)| github_login.to_lowercase() == login)
+            .map(|(_, person)| person.github_id))
+    }
+
+    pub async fn github_to_zulip_id(&self, github_id: u64) -> anyhow::Result<Option<u64>> {
+        let map = self.zulip_map().await?;
+        Ok(map
+            .users
+            .iter()
+            .find(|&(_, &github)| github == github_id)
+            .map(|v| *v.0))
+    }
+
+    pub async fn get_team(&self, team: &str) -> anyhow::Result<Option<rust_team_data::v1::Team>> {
+        let permission = self.teams().await?;
+        let mut map = permission.teams;
+        Ok(map.swap_remove(team))
+    }
+
+    /// Fetches a Rust team via its GitHub team name.
+    pub async fn get_team_by_github_name(
+        &self,
+        org: &str,
+        team: &str,
+    ) -> anyhow::Result<Option<rust_team_data::v1::Team>> {
+        let teams = self.teams().await?;
+        for rust_team in teams.teams.into_values() {
+            if let Some(github) = &rust_team.github {
+                for gh_team in &github.teams {
+                    if gh_team.org == org && gh_team.name == team {
+                        return Ok(Some(rust_team));
+                    }
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    pub async fn zulip_map(&self) -> anyhow::Result<ZulipMapping> {
+        self.zulip_mapping.get(&self.client, &self.base_url).await
+    }
+
+    pub async fn teams(&self) -> anyhow::Result<Teams> {
+        self.teams.get(&self.client, &self.base_url).await
+    }
+
+    pub async fn repos(&self) -> anyhow::Result<Repos> {
+        self.repos.get(&self.client, &self.base_url).await
+    }
+
+    pub async fn people(&self) -> anyhow::Result<People> {
+        self.people.get(&self.client, &self.base_url).await
+    }
+}
+
+/// How long should downloaded team data items be cached in memory.
+const CACHE_DURATION: Duration = Duration::from_secs(2 * 60);
+
+#[derive(Clone)]
+struct CachedTeamItem<T> {
+    value: Arc<RwLock<CachedValue<T>>>,
+    url_path: String,
+}
+
+impl<T: DeserializeOwned + Clone> CachedTeamItem<T> {
+    fn new(url_path: &str) -> Self {
+        Self {
+            value: Arc::new(RwLock::new(CachedValue::Empty)),
+            url_path: url_path.to_string(),
+        }
+    }
+
+    async fn get(&self, client: &Client, base_url: &str) -> anyhow::Result<T> {
+        let now = Instant::now();
+        {
+            let value = self.value.read().await;
+            if let CachedValue::Present {
+                value,
+                last_download,
+            } = &*value
+                && *last_download + CACHE_DURATION > now
+            {
+                return Ok(value.clone());
+            }
+        }
+        match download::<T>(client, base_url, &self.url_path).await {
+            Ok(v) => {
+                let mut value = self.value.write().await;
+                *value = CachedValue::Present {
+                    value: v.clone(),
+                    last_download: Instant::now(),
+                };
+                Ok(v)
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+enum CachedValue<T> {
+    Empty,
+    Present { value: T, last_download: Instant },
+}
+
+async fn download<T: DeserializeOwned>(
+    client: &Client,
+    base_url: &str,
+    path: &str,
+) -> anyhow::Result<T> {
+    let url = format!("{base_url}{path}");
+    for _ in 0i32..3 {
+        let response = client.get(&url).send().await;
+        match response {
+            Ok(v) => return Ok(v.json().await?),
+            Err(e) if e.is_timeout() => continue,
+            Err(e) => return Err(e.into()),
+        }
+    }
+
+    Err(anyhow::anyhow!("Failed to retrieve {url} in 3 requests"))
+}

--- a/agendas/compiler-p-high/templates/_issue.tt
+++ b/agendas/compiler-p-high/templates/_issue.tt
@@ -1,0 +1,12 @@
+{# __tera_context #}
+{% macro render(issue) %}
+### "{{issue.title}}" [{{issue.repo_name}}#{{issue.number}}]({{issue.html_url}})
+Creation date: {{ issue.created_at_hts }}
+Update at: {{ issue.updated_at_hts }}
+Labels: {{ issue.labels | split(pat=",") }}
+Author: `{{ issue.author }}`
+Assignees: `{% if issue.assignees %}{{ issue.assignees | split(pat="`,`") }}{% else %}none{% endif %}`
+Working groups:
+Notes:
+Triage:
+{% endmacro %}

--- a/agendas/compiler-p-high/templates/_issues.tt
+++ b/agendas/compiler-p-high/templates/_issues.tt
@@ -1,0 +1,9 @@
+{% import "_issue.tt" as issue %}
+
+{% macro render(issues, empty="No issues at this time.") %}
+{%- for issue in issues -%}
+{{ issue::render(issue=issue) }}
+{%- else -%}
+{{empty}}
+{%- endfor -%}
+{% endmacro %}

--- a/agendas/compiler-p-high/templates/p_high_issues.tt
+++ b/agendas/compiler-p-high/templates/p_high_issues.tt
@@ -1,0 +1,24 @@
+{% import "_issues.tt" as issues %}
+
+---
+title: T-compiler P-high issues
+tags: p-high-issues
+---
+
+Issues snapshot collected on: {{ CURRENT_DATE }}
+
+## Table of contents:
+- [P-high T-compiler issues unassigned](#P-high-T-compiler-issues-unassigned) ({{ p_high_tcompiler_unassigned | length }})
+- [P-high T-compiler issues assigned](#P-high-T-compiler-issues-assigned) ({{ p_high_tcompiler_assigned | length }})
+- [P-high without a team label](#P-high-issues-without-a-team-label) ({{ p_high_without_tlabel | length }})
+
+# 2026 Q2 T-compiler P-high Issue Review
+
+## P-high T-compiler issues unassigned
+{{-issues::render(issues=p_high_tcompiler_unassigned)}}
+
+## P-high T-compiler issues assigned
+{{-issues::render(issues=p_high_tcompiler_assigned)}}
+
+## P-high without a team label
+{{-issues::render(issues=p_high_without_tlabel)}}


### PR DESCRIPTION
In an effort to make the triagebot more modular, I wanted to experiment with workspaces.

I need a new binary to run another meeting (the P-high issues review we do from time to time) and instead of adding code to the main triagebot codebase, I've tried creating a workspace ("utils", not a great name). Ideally I want to detach these binaries that now live under `./src/bin` and make them as independent as possible. Their main dependency i think is the GitHub client.

Build with: `cargo [ check | build ] --workspace`

Unsure if this is the right direction, so happy to get feedback!

r? @Urgau (for a first opinion, thanks!)