### PR TITLE
Fix the author url and avatar in out GitHub comment's viewer

### DIFF
--- a/src/gh_comments.rs
+++ b/src/gh_comments.rs
@@ -29,7 +29,7 @@ use crate::{
     utils::{immutable_headers, is_known_and_public_repo},
 };
 
-pub const STYLE_URL: &str = "/gh-comments/style@0.0.9.css";
+pub const STYLE_URL: &str = "/gh-comments/style@0.0.10.css";
 pub const MARKDOWN_URL: &str = "/gh-comments/github-markdown@20260117.css";
 pub const SELF_CONTAINED_URL: &str = "/gh-comments/self_contained@0.0.3.js";
 pub const RELATIVE_TIME_ELEMENT_URL: &str = "/gh-comments/relative-time-element@5.0.0.js";
@@ -545,8 +545,10 @@ fn write_comment_as_html(
     minimized: bool,
     minimized_reason: Option<&str>,
 ) -> anyhow::Result<()> {
+    let author_url = &author.url;
     let author_login = &author.login;
     let author_avatar_url = &author.avatar_url;
+    let author_avatar_extra_class = avatar_extra_class(&author.type_);
     let created_at_rfc3339 = created_at.to_rfc3339();
     let id = extract_id_from_github_link(comment_url);
 
@@ -555,23 +557,23 @@ fn write_comment_as_html(
             buffer,
             r###"
     <div class="comment-wrapper">
-      <a href="https://github.com/{author_login}" target="_blank" class="desktop">
-        <img src="{author_avatar_url}" alt="{author_login} Avatar" class="avatar">
+      <a href="{author_url}" target="_blank" class="desktop">
+        <img src="{author_avatar_url}" alt="{author_login} Avatar" class="avatar {author_avatar_extra_class}">
       </a>
       
       <details id="{id}" class="comment">
         <summary class="comment-header">
           <div class="author-info desktop">
-            <a href="https://github.com/{author_login}" target="_blank">{author_login}</a>
+            <a href="{author_url}" target="_blank">{author_login}</a>
             <span> <relative-time datetime="{created_at_rfc3339}">{created_at}</relative-time></span><span> · hidden as {minimized_reason}</span>
           </div>
 
           <div class="author-mobile">
-            <a href="https://github.com/{author_login}" target="_blank">
-              <img src="{author_avatar_url}" alt="{author_login} Avatar" class="avatar">
+            <a href="{author_url}" target="_blank">
+              <img src="{author_avatar_url}" alt="{author_login} Avatar" class="avatar {author_avatar_extra_class}">
             </a>
             <div class="author-info">
-              <a href="https://github.com/{author_login}" target="_blank" class="author-info-name">{author_login}</a>
+              <a href="{author_url}" target="_blank" class="author-info-name">{author_login}</a>
               <a href="#{id}"> <relative-time datetime="{created_at_rfc3339}">{created_at}</relative-time></a><span> · hidden as {minimized_reason}</span>
             </div>
           </div>
@@ -599,23 +601,23 @@ fn write_comment_as_html(
             buffer,
             r###"
     <div class="comment-wrapper">
-      <a href="https://github.com/{author_login}" target="_blank" class="desktop">
-        <img src="{author_avatar_url}" alt="{author_login} Avatar" class="avatar">
+      <a href="{author_url}" target="_blank" class="desktop">
+        <img src="{author_avatar_url}" alt="{author_login} Avatar" class="avatar {author_avatar_extra_class}">
       </a>
 
       <div id="{id}" class="comment">
         <div class="comment-header">
           <div class="author-info desktop">
-            <a href="https://github.com/{author_login}" target="_blank" class="author-info-name">{author_login}</a>
+            <a href="{author_url}" target="_blank" class="author-info-name">{author_login}</a>
             <a href="#{id}"> <relative-time datetime="{created_at_rfc3339}">{created_at}</relative-time></a>{edited}
           </div>
 
           <div class="author-mobile">
-            <a href="https://github.com/{author_login}" target="_blank">
-              <img src="{author_avatar_url}" alt="{author_login} Avatar" class="avatar">
+            <a href="{author_url}" target="_blank">
+              <img src="{author_avatar_url}" alt="{author_login} Avatar" class="avatar {author_avatar_extra_class}">
             </a>
             <div class="author-info">
-              <a href="https://github.com/{author_login}" target="_blank" class="author-info-name">{author_login}</a>
+              <a href="{author_url}" target="_blank" class="author-info-name">{author_login}</a>
               <a href="#{id}"> <relative-time datetime="{created_at_rfc3339}">{created_at}</relative-time></a>{edited}
             </div>
           </div>
@@ -647,8 +649,10 @@ fn write_review_as_html(
     minimized: bool,
     minimized_reason: Option<&str>,
 ) -> anyhow::Result<()> {
+    let author_url = &author.url;
     let author_login = &author.login;
     let author_avatar_url = &author.avatar_url;
+    let author_avatar_extra_class = avatar_extra_class(&author.type_);
     let submitted_at_rfc3339 = submitted_at.to_rfc3339();
     let id = extract_id_from_github_link(review_url);
 
@@ -687,14 +691,14 @@ fn write_review_as_html(
         buffer,
         r###"
     <div id="{id}" class="review">
-      <a href="https://github.com/{author_login}" target="_blank">
-        <img src="{author_avatar_url}" alt="{author_login} Avatar" class="avatar">
+      <a href="{author_url}" target="_blank">
+        <img src="{author_avatar_url}" alt="{author_login} Avatar" class="avatar {author_avatar_extra_class}">
       </a>
       
       <div class="review-header">
         <div class="review-badge {badge_color}">{badge_svg}</div>
         <div class="author-info">
-          <a href="https://github.com/{author_login}" target="_blank" class="author-info-name">{author_login}</a>
+          <a href="{author_url}" target="_blank" class="author-info-name">{author_login}</a>
           <a href="#{id}">{state_message} <relative-time datetime="{submitted_at_rfc3339}">{submitted_at}</relative-time></a>
         </div>
       </div>
@@ -712,7 +716,7 @@ fn write_review_as_html(
       <details class="comment">
         <summary class="comment-header">
           <div class="author-info">
-            <a href="https://github.com/{author_login}" target="_blank">{author_login}</a>
+            <a href="{author_url}" target="_blank">{author_login}</a>
             <span>left a comment · hidden as {minimized_reason}</span>
           </div>
 
@@ -741,7 +745,7 @@ fn write_review_as_html(
       <div class="comment">
         <div class="comment-header">
           <div class="author-info">
-            <a href="https://github.com/{author_login}" target="_blank">{author_login}</a>
+            <a href="{author_url}" target="_blank">{author_login}</a>
             <span>left a comment</span>{edited}
           </div>
 
@@ -801,8 +805,10 @@ fn write_review_thread_as_html(
 
     for comment in comments {
         let author = comment.author.as_ref().unwrap_or(&GHOST_ACCOUNT);
+        let author_url = &author.url;
         let author_login = &author.login;
         let author_avatar_url = &author.avatar_url;
+        let author_avatar_extra_class = avatar_extra_class(&author.type_);
         let created_at = &comment.created_at;
         let created_at_rfc3339 = comment.created_at.to_rfc3339();
         let body_html = &comment.body_html;
@@ -822,10 +828,10 @@ fn write_review_thread_as_html(
       <div id="{id}" class="review-thread-comment">
           <div class="review-thread-comment-header">
             <div class="author-info">
-              <a href="https://github.com/{author_login}" target="_blank">
-                <img src="{author_avatar_url}" alt="{author_login} Avatar" class="avatar avatar-small">
+              <a href="{author_url}" target="_blank">
+                <img src="{author_avatar_url}" alt="{author_login} Avatar" class="avatar {author_avatar_extra_class} avatar-small">
               </a>
-              <a href="https://github.com/{author_login}" target="_blank" class="author-info-name">{author_login}</a>
+              <a href="{author_url}" target="_blank" class="author-info-name">{author_login}</a>
               <a href="#{id}"> <relative-time datetime="{created_at_rfc3339}">{created_at}</relative-time></a>{edited}
             </div>
             <a href="{comment_url}" target="_blank" class="github-link">View on GitHub</a>
@@ -1112,4 +1118,8 @@ fn parse_diff_hunk_and_relevant_lines(
 
 fn extract_id_from_github_link(url: &str) -> &str {
     url.rfind('#').map(|pos| &url[pos + 1..]).unwrap_or("")
+}
+
+fn avatar_extra_class(type_: &str) -> &str {
+    if type_ == "Bot" { "avatar-bot" } else { "" }
 }

--- a/src/gh_comments/style.css
+++ b/src/gh_comments/style.css
@@ -236,6 +236,10 @@ details[open] .review-thread-header .fold-indicator {
     display: block;
 }
 
+.avatar-bot {
+    border-radius: 0.375rem;
+}
+
 .avatar-small {
     width: 24px;
     height: 24px;

--- a/src/github/queries/issue_with_comments.rs
+++ b/src/github/queries/issue_with_comments.rs
@@ -29,6 +29,9 @@ pub struct GitHubIssueWithComments {
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct GitHubSimplifiedAuthor {
     pub login: String,
+    pub url: String,
+    #[serde(rename = "__typename")]
+    pub type_: String,
     #[serde(rename = "avatarUrl")]
     pub avatar_url: String,
 }
@@ -37,7 +40,9 @@ impl Default for GitHubSimplifiedAuthor {
     fn default() -> Self {
         // Default to the "Deleted user" (https://github.com/ghost)
         GitHubSimplifiedAuthor {
+            type_: "User".to_string(),
             login: "ghost".to_string(),
+            url: "https://github.com/ghost".to_string(),
             avatar_url: "https://avatars.githubusercontent.com/u/10137?v=4".to_string(),
         }
     }
@@ -252,8 +257,10 @@ query ($owner: String!, $repo: String!, $issueNumber: Int!, $commentsCursor: Str
         updatedAt
         lastEditedAt
         author {
+          url
           login
           avatarUrl
+          __typename
         }
         reactionGroups {
           content
@@ -269,8 +276,10 @@ query ($owner: String!, $repo: String!, $issueNumber: Int!, $commentsCursor: Str
         comments(first: 100, after: $commentsCursor) {
           nodes {
             author {
+              url
               login
               avatarUrl
+              __typename
             }
             createdAt
             lastEditedAt
@@ -305,8 +314,10 @@ query ($owner: String!, $repo: String!, $issueNumber: Int!, $commentsCursor: Str
         createdAt
         lastEditedAt
         author {
+          url
           login
           avatarUrl
+          __typename
         }
         reactionGroups {
           content
@@ -322,8 +333,10 @@ query ($owner: String!, $repo: String!, $issueNumber: Int!, $commentsCursor: Str
         comments(first: 100, after: $commentsCursor) {
           nodes {
             author {
+              url
               login
               avatarUrl
+              __typename
             }
             createdAt
             lastEditedAt
@@ -361,8 +374,10 @@ query ($owner: String!, $repo: String!, $issueNumber: Int!, $commentsCursor: Str
             comments(first: 100) {
               nodes {
                 author {
+                  url
                   login
                   avatarUrl
+                  __typename
                 }
                 createdAt
                 lastEditedAt
@@ -394,8 +409,10 @@ query ($owner: String!, $repo: String!, $issueNumber: Int!, $commentsCursor: Str
         reviews(first: 100, after: $reviewsCursor) {
           nodes {
             author {
+              url
               login
               avatarUrl
+              __typename
             }
             id
             state


### PR DESCRIPTION
Fix the author url (when it's a bot) and avatar (less round for bot) in out GitHub comment's viewer.

Currently:
<img width="693" height="321" alt="image" src="https://github.com/user-attachments/assets/66f1dc6f-62fc-47ba-bfa7-84ac8eff0754" />
https://github.com/rust-bors

With this PR:
<img width="515" height="404" alt="image" src="https://github.com/user-attachments/assets/f8a23e95-5db1-4d2e-879b-9d556e65837c" />
<img width="788" height="366" alt="image" src="https://github.com/user-attachments/assets/b7cce3ea-8a10-4787-bbdc-12a73c6982f6" />
https://github.com/apps/rust-bors

Localhost:
 - http://localhost:8000/gh-comments/rust-lang/rust/pull/155521