### PR TITLE
Remove T-libs-api labels from code

### DIFF
--- a/src/agenda.rs
+++ b/src/agenda.rs
@@ -29,7 +29,6 @@ pub fn prioritization() -> Box<dyn Action> {
                                 "final-comment-period",
                                 "major-change-accepted",
                                 "t-libs",
-                                "t-libs-api",
                                 "t-rustdoc",
                             ],
                         }),
@@ -46,7 +45,6 @@ pub fn prioritization() -> Box<dyn Action> {
                                 "finished-final-comment-period",
                                 "final-comment-period",
                                 "t-libs",
-                                "t-libs-api",
                                 "t-rustdoc",
                                 "S-waiting-on-author",
                             ],
@@ -58,7 +56,7 @@ pub fn prioritization() -> Box<dyn Action> {
                         query: Arc::new(IssueQuery {
                             filters: vec![("state", "open")],
                             include_labels: vec!["proposed-final-comment-period"],
-                            exclude_labels: vec!["t-libs", "t-libs-api", "t-rustdoc"],
+                            exclude_labels: vec!["t-libs", "t-rustdoc"],
                         }),
                     },
                     QueryMap {
@@ -67,7 +65,7 @@ pub fn prioritization() -> Box<dyn Action> {
                         query: Arc::new(IssueQuery {
                             filters: vec![("state", "open")],
                             include_labels: vec!["final-comment-period"],
-                            exclude_labels: vec!["t-libs", "t-libs-api", "t-rustdoc"],
+                            exclude_labels: vec!["t-libs", "t-rustdoc"],
                         }),
                     },
                     QueryMap {
@@ -76,7 +74,7 @@ pub fn prioritization() -> Box<dyn Action> {
                         query: Arc::new(IssueQuery {
                             filters: vec![("state", "all")],
                             include_labels: vec!["major-change-accepted", "to-announce"],
-                            exclude_labels: vec!["t-libs", "t-libs-api", "t-rustdoc"],
+                            exclude_labels: vec!["t-libs", "t-rustdoc"],
                         }),
                     },
                     QueryMap {
@@ -89,7 +87,7 @@ pub fn prioritization() -> Box<dyn Action> {
                                 "disposition-merge",
                                 "to-announce",
                             ],
-                            exclude_labels: vec!["t-libs", "t-libs-api", "t-rustdoc"],
+                            exclude_labels: vec!["t-libs", "t-rustdoc"],
                         }),
                     },
                 ],
@@ -111,7 +109,6 @@ pub fn prioritization() -> Box<dyn Action> {
                                 "S-waiting-on-t-lang",
                                 "S-waiting-on-t-libs",
                                 "T-libs",
-                                "T-libs-api",
                                 "T-rustdoc",
                             ],
                         }),
@@ -130,7 +127,6 @@ pub fn prioritization() -> Box<dyn Action> {
                                 "S-waiting-on-t-lang",
                                 "S-waiting-on-t-libs",
                                 "T-libs",
-                                "T-libs-api",
                                 "T-rustdoc",
                             ],
                         }),
@@ -147,7 +143,6 @@ pub fn prioritization() -> Box<dyn Action> {
                             ],
                             exclude_labels: vec![
                                 "t-libs",
-                                "t-libs-api",
                                 "t-rustdoc",
                                 "t-rustdoc-frontend",
                                 "t-lang",
@@ -171,7 +166,7 @@ pub fn prioritization() -> Box<dyn Action> {
                         query: Arc::new(IssueQuery {
                             filters: vec![("state", "open")],
                             include_labels: vec!["proposed-final-comment-period"],
-                            exclude_labels: vec!["t-libs", "t-libs-api", "t-rustdoc"],
+                            exclude_labels: vec!["t-libs", "t-rustdoc"],
                         }),
                     },
                     QueryMap {
@@ -180,7 +175,7 @@ pub fn prioritization() -> Box<dyn Action> {
                         query: Arc::new(IssueQuery {
                             filters: vec![("state", "open")],
                             include_labels: vec!["final-comment-period"],
-                            exclude_labels: vec!["t-libs", "t-libs-api", "t-rustdoc"],
+                            exclude_labels: vec!["t-libs", "t-rustdoc"],
                         }),
                     },
                     QueryMap {
@@ -193,7 +188,7 @@ pub fn prioritization() -> Box<dyn Action> {
                                 "disposition-merge",
                                 "to-announce",
                             ],
-                            exclude_labels: vec!["t-libs", "t-libs-api", "t-rustdoc"],
+                            exclude_labels: vec!["t-libs", "t-rustdoc"],
                         }),
                     },
                 ],
@@ -420,13 +415,7 @@ pub fn prioritization() -> Box<dyn Action> {
                         query: Arc::new(IssueQuery {
                             filters: vec![("state", "open")],
                             include_labels: vec!["regression-from-stable-to-beta", "P-high"],
-                            exclude_labels: vec![
-                                "T-infra",
-                                "T-libs",
-                                "T-libs-api",
-                                "T-release",
-                                "T-rustdoc",
-                            ],
+                            exclude_labels: vec!["T-infra", "T-libs", "T-release", "T-rustdoc"],
                         }),
                     },
                     QueryMap {
@@ -435,13 +424,7 @@ pub fn prioritization() -> Box<dyn Action> {
                         query: Arc::new(IssueQuery {
                             filters: vec![("state", "open"), ("no", "assignee")],
                             include_labels: vec!["regression-from-stable-to-nightly", "P-high"],
-                            exclude_labels: vec![
-                                "T-infra",
-                                "T-libs",
-                                "T-libs-api",
-                                "T-release",
-                                "T-rustdoc",
-                            ],
+                            exclude_labels: vec!["T-infra", "T-libs", "T-release", "T-rustdoc"],
                         }),
                     },
                     QueryMap {
@@ -557,7 +540,7 @@ pub fn compiler_backlog_bonanza() -> Box<dyn Action> {
                 query: Arc::new(IssueQuery {
                     filters: vec![("state", "open")],
                     include_labels: vec!["C-tracking-issue"],
-                    exclude_labels: vec!["T-libs-api", "T-libs", "T-lang", "T-rustdoc"],
+                    exclude_labels: vec!["T-libs", "T-lang", "T-rustdoc"],
                 }),
             }],
         }],

--- a/src/config.rs
+++ b/src/config.rs
@@ -971,7 +971,7 @@ mod tests {
             days-threshold = 14
 
             [backport.teamRed]
-            required-pr-labels = ["T-libs", "T-libs-api"]
+            required-pr-labels = ["T-libs"]
             required-issue-label = "regression-from-stable-to-stable"
             add-labels = ["stable-nominated"]
 
@@ -1010,7 +1010,7 @@ mod tests {
         backport_configs.insert(
             "teamRed".into(),
             BackportRuleConfig {
-                required_pr_labels: vec!["T-libs".into(), "T-libs-api".into()],
+                required_pr_labels: vec!["T-libs".into()],
                 required_issue_label: "regression-from-stable-to-stable".into(),
                 add_labels: vec!["stable-nominated".into()],
             },

--- a/templates/prioritization_agenda.tt
+++ b/templates/prioritization_agenda.tt
@@ -73,10 +73,10 @@ note_id: xxx
 
 ### P-high regressions
 
-[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-libs-api+-label%3AT-release+-label%3AT-rustdoc)
+[P-high beta regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-beta+label%3AP-high+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc)
 {{-issues::render(issues=beta_regressions_p_high, empty="No `P-high` beta regressions this time.")}}
 
-[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-libs-api+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-bootstrap)
+[Unassigned P-high nightly regressions](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Aregression-from-stable-to-nightly+label%3AP-high+no%3Aassignee+-label%3AT-infra+-label%3AT-libs+-label%3AT-release+-label%3AT-rustdoc+-label%3AT-bootstrap)
 {{-issues::render(issues=nightly_regressions_unassigned_p_high, empty="No unassigned `P-high` nightly regressions this time.")}}
 
 ## Performance logs


### PR DESCRIPTION
Part of [RFC 3984](https://github.com/rust-lang/rfcs/pull/3984). Most of these don't actually matter, but I figured it's good to just remove mentions of T-libs-api from code for completeness so we can just grep for `libs-api` to make sure it's not being added to things.

In most cases, `T-libs` is added anyway as a precaution, but I figure we want to try and centralise on one label.