### PR TITLE
Add and improve welcome messages for community reviews

### DIFF
--- a/src/handlers/assign.rs
+++ b/src/handlers/assign.rs
@@ -150,20 +150,26 @@ pub(super) async fn handle_input(
                         }],
                     )
                     .await?;
-                if event.issue.author_association.is_probably_first_timer() {
-                    let mut welcome = messages::new_user_welcome_message_community_reviews(
+                let mut welcome = if event.issue.author_association.is_probably_first_timer() {
+                    messages::new_user_welcome_message_community_reviews(
                         community_reviews.minimum_approvals.get(),
-                    );
-                    if let Some(contrib) = &config.contributing_url {
-                        welcome.push_str("\n\n");
-                        welcome.push_str(&messages::contribution_message(contrib, &ctx.username));
-                    }
-                    event
-                        .issue
-                        .post_comment(&ctx.github, &welcome)
-                        .await
-                        .context("couldn't post welcome message")?;
+                    )
+                } else {
+                    messages::returning_user_welcome_message_community_reviews(
+                        community_reviews.minimum_approvals.get(),
+                        event.issue.repository(),
+                        &community_reviews.label,
+                    )
+                };
+                if let Some(contrib) = &config.contributing_url {
+                    welcome.push_str("\n\n");
+                    welcome.push_str(&messages::contribution_message(contrib, &ctx.username));
                 }
+                event
+                    .issue
+                    .post_comment(&ctx.github, &welcome)
+                    .await
+                    .context("couldn't post welcome message")?;
                 false
             } else {
                 // PR was opened normally, perform assignment if not assignees manually set
@@ -292,7 +298,7 @@ pub(super) async fn handle_input(
         } else if !from_comment {
             match &assignee {
                 Some(assignee) => Some(if config.community_reviews.is_some() {
-                    messages::returning_user_welcome_message_community_reviews(
+                    messages::returning_user_assigned_message_community_reviews(
                         &assignee.name,
                         &ctx.username,
                     )

--- a/src/handlers/assign/messages.rs
+++ b/src/handlers/assign/messages.rs
@@ -3,6 +3,8 @@
 //! This module contains the different constants and functions related
 //! to assignment messages.
 
+use crate::github::IssueRepository;
+
 pub fn new_user_welcome_message(reviewer: &str) -> String {
     format!(
         "Thanks for the pull request, and welcome! \
@@ -13,8 +15,21 @@ some time within the next two weeks."
 
 pub fn new_user_welcome_message_community_reviews(min_reviews: u8) -> String {
     format!(
-        "Thanks for the pull request, and welcome!\
-You should hear from one of our reviewers after this PR is reviewed by at least {min_reviews} reviewers from the community"
+        "Thanks for the pull request, and welcome!
+
+You should hear from one of our reviewers after this PR gets at least {min_reviews} reviews from the community."
+    )
+}
+
+pub fn returning_user_welcome_message_community_reviews(
+    min_reviews: u8,
+    repo: &IssueRepository,
+    label: &str,
+) -> String {
+    format!(
+        "Thanks for the pull request. A reviewer will take a look after it receives {min_reviews} community reviews.
+
+In the meantime, we would highly appreciate if you could try to review any of [PRs waiting on community reviews](https://github.com/{repo}/issues?q=state%3Aopen%20label%3A{label}%20label%3AS-waiting-on-review)."
     )
 }
 
@@ -51,7 +66,13 @@ pub fn returning_user_welcome_message_no_reviewer(pr_author: &str) -> String {
     format!("@{pr_author}: no appropriate reviewer found, use `r?` to override")
 }
 
-pub fn returning_user_welcome_message_community_reviews(assignee: &str, bot: &str) -> String {
+pub fn returning_user_welcome_message_no_reviewer_community_reviews(pr_author: &str) -> String {
+    format!(
+        "@{pr_author}: no appropriate reviewer found for the project review, use `r?` to override"
+    )
+}
+
+pub fn returning_user_assigned_message_community_reviews(assignee: &str, bot: &str) -> String {
     format!(
         "r? @{assignee}
 
@@ -60,12 +81,6 @@ They will have a look at your PR within the next two weeks and either review you
 reassign to another reviewer.
 
 Use `r?` to explicitly pick a reviewer"
-    )
-}
-
-pub fn returning_user_welcome_message_no_reviewer_community_reviews(pr_author: &str) -> String {
-    format!(
-        "@{pr_author}: no appropriate reviewer found for the project review, use `r?` to override"
     )
 }
 


### PR DESCRIPTION
Reported at [#clippy > External approvals and review @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/257328-clippy/topic/External.20approvals.20and.20review/near/609474945)

First timer:
> Thanks for the pull request, and welcome!
>
> You should hear from one of our reviewers after this PR gets at least 2 reviews from the community.

Returning user:
> Thanks for the pull request. A reviewer will take a look after it receives 2 community reviews.
>
> In the meantime, we would highly appreciate if you could try to review any of [PRs waiting on community reviews](https://github.com/rust-lang/rust-clippy/issues?q=state%3Aopen%20label%3AS-waiting-on-community-reviews%20label%3AS-waiting-on-review).

cc @blyxyas