### PR TITLE
Add warning against Unicode Bidi characters in our range-diff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3448,6 +3448,7 @@ dependencies = [
  "hyper",
  "ignore",
  "itertools",
+ "memchr",
  "native-tls",
  "octocrab",
  "parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ globset = { version = "0.4.18", default-features = false }
 tower_governor = { version = "0.8.0", default-features = false, features = ["axum", "tracing"] }
 http-body-util = "0.1.3"
 http = "1.4.0"
+memchr = "2.7.5"
 
 [dependencies.serde]
 version = "1"

--- a/src/gh_range_diff.rs
+++ b/src/gh_range_diff.rs
@@ -23,6 +23,8 @@ use crate::github::{GithubCommit, GithubCompare};
 use crate::utils::is_known_and_public_repo;
 use crate::{errors::AppError, github, handlers::Context};
 
+mod bidi_unicode;
+
 static MARKER_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"@@ -[\d]+,[\d]+ [+][\d]+,[\d]+ @@").unwrap());
 
@@ -293,6 +295,15 @@ fn process_old_new(
     .spacer {{
       margin-bottom: 1rem;
     }}
+    .warning {{
+      background-color: #fff8c5;
+      border-color: #d4a72c66;
+      border-width: 1px;
+      border-style: solid;
+      white-space: break-spaces;
+      margin-top: 1rem;
+      padding: 1rem;
+    }}
     @media (prefers-color-scheme: dark) {{
       body {{
         background: #0C0C0C;
@@ -345,6 +356,10 @@ fn process_old_new(
       .line-added-before .word-removed {{
         color: black;
         background-color: rgb(255, 0, 0);
+      }}
+      .warning {{
+         background-color: #ae7c1426;
+         border-color: #ae7c1466;
       }}
     }}
     </style>
@@ -404,11 +419,19 @@ fn process_old_new(
             let after_href =
                 format_args!("https://github.com/{owner}/{repo}/blob/{newhead}/{filename}");
 
-            write!(html, r#"<details open=""><summary>{filename}"#)?;
             write!(
                 html,
-                r#" <a href="{before_href}">before</a> <a href="{after_href}">after</a></summary><pre class="diff-content">{unified_diff}</pre>"#
+                r#"<details open=""><summary>{filename} <a href="{before_href}">before</a> <a href="{after_href}">after</a></summary>"#
             )?;
+
+            if bidi_unicode::contains_text_flow_control_chars(&*new_patch) {
+                write!(
+                    html,
+                    r#"<div class="warning">⚠ <span>This file contains bidirectional or hidden Unicode text that may be interpreted or compiled differently than what appears below. To review, open the file in an editor that reveals hidden Unicode characters. <a href="https://github.co/hiddenchars" target="_blank" rel="noreferrer">Learn more about bidirectional Unicode characters</a></span></div>"#
+                )?;
+            }
+
+            write!(html, r#"<pre class="diff-content">{unified_diff}</pre>"#)?;
             writeln!(html, "</details>")?;
 
             diff_displayed += 1;

--- a/src/gh_range_diff/bidi_unicode.rs
+++ b/src/gh_range_diff/bidi_unicode.rs
@@ -1,0 +1,32 @@
+// Copied from https://github.com/rust-lang/rust/blob/693b3e4c6e4e686cb9878c1722ad26858b5f1d2a/compiler/rustc_ast/src/util/unicode.rs
+
+#[inline]
+pub fn contains_text_flow_control_chars(s: &str) -> bool {
+    // Char   - UTF-8
+    // U+202A - E2 80 AA
+    // U+202B - E2 80 AB
+    // U+202C - E2 80 AC
+    // U+202D - E2 80 AD
+    // U+202E - E2 80 AE
+    // U+2066 - E2 81 A6
+    // U+2067 - E2 81 A7
+    // U+2068 - E2 81 A8
+    // U+2069 - E2 81 A9
+    let mut bytes = s.as_bytes();
+    loop {
+        match memchr::memchr(0xE2, bytes) {
+            Some(idx) => {
+                // bytes are valid UTF-8 -> E2 must be followed by two bytes
+                let ch = &bytes[idx..idx + 3];
+                match ch {
+                    [_, 0x80, 0xAA..=0xAE] | [_, 0x81, 0xA6..=0xA9] => break true,
+                    _ => {}
+                }
+                bytes = &bytes[idx + 3..];
+            }
+            None => {
+                break false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Like GitHub, let's show a warning if we detect bidirectional characters in the patch.

| Dark | Light |
|-----|----|
| <img width="1446" height="1292" alt="image" src="https://github.com/user-attachments/assets/2ac9badd-9532-4af9-91dc-c440438691c2" /> | <img width="1446" height="1292" alt="image" src="https://github.com/user-attachments/assets/77322833-77eb-4574-b4ca-0719e3a59a85" /> |

Links:
 - https://github.co/hiddenchars
 - https://github.com/rust-lang/rust/commit/c0b134582a949062f9f3a8ba3def88b98a98df6a
 - http://localhost:8000/gh-range-diff/rust-lang/rust/38b01d9..38b01d9/38b01d9..c0b134582a949062f9f3a8ba3def88b98a98df6a

Suggested by @camelid