### PR TITLE
Fetch all the reviews instead of just the first 100s

### DIFF
--- a/src/github/issue.rs
+++ b/src/github/issue.rs
@@ -674,7 +674,11 @@ impl Issue {
 
         Ok(())
     }
+}
 
+const REVIEWS_PAGE_SIZE: usize = 100;
+
+impl Issue {
     pub async fn get_review(
         &self,
         client: &GithubClient,
@@ -708,9 +712,13 @@ impl Issue {
         Ok(review)
     }
 
-    pub async fn get_reviews(&self, client: &GithubClient) -> anyhow::Result<Vec<Comment>> {
+    pub async fn get_reviews(
+        &self,
+        client: &GithubClient,
+        page: u32,
+    ) -> anyhow::Result<Vec<Comment>> {
         let review_url = format!(
-            "{}/pulls/{}/reviews?per_page=100",
+            "{}/pulls/{}/reviews?per_page={REVIEWS_PAGE_SIZE}&page={page}",
             self.repository().url(client),
             self.number,
         );
@@ -719,6 +727,28 @@ impl Issue {
             .await
             .with_context(|| format!("unable to fetch reviews for {}", self.number))?;
         Ok(reviews)
+    }
+
+    pub fn get_all_reviews(
+        &self,
+        client: &GithubClient,
+    ) -> impl futures::Stream<Item = anyhow::Result<Vec<Comment>>> {
+        futures::stream::unfold(Some(1), move |page_state| async move {
+            let current_page = page_state?;
+
+            match self.get_reviews(client, current_page).await {
+                Ok(reviews) => {
+                    let next_state = if reviews.len() >= REVIEWS_PAGE_SIZE {
+                        Some(current_page + 1)
+                    } else {
+                        None
+                    };
+
+                    Some((Ok(reviews), next_state))
+                }
+                Err(e) => Some((Err(e), None)), // Stop on error
+            }
+        })
     }
 }
 

--- a/src/handlers/assign.rs
+++ b/src/handlers/assign.rs
@@ -479,26 +479,31 @@ async fn update_community_review_assignment(
     config: &AssignCommunityReviewsConfig,
     issue: &Issue,
 ) -> anyhow::Result<CommunityReviewUpdateStatus> {
-    let reviews = issue
-        .get_reviews(&ctx.github)
-        .await
-        .context("unable to fetch reviews for determining assignement")?;
+    use futures::StreamExt;
 
-    let approval_reviews: Vec<_> = {
-        // Filter duplicated approvals
-        let mut uniq = HashSet::<UserId>::new();
+    let review_stream = issue.get_all_reviews(&ctx.github);
+    tokio::pin!(review_stream);
 
-        reviews
-            .iter()
-            .filter(|c| c.pr_review_state == Some(PullRequestReviewState::Approved))
-            // GitHub doesn't allow PR authors to approve a PR them-selves but just
-            // in case let's filter the PR author.
-            .filter(|c| c.user.id != issue.user.id)
-            // Only keep one approval by user
-            .filter(|c| uniq.insert(c.user.id))
-            .map(|c| &c.user)
-            .collect::<Vec<_>>()
-    };
+    let mut approval_reviews = Vec::new();
+    let mut uniq = HashSet::<UserId>::new();
+
+    while approval_reviews.len() < config.minimum_approvals.get().into()
+        && let Some(reviews) = review_stream.next().await
+    {
+        let reviews = reviews.context("failed to fetch reviews for determining assignement")?;
+
+        for review in reviews {
+            if review.pr_review_state == Some(PullRequestReviewState::Approved)
+                // GitHub doesn't allow PR authors to approve a PR them-selves but just
+                // in case let's filter the PR author.
+                && review.user.id != issue.user.id
+                // Only keep one approval by user
+                && uniq.insert(review.user.id)
+            {
+                approval_reviews.push(review.user);
+            }
+        }
+    }
 
     let enough_reviews = approval_reviews.len() >= config.minimum_approvals.get().into();
 


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/triagebot/pull/2489 where we now actually fetch and check all the reviews.

Used `futures::stream::unfold` to lazily load the pages.

<details>

Tested with:

```rust
    {
        let gh = github::GithubClient::new_from_env();
        let issue = gh
            .issue(
                &github::IssueRepository {
                    organization: "rust-lang".to_string(),
                    repository: "rust".to_string(),
                },
                137944,
            )
            .await
            .unwrap();

        use futures::StreamExt;

        let review_stream = issue.get_all_reviews(&gh);
        tokio::pin!(review_stream);

        while let Some(reviews) = review_stream.next().await {
            dbg!(&reviews);
        }
    }
```

</details> 