### PR TITLE
Make the reporting instructions less distracting when reporting an error

### DIFF
--- a/src/interactions.rs
+++ b/src/interactions.rs
@@ -31,7 +31,7 @@ impl<'a> ErrorComment<'a> {
         let mut body = String::new();
         writeln!(body, "**Error**: {message}")?;
         writeln!(body)?;
-        writeln!(body, "{REPORT_TO}")?;
+        writeln!(body, "*{REPORT_TO}*")?;
         Ok(body)
     }
 


### PR DESCRIPTION
Currently:
<img width="875" height="185" alt="image" src="https://github.com/user-attachments/assets/fb430981-32b1-4341-ad37-ace3ed5f23e0" />

This PR:
<img width="871" height="183" alt="image" src="https://github.com/user-attachments/assets/91490c4c-ea71-4566-ae26-a05a885d52df" />

With this change I feel like it's easier to see the error, and not be distracted by the reporting instructions.