### PR TITLE
Deny warnings on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TEST_DB_URL: postgres://postgres:postgres@localhost:5432/postgres
+      RUSTFLAGS: "-D warnings"
     services:
       postgres:
         image: postgres:14
@@ -30,7 +31,7 @@ jobs:
       - run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: cargo test --workspace --all-targets
+        run: cargo test --locked --workspace --all-targets
       - name: Check formatting
         run: cargo fmt --all --check
 

--- a/src/handlers/assign.rs
+++ b/src/handlers/assign.rs
@@ -161,7 +161,7 @@ pub(super) async fn handle_input(
                     );
                     if let Some(contrib) = &config.contributing_url {
                         welcome.push_str("\n\n");
-                        welcome.push_str(&messages::contribution_message(contrib, &ctx.username));
+                        welcome.push_str(&messages::contribution_message(contrib));
                     }
                     welcome
                 } else {
@@ -301,7 +301,7 @@ pub(super) async fn handle_input(
                     && event.issue.author_association.is_probably_first_timer()
                 {
                     welcome.push_str("\n\n");
-                    welcome.push_str(&messages::contribution_message(contrib, &ctx.username));
+                    welcome.push_str(&messages::contribution_message(contrib));
                 }
                 welcome
             }
@@ -324,7 +324,7 @@ pub(super) async fn handle_input(
                 let mut welcome = messages::new_user_welcome_message(&assignee_text);
                 if let Some(contrib) = &config.contributing_url {
                     welcome.push_str("\n\n");
-                    welcome.push_str(&messages::contribution_message(contrib, &ctx.username));
+                    welcome.push_str(&messages::contribution_message(contrib));
                 }
                 Some(welcome)
             } else {

--- a/src/handlers/assign/messages.rs
+++ b/src/handlers/assign/messages.rs
@@ -33,7 +33,7 @@ In the meantime, we would highly appreciate if you could try to review any of [P
     )
 }
 
-pub fn contribution_message(contributing_url: &str, bot: &str) -> String {
+pub fn contribution_message(contributing_url: &str) -> String {
     format!(
         "Please see [the contribution \
          instructions]({contributing_url}) for more information."


### PR DESCRIPTION
We recently let a warning slip through, we should not allow that on CI.
