### PR TITLE
Fetch the first 100 reviews instead of just the default 30

### DIFF
--- a/src/github/issue.rs
+++ b/src/github/issue.rs
@@ -710,7 +710,7 @@ impl Issue {
 
     pub async fn get_reviews(&self, client: &GithubClient) -> anyhow::Result<Vec<Comment>> {
         let review_url = format!(
-            "{}/pulls/{}/reviews",
+            "{}/pulls/{}/reviews?per_page=100",
             self.repository().url(client),
             self.number,
         );


### PR DESCRIPTION
Reported at [#t-clippy > rustbot not moving an PR out of community review](https://rust-lang.zulipchat.com/#narrow/channel/257328-t-clippy/topic/rustbot.20not.20moving.20an.20PR.20out.20of.20community.20review/with/618661641)

We currently only fetch the default 30 reviews, but https://github.com/rust-lang/rust-clippy/pull/17609 [contains 33 reviews](https://api.github.com/repos/rust-lang/rust-clippy/pulls/17609/reviews?per_page=100) (that includes review threads, I didn't knew that but it make sense). Therefor let's fetch the [maximum 100 on one API call](https://docs.github.com/en/rest/pulls/reviews?apiVersion=2026-03-10#list-reviews-for-a-pull-request) for now.

We can add a loop in the future if necessary.