### PR TITLE
Rename `rust-project-goals` to `goals`

### DIFF
--- a/src/github/queries/open_goal_issues.rs
+++ b/src/github/queries/open_goal_issues.rs
@@ -3,7 +3,7 @@ use anyhow::Context;
 use crate::github::GithubClient;
 
 const ORG: &str = "rust-lang";
-const REPO: &str = "rust-project-goals";
+const REPO: &str = "goals";
 const LABEL: &str = "C-tracking-issue";
 
 pub struct GoalIssue {
@@ -110,7 +110,7 @@ impl From<GraphQlIssue> for GoalIssue {
 }
 
 impl GithubClient {
-    /// Get every open tracking issue in `rust-lang/rust-project-goals`,
+    /// Get every open tracking issue in `rust-lang/goals`,
     /// including the latest comment's date.
     pub async fn open_goal_issues(&self) -> anyhow::Result<Vec<GoalIssue>> {
         let mut cursor = None::<String>;

--- a/src/handlers/project_goals.rs
+++ b/src/handlers/project_goals.rs
@@ -14,7 +14,7 @@ use itertools::Itertools;
 use std::collections::BTreeMap;
 use tracing as log;
 
-const RUST_PROJECT_GOALS_REPO: &str = "rust-lang/rust-project-goals";
+const RUST_PROJECT_GOALS_REPO: &str = "rust-lang/goals";
 const GOALS_TEAM: &str = "goals";
 
 const FIRST_REPORT_GRACE_DAYS: i64 = 7;
@@ -356,7 +356,7 @@ impl<'gh> Goal<'gh> {
         }
     }
 
-    /// Returns a string representing an issue in the `rust-lang/rust-project-goals` repo.
+    /// Returns a string representing an issue in the `rust-lang/goals` repo.
     /// Zulip recognizes strings like `goals#123` and turns them into links.
     fn link(&self) -> String {
         format!("goals#{number}", number = self.issue)


### PR DESCRIPTION
Context: https://github.com/rust-lang/team/pull/2661