### PR TITLE
Add missing CSS for highlighting the labels

### DIFF
--- a/src/gh_comments.rs
+++ b/src/gh_comments.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 
 pub const STYLE_URL: &str = "/gh-comments/style@0.0.10.css";
-pub const MARKDOWN_URL: &str = "/gh-comments/github-markdown@20260117.css";
+pub const MARKDOWN_URL: &str = "/gh-comments/github-markdown@20260615.css";
 pub const SELF_CONTAINED_URL: &str = "/gh-comments/self_contained@0.0.3.js";
 pub const RELATIVE_TIME_ELEMENT_URL: &str = "/gh-comments/relative-time-element@5.0.0.js";
 

--- a/src/gh_comments/github-markdown@20260117.css
+++ b/src/gh_comments/github-markdown@20260117.css
@@ -37,6 +37,8 @@
   --h6-size: 0.75rem;
   --fgColor-onEmphasis: LinkText;
   --fgColor-accent: Highlight;
+  --perceived-lightness: calc(((var(--label-r) * .2126) + (var(--label-g) * .7152) + (var(--label-b) * .0722)) / 255);
+  --lightness-switch: max(0, min(calc((1/(var(--lightness-threshold) - var(--perceived-lightness)))), 1));
 }
 @media (prefers-color-scheme: dark) {
   .markdown-body, [data-theme="dark"] {
@@ -120,6 +122,9 @@
     --button-default-fgColor-rest: var(--control-fgColor-rest);
     --button-default-borderColor-active: var(--button-default-borderColor-rest);
     --button-default-borderColor-hover: var(--button-default-borderColor-rest);
+    --lightness-threshold: .6;
+    --background-alpha: .18;
+    --border-alpha: .3;
   }
 }
 @media (prefers-color-scheme: light) {
@@ -204,6 +209,9 @@
     --diffBlob-deletionNum-fgColor: var(--fgColor-default);
     --diffBlob-deletionWord-fgColor: var(--fgColor-default);
     --button-default-borderColor-hover: var(--button-default-borderColor-rest);
+    --lightness-threshold: .453;
+    --border-threshold: .96;
+    --border-alpha: max(0, min(calc((var(--perceived-lightness) - var(--border-threshold)) * 100), 1));
   }
 }
 
@@ -262,7 +270,8 @@
 .markdown-body a {
   background-color: rgba(0,0,0,0);
   color: var(--fgColor-accent);
-  text-decoration: none;
+  text-underline-offset: .2rem;
+  text-decoration: underline;
 }
 
 .markdown-body abbr[title] {
@@ -2214,3 +2223,25 @@
   min-height: 52px;
 }
 
+.markdown-body .hx_IssueLabel {
+  color: hsl(0deg, 0%, calc(var(--lightness-switch) * 100%));
+  background: rgb(var(--label-r), var(--label-g), var(--label-b));
+  border-color: hsla(var(--label-h), calc(var(--label-s) * 1%), calc((var(--label-l) - 25) * 1%), var(--border-alpha));
+}
+
+.markdown-body .Label--inline {
+  padding: .12em .5em;
+  font-size: 85%;
+  display: inline;
+}
+
+.markdown-body .IssueLabel {
+  font-size: 12px;
+  font-weight: var(--base-text-weight-medium,500);
+  white-space: nowrap;
+  border: 1px solid #0000;
+  border-radius: 2em;
+  padding: 0 7px;
+  line-height: 18px;
+  display: inline-block;
+}


### PR DESCRIPTION
This PR add the missing CSS for highlighting the labels in our GitHub comments viewer.

https://github.com/rust-lang/rust/pull/155750#issuecomment-4708354303

| Currently | This PR |
|-----|-----|
| <img width="963" height="153" alt="image" src="https://github.com/user-attachments/assets/cb3b9331-0231-421e-a488-c35c00c19868" /> | <img width="971" height="161" alt="image" src="https://github.com/user-attachments/assets/4492410c-87ef-46b5-a541-66a2a2d0099c" /> |

Reported by @WaffleLapkin