### PR TITLE
update team data to remove allowed_merge_apps field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2553,7 +2553,7 @@ dependencies = [
 [[package]]
 name = "rust_team_data"
 version = "1.0.0"
-source = "git+https://github.com/rust-lang/team#b86b8e453891d8cccb641b0f86fb6c0adfbc4041"
+source = "git+https://github.com/rust-lang/team#99a209f68462354a2e69bfbe938741036c731cdb"
 dependencies = [
  "indexmap",
  "serde",


### PR DESCRIPTION
PR that removed this field: https://github.com/rust-lang/team/pull/2639