### PR TITLE
Run CI on `main` branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   # We only run this on push to the default branch to prime CI cache
   push:
     branches:
-      - master
+      - main
 
 env:
   AWS_ACCESS_KEY_ID: AKIA46X5W6CZEAQSMRH7


### PR DESCRIPTION
Triagebot is one of the last remaining bot repos still on the `master` branch, let's move it over.

CC @rust-lang/triagebot