### PR TITLE
Avoid de-serialization failure of GraphQl group reactor nodes

### DIFF
--- a/src/gh_comments.rs
+++ b/src/gh_comments.rs
@@ -925,6 +925,7 @@ fn write_reaction_groups_as_html(
                     .reactors
                     .nodes
                     .iter()
+                    .flatten()
                     .filter_map(|r| r.login.as_deref())
                     .collect::<Vec<_>>();
                 let left = total_count.saturating_sub(users.len() as u32);

--- a/src/github/queries/issue_with_comments.rs
+++ b/src/github/queries/issue_with_comments.rs
@@ -159,7 +159,7 @@ pub struct GitHubGraphQlReactionGroup {
 pub struct GitHubGraphQlReactionGroupReactors {
     #[serde(rename = "totalCount")]
     pub total_count: u32,
-    pub nodes: Vec<GitHubGraphQlReactionGroupReactor>,
+    pub nodes: Vec<Option<GitHubGraphQlReactionGroupReactor>>,
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]


### PR DESCRIPTION
```
Caused by:
0: fail to deserialize the GraphQl json response
1: invalid type: null, expected struct GitHubGraphQlReactionGroupReactor
```

http://localhost:8000/gh-comments/rust-lang/rust/issues/39699