### PR TITLE
Shorter welcome message for new PRs

### DIFF
--- a/src/handlers/assign/messages.rs
+++ b/src/handlers/assign/messages.rs
@@ -8,7 +8,7 @@ use crate::github::IssueRepository;
 pub fn new_user_welcome_message(reviewer: &str) -> String {
     format!(
         "Thanks for the pull request, and welcome! \
-The Rust Project has assigned {reviewer} for review, you should hear from them (or someone else) \
+The Rust Project has assigned {reviewer} to review your changes, you should hear from them (or someone else) \
 within the next two weeks."
     )
 }

--- a/src/handlers/assign/messages.rs
+++ b/src/handlers/assign/messages.rs
@@ -8,8 +8,8 @@ use crate::github::IssueRepository;
 pub fn new_user_welcome_message(reviewer: &str) -> String {
     format!(
         "Thanks for the pull request, and welcome! \
-The Rust Project is excited to review your changes, and you should hear from {reviewer} \
-some time within the next two weeks."
+The Rust Project has assigned {reviewer} for review, you should hear from them (or someone else) \
+within the next two weeks."
     )
 }
 
@@ -36,13 +36,7 @@ In the meantime, we would highly appreciate if you could try to review any of [P
 pub fn contribution_message(contributing_url: &str, bot: &str) -> String {
     format!(
         "Please see [the contribution \
-instructions]({contributing_url}) for more information. Namely, in order to ensure the \
-minimum review times lag, PR authors and assigned reviewers should ensure that the review \
-label (`S-waiting-on-review` and `S-waiting-on-author`) stays updated, invoking these commands \
-when appropriate:
-
-- `@{bot} author`: the review is finished, PR author should check the comments and take action accordingly
-- `@{bot} review`: the author is ready for a review, this PR will be queued again in the reviewer's queue"
+         instructions]({contributing_url}) for more information."
     )
 }
 


### PR DESCRIPTION
As I mentioned on [Zulip](https://rust-lang.zulipchat.com/#narrow/channel/224082-triagebot/topic/LLM.20policy.20link.20in.20welcome.20messages/near/614935488), I wanted to take a stab at cutting some words from the welcome message when a PR from a new contributor is opened.

<details><summary>Current version</summary>
<p>

<img width="832" height="355" alt="grafik" src="https://github.com/user-attachments/assets/72c73088-974d-41bc-88df-2fbe05b4581a" />


</p>
</details> 

<details><summary>New version</summary>
<p>

<img width="829" height="374" alt="grafik" src="https://github.com/user-attachments/assets/efbcefac-7692-4c4b-8d8e-9aa7512105f4" />


</p>
</details> 


How do you feel about this proposal? :)

thanks