### PR TITLE
Implement crate yanking/unyanking on Zulip

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -32,6 +32,9 @@ GITHUB_WEBHOOK_SECRET=MUST_BE_CONFIGURED
 # Authenticates inbound webhooks from Github
 # ZULIP_WEBHOOK_SECRET=xxx
 
+# Token used for yanking/unyanking crates.io crates
+# CRATES_IO_API_TOKEN=xxx
+
 # Which GitHub repository should be used when triagebot executes commands sent from Zulip
 # For testing purposes, you can use another repository
 # Defaults: "rust-lang" and "rust"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2250,7 +2250,7 @@ dependencies = [
 [[package]]
 name = "rust_team_data"
 version = "1.0.0"
-source = "git+https://github.com/rust-lang/team#99a209f68462354a2e69bfbe938741036c731cdb"
+source = "git+https://github.com/rust-lang/team#1aff2ec5d885254ff77795cf26e1d83f6fb8bc65"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2392,6 +2392,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3125,6 +3131,7 @@ dependencies = [
  "reqwest",
  "rust_team_data",
  "secrecy",
+ "semver",
  "serde",
  "serde_json",
  "serde_path_to_error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2250,7 +2250,7 @@ dependencies = [
 [[package]]
 name = "rust_team_data"
 version = "1.0.0"
-source = "git+https://github.com/rust-lang/team#1aff2ec5d885254ff77795cf26e1d83f6fb8bc65"
+source = "git+https://github.com/rust-lang/team#11f22ac016e874152e3c520f2f3e211baaaba7cd"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ tower_governor = { version = "0.8.0", default-features = false, features = ["axu
 http-body-util = "0.1.3"
 http = "1.4.0"
 memchr = "2.7.5"
+semver = "1"
 
 [dependencies.serde]
 version = "1"

--- a/src/crates_io/mod.rs
+++ b/src/crates_io/mod.rs
@@ -1,0 +1,83 @@
+use reqwest::Client;
+use reqwest::header;
+use reqwest::header::{HeaderMap, HeaderValue};
+use secrecy::{ExposeSecret, SecretString};
+use serde::Serialize;
+use std::env;
+use std::sync::OnceLock;
+
+// OpenAPI spec: https://crates.io/api/openapi.json
+const CRATES_IO_BASE_URL: &str = "https://crates.io/api/v1";
+
+/// Access to the Crates.io API
+pub struct CratesIoApi {
+    client: Client,
+    // The token is loaded lazily, to avoid requiring the API token if crates.io APIs are not
+    // actually accessed.
+    token: OnceLock<SecretString>,
+}
+
+impl CratesIoApi {
+    pub fn new() -> Self {
+        let mut map = HeaderMap::default();
+        map.insert(
+            header::USER_AGENT,
+            HeaderValue::from_static("triagebot@rust-lang.org"),
+        );
+
+        Self {
+            client: reqwest::ClientBuilder::default()
+                .default_headers(map)
+                .build()
+                .unwrap(),
+            token: Default::default(),
+        }
+    }
+
+    fn get_api_token(&self) -> &SecretString {
+        self.token.get_or_init(|| {
+            env::var("CRATES_IO_API_TOKEN")
+                .expect("CRATES_IO_API_TOKEN is missing")
+                .into()
+        })
+    }
+
+    /// Yanks a crate from crates.io.
+    pub(crate) async fn yank_crate(&self, krate: &str, version: &str) -> anyhow::Result<()> {
+        self.req::<()>(
+            reqwest::Method::DELETE,
+            &format!("/crates/{krate}/{version}/yank"),
+        )
+        .await?
+        .error_for_status()?;
+
+        Ok(())
+    }
+
+    /// Unyanks a crate from crates.io.
+    pub(crate) async fn unyank_crate(&self, krate: &str, version: &str) -> anyhow::Result<()> {
+        self.req::<()>(
+            reqwest::Method::PUT,
+            &format!("/crates/{krate}/{version}/unyank"),
+        )
+        .await?
+        .error_for_status()?;
+
+        Ok(())
+    }
+
+    /// Perform a request against the crates.io API
+    async fn req<T: Serialize>(
+        &self,
+        method: reqwest::Method,
+        path: &str,
+    ) -> anyhow::Result<reqwest::Response> {
+        let token = self.get_api_token();
+        let req = self
+            .client
+            .request(method, format!("{CRATES_IO_BASE_URL}{path}"))
+            .bearer_auth(token.expose_secret());
+
+        Ok(req.send().await?)
+    }
+}

--- a/src/crates_io/mod.rs
+++ b/src/crates_io/mod.rs
@@ -5,6 +5,7 @@ use secrecy::{ExposeSecret, SecretString};
 use serde::Serialize;
 use std::env;
 use std::sync::OnceLock;
+use url::Url;
 
 // OpenAPI spec: https://crates.io/api/openapi.json
 const CRATES_IO_BASE_URL: &str = "https://crates.io/api/v1";
@@ -43,10 +44,10 @@ impl CratesIoApi {
     }
 
     /// Yanks a crate from crates.io.
-    pub(crate) async fn yank_crate(&self, krate: &str, version: &str) -> anyhow::Result<()> {
+    pub async fn yank_crate(&self, krate: &str, version: &str) -> anyhow::Result<()> {
         self.req::<()>(
             reqwest::Method::DELETE,
-            &format!("/crates/{krate}/{version}/yank"),
+            self.url(&["crates", krate, version, "yank"]),
         )
         .await?
         .error_for_status()?;
@@ -55,10 +56,10 @@ impl CratesIoApi {
     }
 
     /// Unyanks a crate from crates.io.
-    pub(crate) async fn unyank_crate(&self, krate: &str, version: &str) -> anyhow::Result<()> {
+    pub async fn unyank_crate(&self, krate: &str, version: &str) -> anyhow::Result<()> {
         self.req::<()>(
             reqwest::Method::PUT,
-            &format!("/crates/{krate}/{version}/unyank"),
+            self.url(&["crates", krate, version, "unyank"]),
         )
         .await?
         .error_for_status()?;
@@ -66,18 +67,31 @@ impl CratesIoApi {
         Ok(())
     }
 
-    /// Perform a request against the crates.io API
+    /// Performs a request against the crates.io API
     async fn req<T: Serialize>(
         &self,
         method: reqwest::Method,
-        path: &str,
+        url: Url,
     ) -> anyhow::Result<reqwest::Response> {
         let token = self.get_api_token();
         let req = self
             .client
-            .request(method, format!("{CRATES_IO_BASE_URL}{path}"))
+            .request(method, url)
             .bearer_auth(token.expose_secret());
 
         Ok(req.send().await?)
+    }
+
+    /// We construct the URL from individual segments, to avoid possible "URL injection" by using
+    /// segments like "../<path>", which could overwrite other segments of the URL.
+    fn url(&self, segments: &[&str]) -> Url {
+        let mut url = Url::parse(CRATES_IO_BASE_URL).unwrap();
+        {
+            let mut url_segments = url.path_segments_mut().unwrap();
+            for segment in segments {
+                url_segments.push(segment);
+            }
+        }
+        url
     }
 }

--- a/src/crates_io/mod.rs
+++ b/src/crates_io/mod.rs
@@ -5,6 +5,7 @@ use secrecy::{ExposeSecret, SecretString};
 use serde::Serialize;
 use std::env;
 use std::sync::OnceLock;
+use tracing::instrument;
 use url::Url;
 
 // OpenAPI spec: https://crates.io/api/openapi.json
@@ -44,10 +45,11 @@ impl CratesIoApi {
     }
 
     /// Yanks a crate from crates.io.
-    pub async fn yank_crate(&self, krate: &str, version: &str) -> anyhow::Result<()> {
+    #[instrument(level = "info", skip(self))]
+    pub async fn yank_crate(&self, krate: &str, version: &semver::Version) -> anyhow::Result<()> {
         self.req::<()>(
             reqwest::Method::DELETE,
-            self.url(&["crates", krate, version, "yank"]),
+            self.url(&["crates", krate, &version.to_string(), "yank"]),
         )
         .await?
         .error_for_status()?;
@@ -56,10 +58,11 @@ impl CratesIoApi {
     }
 
     /// Unyanks a crate from crates.io.
-    pub async fn unyank_crate(&self, krate: &str, version: &str) -> anyhow::Result<()> {
+    #[instrument(level = "info", skip(self))]
+    pub async fn unyank_crate(&self, krate: &str, version: &semver::Version) -> anyhow::Result<()> {
         self.req::<()>(
             reqwest::Method::PUT,
-            self.url(&["crates", krate, version, "unyank"]),
+            self.url(&["crates", krate, &version.to_string(), "unyank"]),
         )
         .await?
         .error_for_status()?;

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,4 +1,5 @@
 use crate::config::{self, Config, ConfigurationError};
+use crate::crates_io::CratesIoApi;
 use crate::gh_comments::GitHubCommentsCache;
 use crate::gha_logs::GitHubActionLogsCache;
 use crate::github::{Event, GithubClient, IssueCommentAction, IssuesAction, IssuesEvent};
@@ -53,6 +54,7 @@ pub struct Context {
     pub github: GithubClient,
     pub zulip: ZulipClient,
     pub team: TeamClient,
+    pub crates_io: CratesIoApi,
     pub db: crate::db::ClientPool,
     pub username: String,
     pub octocrab: Octocrab,

--- a/src/handlers/notify_zulip.rs
+++ b/src/handlers/notify_zulip.rs
@@ -5,7 +5,7 @@
 
 use crate::github::GitHubUser;
 use crate::zulip::api::Recipient;
-use crate::zulip::render_zulip_username;
+use crate::zulip::{PingMode, format_zulip_username};
 use crate::{
     config::{NotifyZulipConfig, NotifyZulipLabelConfig, NotifyZulipTablesConfig},
     github::{Issue, IssuesAction, IssuesEvent, Label},
@@ -283,7 +283,7 @@ async fn get_zulip_ids(ctx: &Context, recipients: &[GitHubUser]) -> String {
             if let Ok(id2) = x.as_ref()
                 && let Some(id) = *id2
             {
-                Some(render_zulip_username(id))
+                Some(format_zulip_username(id, PingMode::Ping))
             } else {
                 None
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod bors;
 mod cache;
 mod changelogs;
 mod config;
+pub mod crates_io;
 pub mod db;
 mod errors;
 pub mod gh_changes_since;

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ use tower_http::compression::CompressionLayer;
 use tower_http::request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer};
 use tower_http::trace::TraceLayer;
 use tracing::{self as log, info_span};
+use triagebot::crates_io::CratesIoApi;
 use triagebot::gh_comments::{GH_COMMENTS_CACHE_CAPACITY_BYTES, GitHubCommentsCache};
 use triagebot::gha_logs::{GHA_LOGS_CACHE_CAPACITY_BYTES, GitHubActionLogsCache};
 use triagebot::handlers::Context;
@@ -126,6 +127,7 @@ async fn run_server(addr: SocketAddr) -> anyhow::Result<()> {
             GH_COMMENTS_CACHE_CAPACITY_BYTES,
         ))),
         zulip,
+        crates_io: CratesIoApi::new(),
     });
 
     // Run all jobs that have a schedule (recurring jobs)

--- a/src/team_data.rs
+++ b/src/team_data.rs
@@ -1,5 +1,5 @@
 use reqwest::Client;
-use rust_team_data::v1::{BASE_URL, People, Repos, Teams, ZulipMapping};
+use rust_team_data::v1::{BASE_URL, Crates, People, Repos, Teams, ZulipMapping};
 use serde::de::DeserializeOwned;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -13,6 +13,7 @@ pub struct TeamClient {
     repos: CachedTeamItem<Repos>,
     people: CachedTeamItem<People>,
     zulip_mapping: CachedTeamItem<ZulipMapping>,
+    crate_map: CachedTeamItem<Crates>,
 }
 
 impl TeamClient {
@@ -29,6 +30,7 @@ impl TeamClient {
             repos: CachedTeamItem::new("/repos.json"),
             people: CachedTeamItem::new("/people.json"),
             zulip_mapping: CachedTeamItem::new("/zulip-map.json"),
+            crate_map: CachedTeamItem::new("/crates.json"),
         }
     }
 
@@ -115,6 +117,10 @@ impl TeamClient {
 
     pub async fn zulip_map(&self) -> anyhow::Result<ZulipMapping> {
         self.zulip_mapping.get(&self.client, &self.base_url).await
+    }
+
+    pub async fn crate_map(&self) -> anyhow::Result<Crates> {
+        self.crate_map.get(&self.client, &self.base_url).await
     }
 
     pub async fn teams(&self) -> anyhow::Result<Teams> {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,3 +1,4 @@
+use crate::crates_io::CratesIoApi;
 use crate::db;
 use crate::db::users::record_username;
 use crate::db::{ClientPool, PooledClient, make_client};
@@ -80,6 +81,7 @@ impl TestContext {
             github,
             zulip,
             team: team_api,
+            crates_io: CratesIoApi::new(),
             db: pool,
             username: "triagebot-test".to_string(),
             octocrab,

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -1534,6 +1534,9 @@ async fn yank_crate_cmd(
     if let Err(error) = check_yank_stream(message_data) {
         return Ok(Some(error));
     }
+    if let Err(error) = check_crate_info(krate, version) {
+        return Ok(Some(error));
+    }
 
     if !owns_crate(ctx, gh_id, krate).await? {
         return Ok(Some(
@@ -1563,6 +1566,9 @@ async fn unyank_crate_cmd(
     if let Err(error) = check_yank_stream(message_data) {
         return Ok(Some(error));
     }
+    if let Err(error) = check_crate_info(krate, version) {
+        return Ok(Some(error));
+    }
 
     if !owns_crate(ctx, gh_id, krate).await? {
         return Ok(Some(
@@ -1579,6 +1585,30 @@ async fn unyank_crate_cmd(
         "Crate {krate}@{version} was successfully unyanked by {}",
         format_zulip_username(message_data.sender_id, PingMode::Silent)
     )))
+}
+
+/// Checks whether the krate name and version look correct, i.e. do not contain any suspicious
+/// characters, and whether the version is in a correct semver format.
+///
+/// It is important to call this function, because we pass the crate name and version to a
+/// crates.io API request.
+fn check_crate_info(krate: &str, version: &str) -> Result<(), String> {
+    if !krate
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        return Err("Crate name contains invalid characters".to_string());
+    }
+    if let Err(error) = semver::Version::parse(version) {
+        return Err(format!(
+            "Crate version is not a valid semver version: {error}"
+        ));
+    }
+    if version.contains("..") || version.contains("/") {
+        return Err("Crate version contains invalid characters".to_string());
+    }
+
+    Ok(())
 }
 
 /// Stream that has to be used for yanking/unyanking of crates.

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -1581,6 +1581,13 @@ async fn unyank_crate_cmd(
     )))
 }
 
+/// Stream that has to be used for yanking/unyanking of crates.
+/// #t-libs/crates
+const YANK_STREAM_ID: u64 = 351149;
+
+/// Topic in `YANK_STREAM_ID` that has to be used for yanking/unyanking of crates.
+const YANK_TOPIC: &str = "crate yanking and unyanking";
+
 /// Checks if the message was sent to a stream that is allowed to yank/unyank crates.
 /// If not, returns an error message.
 fn check_yank_stream(message: &Message) -> Result<(), String> {
@@ -1591,13 +1598,9 @@ fn check_yank_stream(message: &Message) -> Result<(), String> {
         return Err("Message was not sent to a topic".to_string());
     };
 
-    // #t-libs/crates
-    const STREAM_ID: u64 = 351149;
-    const TOPIC: &str = "crate yanking and unyanking";
-
-    if stream_id != STREAM_ID || topic != TOPIC {
+    if stream_id != YANK_STREAM_ID || topic != YANK_TOPIC {
         Err(format!(
-            "Yanking and unyanking can only be performed in the #t-libs/crates#{TOPIC} topic"
+            "Yanking and unyanking can only be performed in the #t-libs/crates > {YANK_TOPIC} topic"
         ))
     } else {
         Ok(())

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -1528,13 +1528,13 @@ async fn yank_crate_cmd(
     ctx: &Context,
     gh_id: u64,
     krate: &str,
-    version: &str,
+    version: &semver::Version,
     message_data: &Message,
 ) -> anyhow::Result<Option<String>> {
     if let Err(error) = check_yank_stream(message_data) {
         return Ok(Some(error));
     }
-    if let Err(error) = check_crate_info(krate, version) {
+    if let Err(error) = check_crate_info(krate) {
         return Ok(Some(error));
     }
 
@@ -1550,7 +1550,7 @@ async fn yank_crate_cmd(
         .context("Cannot yank crate")?;
 
     Ok(Some(format!(
-        "Crate {krate}@{version} was successfully yanked by {}",
+        "Crate `{krate}@{version}` was successfully yanked by {}",
         format_zulip_username(message_data.sender_id, PingMode::Silent)
     )))
 }
@@ -1560,13 +1560,13 @@ async fn unyank_crate_cmd(
     ctx: &Context,
     gh_id: u64,
     krate: &str,
-    version: &str,
+    version: &semver::Version,
     message_data: &Message,
 ) -> anyhow::Result<Option<String>> {
     if let Err(error) = check_yank_stream(message_data) {
         return Ok(Some(error));
     }
-    if let Err(error) = check_crate_info(krate, version) {
+    if let Err(error) = check_crate_info(krate) {
         return Ok(Some(error));
     }
 
@@ -1582,30 +1582,19 @@ async fn unyank_crate_cmd(
         .context("Cannot unyank crate")?;
 
     Ok(Some(format!(
-        "Crate {krate}@{version} was successfully unyanked by {}",
+        "Crate `{krate}@{version}` was successfully unyanked by {}",
         format_zulip_username(message_data.sender_id, PingMode::Silent)
     )))
 }
 
-/// Checks whether the krate name and version look correct, i.e. do not contain any suspicious
-/// characters, and whether the version is in a correct semver format.
-///
-/// It is important to call this function, because we pass the crate name and version to a
-/// crates.io API request.
-fn check_crate_info(krate: &str, version: &str) -> Result<(), String> {
+/// Checks whether the krate name look correct, i.e. do not contain any suspicious
+/// characters.
+fn check_crate_info(krate: &str) -> Result<(), String> {
     if !krate
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
     {
         return Err("Crate name contains invalid characters".to_string());
-    }
-    if let Err(error) = semver::Version::parse(version) {
-        return Err(format!(
-            "Crate version is not a valid semver version: {error}"
-        ));
-    }
-    if version.contains("..") || version.contains("/") {
-        return Err("Crate version contains invalid characters".to_string());
     }
 
     Ok(())
@@ -1647,7 +1636,7 @@ async fn owns_crate(ctx: &Context, gh_id: u64, krate: &str) -> anyhow::Result<bo
         .context("Cannot load crate map")?;
     let Some(krate) = crate_map.crates.get(krate) else {
         return Err(anyhow::anyhow!(
-            "Crate {krate} is not managed in the team database"
+            "Couldn't find {krate} in the team database"
         ));
     };
     let teams = ctx.team.teams().await?;

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -1462,16 +1462,8 @@ async fn lookup_github_username(ctx: &Context, zulip_username: &str) -> anyhow::
 
     Ok(format!(
         "{}'s GitHub profile is [{github_username}](https://github.com/{github_username}).",
-        render_zulip_username(zulip_user.user_id)
+        format_zulip_username(zulip_user.user_id, PingMode::Silent)
     ))
-}
-
-pub fn render_zulip_username(zulip_id: u64) -> String {
-    // Rendering the username directly was running into some encoding issues, so we use
-    // the special `|<user-id>` syntax instead.
-    // @**|<zulip-id>** is Zulip syntax that will render as the username (and a link) of the user
-    // with the given Zulip ID.
-    format!("@**|{zulip_id}**")
 }
 
 /// Tries to find a Zulip username from a GitHub username.
@@ -1527,7 +1519,7 @@ async fn lookup_zulip_username(ctx: &Context, gh_username: &str) -> anyhow::Resu
     };
     Ok(format!(
         "The GitHub user `{gh_username}` has the following Zulip account: {}",
-        render_zulip_username(zulip_id)
+        format_zulip_username(zulip_id, PingMode::Silent)
     ))
 }
 
@@ -1555,7 +1547,8 @@ async fn yank_crate_cmd(
         .context("Cannot yank crate")?;
 
     Ok(Some(format!(
-        "Crate {krate}@{version} was successfully yanked"
+        "Crate {krate}@{version} was successfully yanked by {}",
+        format_zulip_username(message_data.sender_id, PingMode::Silent)
     )))
 }
 
@@ -1583,7 +1576,8 @@ async fn unyank_crate_cmd(
         .context("Cannot unyank crate")?;
 
     Ok(Some(format!(
-        "Crate {krate}@{version} was successfully unyanked"
+        "Crate {krate}@{version} was successfully unyanked by {}",
+        format_zulip_username(message_data.sender_id, PingMode::Silent)
     )))
 }
 
@@ -1866,6 +1860,26 @@ pub fn format_user_pr(pr: &UserPullRequest) -> String {
             PullRequestState::Merged => ":purple_circle:",
         }
     )
+}
+
+/// Ping mode for @<user> mentions on Zulip.
+pub enum PingMode {
+    /// Do not ping the person
+    Silent,
+    /// Ping the person
+    Ping,
+}
+
+pub fn format_zulip_username(zulip_id: u64, ping_mode: PingMode) -> String {
+    // Rendering the username directly was running into some encoding issues, so we use
+    // the special `|<user-id>` syntax instead.
+    // @**|<zulip-id>** is Zulip syntax that will render as the username (and a link) of the user
+    // with the given Zulip ID.
+    let prefix = match ping_mode {
+        PingMode::Silent => "_",
+        PingMode::Ping => "",
+    };
+    format!("@{prefix}**|{zulip_id}**")
 }
 
 fn format_date(date: Option<DateTime<Utc>>) -> String {

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -161,7 +161,10 @@ pub async fn webhook(
 }
 
 pub fn get_token_from_env() -> Result<SecretString, anyhow::Error> {
-    #[expect(clippy::bind_instead_of_map, reason = "`.map_err` is suggested, but we don't really map the error")]
+    #[expect(
+        clippy::bind_instead_of_map,
+        reason = "`.map_err` is suggested, but we don't really map the error"
+    )]
     // ZULIP_WEBHOOK_SECRET is preferred, ZULIP_TOKEN is kept for retrocompatibility but will be deprecated
     std::env::var("ZULIP_WEBHOOK_SECRET")
         .or_else(|_| std::env::var("ZULIP_TOKEN"))
@@ -392,6 +395,12 @@ async fn handle_command<'a>(
                     repo,
                     id,
                 } => unlock_cmd(&ctx, gh_id, &organization, &repo, id).await,
+                StreamCommand::Yank { krate, version } => {
+                    yank_crate_cmd(&ctx, gh_id, &krate, &version, message_data).await
+                }
+                StreamCommand::Unyank { krate, version } => {
+                    unyank_crate_cmd(&ctx, gh_id, &krate, &version, message_data).await
+                }
             };
         }
 
@@ -1520,6 +1529,116 @@ async fn lookup_zulip_username(ctx: &Context, gh_username: &str) -> anyhow::Resu
         "The GitHub user `{gh_username}` has the following Zulip account: {}",
         render_zulip_username(zulip_id)
     ))
+}
+
+/// Yank a crate on crates.io, if the user has permissions for it.
+async fn yank_crate_cmd(
+    ctx: &Context,
+    gh_id: u64,
+    krate: &str,
+    version: &str,
+    message_data: &Message,
+) -> anyhow::Result<Option<String>> {
+    if let Err(error) = check_yank_stream(message_data) {
+        return Ok(Some(error));
+    }
+
+    if !owns_crate(ctx, gh_id, krate).await? {
+        return Ok(Some(
+            "You do not have permissions to yank this crate".to_string(),
+        ));
+    }
+
+    ctx.crates_io
+        .yank_crate(krate, version)
+        .await
+        .context("Cannot yank crate")?;
+
+    Ok(Some(format!(
+        "Crate {krate}@{version} was successfully yanked"
+    )))
+}
+
+/// Unyank a crate on crates.io, if the user has permissions for it.
+async fn unyank_crate_cmd(
+    ctx: &Context,
+    gh_id: u64,
+    krate: &str,
+    version: &str,
+    message_data: &Message,
+) -> anyhow::Result<Option<String>> {
+    if let Err(error) = check_yank_stream(message_data) {
+        return Ok(Some(error));
+    }
+
+    if !owns_crate(ctx, gh_id, krate).await? {
+        return Ok(Some(
+            "You do not have permissions to unyank this crate".to_string(),
+        ));
+    }
+
+    ctx.crates_io
+        .unyank_crate(krate, version)
+        .await
+        .context("Cannot unyank crate")?;
+
+    Ok(Some(format!(
+        "Crate {krate}@{version} was successfully unyanked"
+    )))
+}
+
+/// Checks if the message was sent to a stream that is allowed to yank/unyank crates.
+/// If not, returns an error message.
+fn check_yank_stream(message: &Message) -> Result<(), String> {
+    let Some(stream_id) = message.stream_id else {
+        return Err("Message was not sent to a channel".to_string());
+    };
+    let Some(topic) = &message.subject else {
+        return Err("Message was not sent to a topic".to_string());
+    };
+
+    // #t-libs/crates
+    const STREAM_ID: u64 = 351149;
+    const TOPIC: &str = "crate yanking and unyanking";
+
+    if stream_id != STREAM_ID || topic != TOPIC {
+        Err(format!(
+            "Yanking and unyanking can only be performed in the #t-libs/crates#{TOPIC} topic"
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+/// Returns Ok(true) if user with the given GitHub id is a member of a team that owns `krate`
+/// in the team database (and thus on crates.io).
+async fn owns_crate(ctx: &Context, gh_id: u64, krate: &str) -> anyhow::Result<bool> {
+    let crate_map = ctx
+        .team
+        .crate_map()
+        .await
+        .context("Cannot load crate map")?;
+    let Some(krate) = crate_map.crates.get(krate) else {
+        return Err(anyhow::anyhow!(
+            "Crate {krate} is not managed in the team database"
+        ));
+    };
+    let teams = ctx.team.teams().await?;
+    for team in &krate.teams {
+        let Some(team) = teams.teams.get(team.as_str()) else {
+            continue;
+        };
+        if team
+            .members
+            .iter()
+            .find(|member| member.github_id == gh_id)
+            .is_some()
+        {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
 }
 
 pub(crate) struct MessageApiRequest<'a> {

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -1601,11 +1601,11 @@ fn check_crate_info(krate: &str) -> Result<(), String> {
 }
 
 /// Stream that has to be used for yanking/unyanking of crates.
-/// #t-libs/crates
-const YANK_STREAM_ID: u64 = 351149;
+/// Corresponds to the #t-infra channel.
+const YANK_CHANNEL_ID: u64 = 242791;
 
 /// Topic in `YANK_STREAM_ID` that has to be used for yanking/unyanking of crates.
-const YANK_TOPIC: &str = "crate yanking and unyanking";
+const YANK_TOPIC: &str = "Crate yanking/unyanking";
 
 /// Checks if the message was sent to a stream that is allowed to yank/unyank crates.
 /// If not, returns an error message.
@@ -1617,7 +1617,7 @@ fn check_yank_stream(message: &Message) -> Result<(), String> {
         return Err("Message was not sent to a topic".to_string());
     };
 
-    if stream_id != YANK_STREAM_ID || topic != YANK_TOPIC {
+    if stream_id != YANK_CHANNEL_ID || topic != YANK_TOPIC {
         Err(format!(
             "Yanking and unyanking can only be performed in the #t-libs/crates > {YANK_TOPIC} topic"
         ))

--- a/src/zulip/commands.rs
+++ b/src/zulip/commands.rs
@@ -185,6 +185,24 @@ pub enum StreamCommand {
         /// Issue or pull-request number to unlock.
         id: PullRequestNumber,
     },
+    /// Yank a specific crate version from crates.io.
+    /// Can only be performed by members of teams that own the crate.
+    Yank {
+        /// Crate to yank.
+        #[arg(name = "crate")]
+        krate: String,
+        /// Version of the crate to yank
+        version: String,
+    },
+    /// Unynk a specific crate version from crates.io.
+    /// Can only be performed by members of teams that own the crate.
+    Unyank {
+        /// Crate to unyank.
+        #[arg(name = "crate")]
+        krate: String,
+        /// Version of the crate to unyank
+        version: String,
+    },
 }
 
 /// Backport release channels
@@ -458,6 +476,24 @@ mod tests {
             ChatCommand::UserInfo {
                 username: "foobar".to_string(),
                 organization: "rust-lang-nursery".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn yank_unyank_command() {
+        assert_eq!(
+            parse_stream(&["yank", "foo", "1.2.3"]),
+            StreamCommand::Yank {
+                krate: "foo".to_string(),
+                version: "1.2.3".to_string(),
+            }
+        );
+        assert_eq!(
+            parse_stream(&["unyank", "bar", "1.4.3"]),
+            StreamCommand::Unyank {
+                krate: "bar".to_string(),
+                version: "1.4.3".to_string(),
             }
         );
     }

--- a/src/zulip/commands.rs
+++ b/src/zulip/commands.rs
@@ -192,7 +192,7 @@ pub enum StreamCommand {
         #[arg(name = "crate")]
         krate: String,
         /// Version of the crate to yank
-        version: String,
+        version: semver::Version,
     },
     /// Unynk a specific crate version from crates.io.
     /// Can only be performed by members of teams that own the crate.
@@ -201,7 +201,7 @@ pub enum StreamCommand {
         #[arg(name = "crate")]
         krate: String,
         /// Version of the crate to unyank
-        version: String,
+        version: semver::Version,
     },
 }
 
@@ -486,14 +486,14 @@ mod tests {
             parse_stream(&["yank", "foo", "1.2.3"]),
             StreamCommand::Yank {
                 krate: "foo".to_string(),
-                version: "1.2.3".to_string(),
+                version: semver::Version::parse("1.2.3").unwrap(),
             }
         );
         assert_eq!(
             parse_stream(&["unyank", "bar", "1.4.3"]),
             StreamCommand::Unyank {
                 krate: "bar".to_string(),
-                version: "1.4.3".to_string(),
+                version: semver::Version::parse("1.4.3").unwrap(),
             }
         );
     }


### PR DESCRIPTION
To enable us to move forward with removing individual and team access for `rust-lang` crates.io crates (see https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Crate.20yanking.2Funyanking.20on.20Zulip).

This will need the crates.io yank-only `rust-lang-owner` crates.io token configured in the triagebot environment, in the `CRATES_IO_API_TOKEN` environment variable.