### PR TITLE
Add `delegate` command to allow others to merge PRs

### DIFF
--- a/parser/src/command.rs
+++ b/parser/src/command.rs
@@ -458,5 +458,64 @@ fn resolve() {
 fn merge() {
     let input = "@bot merge";
     let mut input = Input::new(input, vec!["bot"]);
-    assert_eq!(input.next(), Some(Command::Merge(Ok(merge::MergeCommand))));
+    assert_eq!(
+        input.next(),
+        Some(Command::Merge(Ok(merge::MergeCommand::Merge)))
+    );
+}
+
+#[test]
+fn delegate() {
+    let input = "@bot delegate=ghost";
+    let mut input = Input::new(input, vec!["bot"]);
+    assert_eq!(
+        input.next(),
+        Some(Command::Merge(Ok(merge::MergeCommand::Delegate {
+            login: "ghost".to_string()
+        })))
+    );
+}
+
+#[test]
+fn delegate_author() {
+    let input = "@bot delegate+";
+    let mut input = Input::new(input, vec!["bot"]);
+    assert_eq!(
+        input.next(),
+        Some(Command::Merge(Ok(merge::MergeCommand::DelegateToAuthor)))
+    );
+}
+
+#[test]
+fn delegate_author_2() {
+    let input = "@bot delegate";
+    let mut input = Input::new(input, vec!["bot"]);
+    assert_eq!(
+        input.next(),
+        Some(Command::Merge(Ok(merge::MergeCommand::DelegateToAuthor)))
+    );
+}
+
+#[test]
+fn delegate_empty() {
+    let input = "@bot delegate=";
+    let mut input = Input::new(input, vec!["bot"]);
+    assert_eq!(
+        input.next(),
+        Some(Command::Merge(Ok(merge::MergeCommand::Delegate {
+            login: "".to_string()
+        })))
+    );
+}
+
+#[test]
+fn delegate_with_at() {
+    let input = "@bot delegate=@ghost";
+    let mut input = Input::new(input, vec!["bot"]);
+    assert_eq!(
+        input.next(),
+        Some(Command::Merge(Ok(merge::MergeCommand::Delegate {
+            login: "@ghost".to_string()
+        })))
+    );
 }

--- a/parser/src/command/merge.rs
+++ b/parser/src/command/merge.rs
@@ -2,12 +2,24 @@ use crate::error::Error;
 use crate::token::{Token, Tokenizer};
 
 #[derive(PartialEq, Eq, Debug)]
-pub struct MergeCommand;
+pub enum MergeCommand {
+    Merge,
+    DelegateToAuthor,
+    Delegate { login: String },
+}
 
 impl MergeCommand {
     pub fn parse<'a>(input: &mut Tokenizer<'a>) -> Result<Option<Self>, Error<'a>> {
         if let Some(Token::Word("merge")) = input.peek_token()? {
-            Ok(Some(Self))
+            Ok(Some(MergeCommand::Merge))
+        } else if let Some(Token::Word("delegate" | "delegate+")) = input.peek_token()? {
+            Ok(Some(MergeCommand::DelegateToAuthor))
+        } else if let Some(Token::Word(word)) = input.peek_token()?
+            && let Some(login) = word.strip_prefix("delegate=")
+        {
+            Ok(Some(MergeCommand::Delegate {
+                login: login.to_string(),
+            }))
         } else {
             Ok(None)
         }

--- a/src/github/queries/user_info.rs
+++ b/src/github/queries/user_info.rs
@@ -1,10 +1,12 @@
 use anyhow::Context;
 use chrono::{DateTime, Utc};
 
-use crate::github::GithubClient;
+use crate::github::{GithubClient, UserId};
 
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct UserInfo {
+    pub id: UserId,
+    pub login: String,
     /// When was the user account created?
     pub created_at: DateTime<Utc>,
     pub public_repos: u32,

--- a/src/handlers/merge.rs
+++ b/src/handlers/merge.rs
@@ -3,27 +3,40 @@ use parser::command::merge::MergeCommand;
 
 use crate::{
     config::MergeConfig,
+    db::issue_data::IssueData,
     errors::user_error,
-    github::{Event, client::GraphQlErrors},
+    github::{Event, IssueCommentEvent, UserId as GitHubUserId, client::GraphQlErrors},
     handlers::Context,
 };
+
+/// Key for the state in the database
+const DELEGATIONS_KEY: &str = "merge-delegations";
+
+/// State stored in the database
+#[derive(Debug, Default, serde::Deserialize, serde::Serialize, Clone, PartialEq)]
+struct DelegationsState {
+    // List of all the user IDs who have been delegated the power to merge the PR.
+    delegations: Vec<GitHubUserId>,
+}
 
 pub(super) async fn handle_command(
     ctx: &Context,
     config: &MergeConfig,
     event: &Event,
-    _cmd: MergeCommand,
+    cmd: MergeCommand,
 ) -> anyhow::Result<()> {
     let Event::IssueComment(issue_comment) = event else {
         return user_error!(
-            "`merge` command can only be issued from a pull-request comment/review"
+            "`merge` and `delegate` commands can only be issued from a pull-request comment/review"
         );
     };
     if issue_comment.issue.pull_request.is_none() {
-        return user_error!("`merge` command can only be issued on an pull-request");
+        return user_error!(
+            "`merge` and `delegate` commands can only be issued on an pull-request"
+        );
     };
 
-    let has_perm = {
+    let has_write_permissions = {
         let perm = issue_comment
             .issue
             .repository()
@@ -34,12 +47,58 @@ pub(super) async fn handle_command(
         perm.permission.has_write_permissions()
     };
 
-    if !has_perm {
-        return user_error!(
-            "Unauthorized, only user with `write` permissions on this repository can merge PRs."
-        );
-    };
+    match cmd {
+        MergeCommand::Merge => {
+            if !has_write_permissions {
+                let has_delegation_rights = was_delegated_to_commenter(ctx, &issue_comment)
+                    .await
+                    .context(
+                    "Couldn't determine if the user has merge rights via delegation",
+                )?;
 
+                if !has_delegation_rights {
+                    return user_error!(
+                        "Unauthorized, only user with `write` permissions in this repository can merge PRs."
+                    );
+                }
+            }
+
+            merge_pr(ctx, config, issue_comment).await?;
+        }
+        MergeCommand::Delegate { login } => {
+            if !has_write_permissions {
+                return user_error!(
+                    "Unauthorized, only user with `write` permissions in this repository can delegate PRs."
+                );
+            };
+
+            let login = login.trim_start_matches('@');
+
+            if login.is_empty() {
+                return user_error!("Cannot delegate to an empty login.");
+            }
+
+            delegate_to(ctx, issue_comment, login).await?;
+        }
+        MergeCommand::DelegateToAuthor => {
+            if !has_write_permissions {
+                return user_error!(
+                    "Unauthorized, only user with `write` permissions in this repository can delegate PRs."
+                );
+            };
+
+            delegate_to(ctx, issue_comment, &issue_comment.issue.user.login).await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn merge_pr(
+    ctx: &Context,
+    config: &MergeConfig,
+    issue_comment: &IssueCommentEvent,
+) -> anyhow::Result<()> {
     match config.type_ {
         crate::config::MergeType::MergeQueue => {
             if let Err(err) = issue_comment
@@ -61,4 +120,70 @@ pub(super) async fn handle_command(
     }
 
     Ok(())
+}
+
+async fn delegate_to(
+    ctx: &Context,
+    issue_comment: &IssueCommentEvent,
+    delegate_to: &str,
+) -> anyhow::Result<()> {
+    let delegatee = ctx.github.user_info(delegate_to).await?;
+
+    let mut db = ctx.db.get().await;
+    let mut state: IssueData<'_, DelegationsState> =
+        IssueData::load(&mut db, &issue_comment.issue, DELEGATIONS_KEY).await?;
+
+    if state.data.delegations.contains(&delegatee.id) {
+        return user_error!(format!(
+            "Merge rights have already been delegated to @{}.",
+            &delegatee.login
+        ));
+    }
+
+    state.data.delegations.push(delegatee.id);
+
+    state
+        .save()
+        .await
+        .context("Couldn't save the new delegations")?;
+
+    issue_comment
+        .issue
+        .post_comment(&ctx.github, &format!(r#":v: @{delegatee}, you can now merge this pull request!
+
+If @{delegator} told you to merge after making some further change, then please make that change and post `@{bot_prefix} merge`.
+
+[View changes since this delegation](https://triagebot.infra.rust-lang.org/gh-changes-since/{org_repo}/{pr_num}/{base_sha}..{head_sha}).
+"#,
+delegatee = &delegatee.login,
+bot_prefix = ctx.username,
+delegator = &issue_comment.comment.user.login,
+org_repo = &issue_comment.repository.full_name,
+pr_num = issue_comment.issue.number,
+base_sha = &issue_comment.issue.base.as_ref().context("no base sha")?.sha,
+head_sha = &issue_comment.issue.head.as_ref().context("no head sha")?.sha,
+))
+        .await
+        .context("Couldn't post the delegation confirmation comment")?;
+
+    Ok(())
+}
+
+async fn was_delegated_to_commenter(
+    ctx: &Context,
+    issue_comment: &IssueCommentEvent,
+) -> anyhow::Result<bool> {
+    let mut db = ctx.db.get().await;
+    let state: IssueData<'_, DelegationsState> =
+        IssueData::load(&mut db, &issue_comment.issue, DELEGATIONS_KEY)
+            .await
+            .context("failed to load the delegations state")?;
+
+    for delegated_user_id in &state.data.delegations {
+        if delegated_user_id == &issue_comment.comment.user.id {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
 }


### PR DESCRIPTION
This PR adds the `delegate` command to allow other users to merge PRs using the `merge` command for merge-queues.

Follow-up to https://github.com/rust-lang/triagebot/pull/2412
cc @samueltardieu