### PR TITLE
Fix CSS colors when highlighting issue labels in comments

### DIFF
--- a/src/gh_comments.rs
+++ b/src/gh_comments.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 
 pub const STYLE_URL: &str = "/gh-comments/style@0.0.10.css";
-pub const MARKDOWN_URL: &str = "/gh-comments/github-markdown@20260615.css";
+pub const MARKDOWN_URL: &str = "/gh-comments/github-markdown@20260616.css";
 pub const SELF_CONTAINED_URL: &str = "/gh-comments/self_contained@0.0.3.js";
 pub const RELATIVE_TIME_ELEMENT_URL: &str = "/gh-comments/relative-time-element@5.0.0.js";
 

--- a/src/gh_comments/github-markdown@20260117.css
+++ b/src/gh_comments/github-markdown@20260117.css
@@ -122,9 +122,18 @@
     --button-default-fgColor-rest: var(--control-fgColor-rest);
     --button-default-borderColor-active: var(--button-default-borderColor-rest);
     --button-default-borderColor-hover: var(--button-default-borderColor-rest);
+  }
+
+  .markdown-body .hx_IssueLabel {
     --lightness-threshold: .6;
     --background-alpha: .18;
     --border-alpha: .3;
+    --perceived-lightness: calc(((var(--label-r) * .2126) + (var(--label-g) * .7152) + (var(--label-b) * .0722)) / 255);
+    --lightness-switch: max(0, min(calc((1/(var(--lightness-threshold) - var(--perceived-lightness)))), 1));
+    --lighten-by: calc(((var(--lightness-threshold) - var(--perceived-lightness)) * 100) * var(--lightness-switch));
+    color: hsl(var(--label-h), calc(var(--label-s) * 1%), calc((var(--label-l) + var(--lighten-by)) * 1%));
+    background: rgba(var(--label-r), var(--label-g), var(--label-b), var(--background-alpha));
+    border-color: hsla(var(--label-h), calc(var(--label-s) * 1%), calc((var(--label-l) + var(--lighten-by)) * 1%), var(--border-alpha));
   }
 }
 @media (prefers-color-scheme: light) {
@@ -209,9 +218,17 @@
     --diffBlob-deletionNum-fgColor: var(--fgColor-default);
     --diffBlob-deletionWord-fgColor: var(--fgColor-default);
     --button-default-borderColor-hover: var(--button-default-borderColor-rest);
+  }
+  
+  .markdown-body .hx_IssueLabel {
     --lightness-threshold: .453;
     --border-threshold: .96;
+    --perceived-lightness: calc(((var(--label-r) * .2126) + (var(--label-g) * .7152) + (var(--label-b) * .0722)) / 255);
+    --lightness-switch: max(0, min(calc((1/(var(--lightness-threshold) - var(--perceived-lightness)))), 1));
     --border-alpha: max(0, min(calc((var(--perceived-lightness) - var(--border-threshold)) * 100), 1));
+    color: hsl(0deg, 0%, calc(var(--lightness-switch) * 100%));
+    background: rgb(var(--label-r), var(--label-g), var(--label-b));
+    border-color: hsla(var(--label-h), calc(var(--label-s) * 1%), calc((var(--label-l) - 25) * 1%), var(--border-alpha));
   }
 }
 
@@ -2223,12 +2240,6 @@
   min-height: 52px;
 }
 
-.markdown-body .hx_IssueLabel {
-  color: hsl(0deg, 0%, calc(var(--lightness-switch) * 100%));
-  background: rgb(var(--label-r), var(--label-g), var(--label-b));
-  border-color: hsla(var(--label-h), calc(var(--label-s) * 1%), calc((var(--label-l) - 25) * 1%), var(--border-alpha));
-}
-
 .markdown-body .Label--inline {
   padding: .12em .5em;
   font-size: 85%;
@@ -2239,7 +2250,8 @@
   font-size: 12px;
   font-weight: var(--base-text-weight-medium,500);
   white-space: nowrap;
-  border: 1px solid #0000;
+  border-width: 1px;
+  border-style: solid;
   border-radius: 2em;
   padding: 0 7px;
   line-height: 18px;


### PR DESCRIPTION
I was to cleaver with my previous PR, and accidentally broke the colors in dark mode.

Now it should be correct :crossed_fingers:. I re-copy/pasted from GitHub.

| Light | Dark |
|------|------|
| <img width="1053" height="170" alt="image" src="https://github.com/user-attachments/assets/238401a5-39cd-4820-ac32-ba50047337bb" /> | <img width="1057" height="175" alt="image" src="https://github.com/user-attachments/assets/b98f6d1d-9162-4ed8-aa29-43cfbfd2ad9a" /> |