### PR TITLE
Fix sending of Zulip DMs

### DIFF
--- a/src/handlers/project_goals.rs
+++ b/src/handlers/project_goals.rs
@@ -755,7 +755,7 @@ async fn send_dm(
     }
 
     MessageApiRequest {
-        recipient: Recipient::Private { id: owner.0 },
+        recipient: Recipient::DirectMessage { id: owner.0 },
         content,
     }
     .send(zulip)

--- a/src/handlers/project_goals.rs
+++ b/src/handlers/project_goals.rs
@@ -755,10 +755,7 @@ async fn send_dm(
     }
 
     MessageApiRequest {
-        recipient: Recipient::Private {
-            id: owner.0,
-            email: "",
-        },
+        recipient: Recipient::Private { id: owner.0 },
         content,
     }
     .send(zulip)

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -1524,7 +1524,6 @@ async fn lookup_zulip_username(ctx: &Context, gh_username: &str) -> anyhow::Resu
     ))
 }
 
-#[derive(serde::Serialize)]
 pub(crate) struct MessageApiRequest<'a> {
     /// The recipient of the message. Could be DM or a Stream
     pub(crate) recipient: Recipient<'a>,

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -79,7 +79,6 @@ struct Message {
     #[allow(unused)]
     recipient_id: u64,
     sender_full_name: String,
-    sender_email: String,
     /// The ID of the stream.
     ///
     /// `None` if it is a private message.
@@ -106,10 +105,7 @@ impl Message {
                     .as_ref()
                     .expect("stream messages should have a topic"),
             },
-            None => Recipient::Private {
-                id: self.sender_id,
-                email: &self.sender_email,
-            },
+            None => Recipient::Private { id: self.sender_id },
         }
     }
 }
@@ -299,10 +295,7 @@ async fn handle_command<'a>(
             );
 
             MessageApiRequest {
-                recipient: Recipient::Private {
-                    id: user.user_id,
-                    email: &user.email,
-                },
+                recipient: Recipient::Private { id: user.user_id },
                 content: &message,
             }
             .send(&ctx.zulip)

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -105,7 +105,7 @@ impl Message {
                     .as_ref()
                     .expect("stream messages should have a topic"),
             },
-            None => Recipient::Private { id: self.sender_id },
+            None => Recipient::DirectMessage { id: self.sender_id },
         }
     }
 }
@@ -295,7 +295,7 @@ async fn handle_command<'a>(
             );
 
             MessageApiRequest {
-                recipient: Recipient::Private { id: user.user_id },
+                recipient: Recipient::DirectMessage { id: user.user_id },
                 content: &message,
             }
             .send(&ctx.zulip)

--- a/src/zulip/api.rs
+++ b/src/zulip/api.rs
@@ -53,8 +53,10 @@ impl MessageApiResponse {
 
 #[derive(Copy, Clone)]
 pub(crate) enum Recipient<'a> {
+    /// Send a message to a Zulip stream.
     Stream { id: u64, topic: &'a str },
-    Private { id: u64 },
+    /// Send a direct message.
+    DirectMessage { id: u64 },
 }
 
 impl Recipient<'_> {
@@ -83,7 +85,7 @@ impl Recipient<'_> {
                 }
                 format!("stream/{id}-xxx/topic/{encoded_topic}")
             }
-            Recipient::Private { id, .. } => format!("pm-with/{id}-xxx"),
+            Recipient::DirectMessage { id, .. } => format!("pm-with/{id}-xxx"),
         }
     }
 

--- a/src/zulip/api.rs
+++ b/src/zulip/api.rs
@@ -52,21 +52,10 @@ impl MessageApiResponse {
     }
 }
 
-#[derive(Copy, Clone, serde::Serialize)]
-#[serde(tag = "type")]
-#[serde(rename_all = "snake_case")]
+#[derive(Copy, Clone)]
 pub(crate) enum Recipient<'a> {
-    Stream {
-        #[serde(rename = "to")]
-        id: u64,
-        topic: &'a str,
-    },
-    Private {
-        #[serde(skip)]
-        id: u64,
-        #[serde(rename = "to")]
-        email: &'a str,
-    },
+    Stream { id: u64, topic: &'a str },
+    Private { id: u64, email: &'a str },
 }
 
 impl Recipient<'_> {

--- a/src/zulip/api.rs
+++ b/src/zulip/api.rs
@@ -21,7 +21,6 @@ pub(crate) struct ZulipUser {
     pub(crate) user_id: u64,
     #[serde(rename = "full_name")]
     pub(crate) name: String,
-    pub(crate) email: String,
     #[serde(default)]
     pub(crate) profile_data: HashMap<String, ProfileValue>,
 }
@@ -55,7 +54,7 @@ impl MessageApiResponse {
 #[derive(Copy, Clone)]
 pub(crate) enum Recipient<'a> {
     Stream { id: u64, topic: &'a str },
-    Private { id: u64, email: &'a str },
+    Private { id: u64 },
 }
 
 impl Recipient<'_> {

--- a/src/zulip/client.rs
+++ b/src/zulip/client.rs
@@ -76,15 +76,15 @@ impl ZulipClient {
             .form(&SerializedApi {
                 type_: match recipient {
                     Recipient::Stream { .. } => "stream",
-                    Recipient::Private { .. } => "private",
+                    Recipient::DirectMessage { .. } => "direct",
                 },
                 to: match recipient {
                     Recipient::Stream { id, .. } => id.to_string(),
-                    Recipient::Private { id, .. } => id.to_string(),
+                    Recipient::DirectMessage { id, .. } => id.to_string(),
                 },
                 topic: match recipient {
                     Recipient::Stream { topic, .. } => Some(topic),
-                    Recipient::Private { .. } => None,
+                    Recipient::DirectMessage { .. } => None,
                 },
                 content,
             })

--- a/src/zulip/client.rs
+++ b/src/zulip/client.rs
@@ -80,7 +80,7 @@ impl ZulipClient {
                 },
                 to: match recipient {
                     Recipient::Stream { id, .. } => id.to_string(),
-                    Recipient::Private { email, .. } => email.to_string(),
+                    Recipient::Private { id, .. } => id.to_string(),
                 },
                 topic: match recipient {
                     Recipient::Stream { topic, .. } => Some(topic),


### PR DESCRIPTION
The e-mail field shouldn't really have been used, I removed it and switched to IDs instead. Also migrated the DM message type to `direct` from `private`, as per https://zulip.com/api/send-message#parameter-type.

Note: according to the documentation, the `to` field for DMs should actually be a list. But it seems that Zulip accepts also just a single value there.