### PR TITLE
resolve zulip topic on issue priority assigned

### DIFF
--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -375,10 +375,19 @@ async fn handle_command<'a>(
                 StreamCommand::AssignPriority { issue_num, prio } => {
                     let _ = match assign_issue_prio(&ctx, message_data, issue_num, prio).await {
                         // give user feedback
-                        Ok(_) => ctx.zulip.add_reaction(message_data.id, "check").await,
+                        Ok(_) => {
+                            // emoji reaction for the triagebot command
+                            ctx.zulip.add_reaction(message_data.id, "check").await?;
+                            // resolve the Zulip topic
+                            if let Some(ref topic) = message_data.subject {
+                                ctx.zulip.resolve_topic(message_data.id, &topic).await?;
+                            } else {
+                                log::warn!("Zulip topic has empty subject");
+                            }
+                        }
                         Err(err) => {
                             log::error!("Could not assign priority to #{}: {:?}", issue_num, err);
-                            ctx.zulip.add_reaction(message_data.id, "scream").await
+                            ctx.zulip.add_reaction(message_data.id, "scream").await?;
                         }
                     };
                     Ok(None)

--- a/src/zulip/client.rs
+++ b/src/zulip/client.rs
@@ -203,7 +203,11 @@ impl ZulipClient {
     }
 
     // https://zulip.com/api/update-message#parameter-topic
-    pub(crate) async fn resolve_topic(&self, message_id: u64, topic: &str) -> anyhow::Result<()> {
+    pub(crate) async fn resolve_topic(
+        &self,
+        message_id: u64,
+        message_topic: &str,
+    ) -> anyhow::Result<()> {
         #[derive(serde::Serialize)]
         struct ResolveTopic<'a> {
             topic: &'a str,
@@ -212,10 +216,19 @@ impl ZulipClient {
             send_notification_to_new_thread: bool,
         }
 
+        let mut topic = message_topic.replacen("", "✔ ", 1);
+        // Maximum 60, minus the elipsis
+        let mut chars = topic.char_indices().skip(60 - 1);
+        if let Some((len, _)) = chars.next()
+            && chars.next().is_some()
+        {
+            topic = format!("{}…", &topic[..len]);
+        }
+
         let resp = self
             .make_request(Method::PATCH, &format!("messages/{message_id}"))
             .form(&ResolveTopic {
-                topic: &topic.replacen("", "✔ ", 1),
+                topic: &topic,
                 propagate_mode: "change_all",
                 send_notification_to_old_thread: false,
                 send_notification_to_new_thread: false,

--- a/src/zulip/client.rs
+++ b/src/zulip/client.rs
@@ -201,6 +201,40 @@ impl ZulipClient {
                 .into()
         })
     }
+
+    // https://zulip.com/api/update-message#parameter-topic
+    pub(crate) async fn resolve_topic(&self, message_id: u64, topic: &str) -> anyhow::Result<()> {
+        #[derive(serde::Serialize)]
+        struct ResolveTopic<'a> {
+            topic: &'a str,
+            propagate_mode: &'a str,
+            send_notification_to_old_thread: bool,
+            send_notification_to_new_thread: bool,
+        }
+
+        let resp = self
+            .make_request(Method::PATCH, &format!("messages/{message_id}"))
+            .form(&ResolveTopic {
+                topic: &topic.replacen("", "✔ ", 1),
+                propagate_mode: "change_all",
+                send_notification_to_old_thread: false,
+                send_notification_to_new_thread: false,
+            })
+            .send()
+            .await
+            .context("failed to add resolve Zulip topic")?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp
+                .text()
+                .await
+                .context("fail receiving Zulip API response (when resolving topic)")?;
+            anyhow::bail!(body)
+        }
+
+        Ok(())
+    }
 }
 
 async fn deserialize_response<T>(response: Response) -> anyhow::Result<T>


### PR DESCRIPTION
Closes #2139

As per [Zulip discussion](https://rust-lang.zulipchat.com/#narrow/channel/227806-t-compiler.2Fops/topic/.E2.9C.94.20alarts.20mark.20as.20resolved.20once.20.20gets.20removed/near/619483354).

This should resolve the Zulip topic when a regression has been assigned a priority label.

Note after a first test: if an issue is solved and then given again a `I-prioritize` label, a new zulip topic will be created (because the title of the old one has now a "✔ ".