### PR TITLE
Use auto merge unless ready to be enqueued in the merge queue

### DIFF
--- a/src/github/issue.rs
+++ b/src/github/issue.rs
@@ -1,5 +1,6 @@
 use anyhow::Context;
 use chrono::Utc;
+use octocrab::models::pulls::MergeableState;
 use reqwest::StatusCode;
 use std::fmt;
 use std::sync::OnceLock;
@@ -87,6 +88,8 @@ pub struct Issue {
     pub milestone: Option<Milestone>,
     /// Whether a PR has merge conflicts.
     pub mergeable: Option<bool>,
+    /// The mergeable state (clean, blocked, unknown, ...)
+    pub mergeable_state: Option<MergeableState>,
 
     /// How the author is associated with the repository
     pub author_association: AuthorAssociation,
@@ -629,6 +632,26 @@ impl Issue {
                 }),
             )
             .await?;
+        Ok(())
+    }
+
+    /// Enable auto merge for this specific PR.
+    pub async fn enable_auto_merge(&self, client: &GithubClient) -> anyhow::Result<()> {
+        let pr_id = self.graphql_issue_id(client).await?;
+
+        client
+            .graphql_query(
+                "mutation ($pullRequestId: ID!) {
+                  enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId }) {
+                    clientMutationId
+                  }
+                }",
+                serde_json::json!({
+                    "pullRequestId": pr_id,
+                }),
+            )
+            .await?;
+
         Ok(())
     }
 

--- a/src/handlers/check_commits.rs
+++ b/src/handlers/check_commits.rs
@@ -420,6 +420,7 @@ r#":warning: **Warning** :warning:
                 state: crate::github::IssueState::Open,
                 milestone: None,
                 mergeable: None,
+                mergeable_state: None,
                 author_association: octocrab::models::AuthorAssociation::Contributor.into(),
             },
             changes: None,

--- a/src/handlers/merge.rs
+++ b/src/handlers/merge.rs
@@ -1,4 +1,5 @@
 use anyhow::Context as _;
+use octocrab::models::pulls::MergeableState;
 use parser::command::merge::MergeCommand;
 
 use crate::{
@@ -101,21 +102,59 @@ async fn merge_pr(
 ) -> anyhow::Result<()> {
     match config.type_ {
         crate::config::MergeType::MergeQueue => {
-            if let Err(err) = issue_comment
-                .issue
-                .enqueue_to_merge_queue(&ctx.github)
-                .await
-            {
-                if let Some(graphql_errors) = err.downcast_ref::<GraphQlErrors>()
-                    && let [error] = &*graphql_errors.errors
-                    && error.path == &["enqueuePullRequest"]
-                    && error.type_ == "UNPROCESSABLE"
-                {
-                    return user_error!(error.message.to_string());
-                }
+            merge_pr_with_merge_queue(ctx, issue_comment).await?;
+        }
+    }
 
-                anyhow::bail!(err);
+    Ok(())
+}
+
+async fn merge_pr_with_merge_queue(
+    ctx: &Context,
+    issue_comment: &IssueCommentEvent,
+) -> anyhow::Result<()> {
+    let pr = ctx
+        .github
+        .pull_request(issue_comment.issue.repository(), issue_comment.issue.number)
+        .await
+        .context("failed to fetch the PR to merge")?;
+
+    tracing::info!(
+        "pr mergeable status={:?} ({:?})",
+        &pr.mergeable,
+        &pr.mergeable_state
+    );
+
+    // Unless the mergeable state is "clean" we enable auto merge, if it's "clean"
+    // we can't use auto merge (GitHub blocks it), so let's enqueue the PR in the
+    // merge queue, since we know by the "clean" state that we can.
+    if pr.mergeable_state != Some(MergeableState::Clean) {
+        if let Err(err) = issue_comment.issue.enable_auto_merge(&ctx.github).await {
+            if let Some(graphql_errors) = err.downcast_ref::<GraphQlErrors>()
+                && let [error] = &*graphql_errors.errors
+                && error.path == &["enablePullRequestAutoMerge"]
+                && error.type_ == "UNPROCESSABLE"
+            {
+                return user_error!(error.message.to_string());
             }
+
+            anyhow::bail!(err);
+        }
+    } else {
+        if let Err(err) = issue_comment
+            .issue
+            .enqueue_to_merge_queue(&ctx.github)
+            .await
+        {
+            if let Some(graphql_errors) = err.downcast_ref::<GraphQlErrors>()
+                && let [error] = &*graphql_errors.errors
+                && error.path == &["enqueuePullRequest"]
+                && error.type_ == "UNPROCESSABLE"
+            {
+                return user_error!(error.message.to_string());
+            }
+
+            anyhow::bail!(err);
         }
     }
 

--- a/src/tests/github.rs
+++ b/src/tests/github.rs
@@ -74,6 +74,7 @@ pub fn issue(
         state,
         milestone: None,
         mergeable: None,
+        mergeable_state: None,
         author_association: octocrab::models::AuthorAssociation::None.into(),
     }
 }


### PR DESCRIPTION
As discussed in https://github.com/rust-lang/triagebot/pull/2449#issuecomment-4860165623, let's use the auto merge functionality when the PR is not yet ready to be enqueued in the merge queue (PR CI still running, ...).

That way PRs that are not yet ready can still be `@rustbot merge`-ed.

I tested the logic in my fork and it seems to work as expected.

<details>

<img width="894" height="426" alt="image" src="https://github.com/user-attachments/assets/56c2651f-2b91-4b7c-8ae5-c88c23a8c8b9" />

</details>

cc @samueltardieu