### PR TITLE
Tell the user that nothing changed rather than a cryptic GitHub message

### DIFF
--- a/src/gh_changes_since.rs
+++ b/src/gh_changes_since.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use anyhow::Context as _;
 use axum::{
     extract::{Path, State},
-    response::{IntoResponse, Redirect, Response},
+    response::{Html, IntoResponse, Redirect, Response},
 };
 use hyper::StatusCode;
 
@@ -46,6 +46,20 @@ pub async fn gh_changes_since(
 
     let newbase = &pr.base.as_ref().context("no base")?.sha;
     let newhead = &pr.head.as_ref().context("no head")?.sha;
+
+    // Did something changed, no?
+    if oldhead == newhead {
+        // Inform the user that nothing changed.
+        return Ok((StatusCode::OK, Html(format!(
+r##"<!DOCTYPE html>
+<title>Changes since for {owner}/{repo}#{pr_num}</title>
+<style>
+  :root {{ color-scheme: light dark; font-family: system-ui; margin: 2rem auto; max-width: 60ch; }}
+</style>
+<h1>No changes since this review.</h1>
+<p>Head back to the <a href="https://github.com/{owner}/{repo}/pull/{pr_num}/changes">latest changes here</a>.</p>
+"##))).into_response());
+    }
 
     // Has the base changed?
     if oldbase == newbase {


### PR DESCRIPTION
Instead of redirecting the user to GitHub's compare view when nothing changed in our "View changes this review" link, show a clear message, instead of the cryptic GitHub message.

| GitHub compare | This PR |
|---------|--------|
| <img width="2432" height="568" alt="image" src="https://github.com/user-attachments/assets/90ebda1e-7900-4fa7-bdc4-eb2b3af98014" />| <img width="718" height="184" alt="image" src="https://github.com/user-attachments/assets/46b88d95-0e8e-473d-ac4d-bd7cf57978ff" /> |

cc @camelid 